### PR TITLE
Fix CI dev dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
-      - name: Install package + dev extras
+      - name: Install package + dev group
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
+          python -m pip install -e . --group dev
 
       - name: Ruff lint
         run: ruff check src/sovereign_agent/ tests/
@@ -105,10 +105,10 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install package
+      - name: Install package + dev group
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
+          python -m pip install -e . --group dev
 
       - name: Kernel info (Landlock requires Linux >= 5.13)
         run: |


### PR DESCRIPTION
## Summary
- install the PEP 735 `dev` dependency group in the Python 3.12 test job so Ruff and pytest are available
- install the same group in the v0.2 examples job for its pytest integration step
- keep development tooling out of user-facing package extras

## Test plan
- [x] Create a clean Python 3.12 virtual environment
- [x] Run `python -m pip install -e . --group dev`
- [x] Run `ruff check src/sovereign_agent/ tests/`
- [x] Run the full test suite (369 passed, 1 skipped)
- [x] Run `pytest -v tests/integration/test_examples.py` (9 passed)

Made with [Cursor](https://cursor.com)