### PR TITLE
Add governed runtime identity contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           mypy \
             src/sovereign_agent/channels \
+            src/sovereign_agent/contracts \
             src/sovereign_agent/discovery.py \
             src/sovereign_agent/errors.py \
             src/sovereign_agent/executor \
@@ -45,6 +46,7 @@ jobs:
             src/sovereign_agent/memory \
             src/sovereign_agent/observability \
             src/sovereign_agent/planner \
+            src/sovereign_agent/runtime \
             src/sovereign_agent/tickets \
             src/sovereign_agent/voice
 

--- a/MANIFEST-CRITICAL.txt
+++ b/MANIFEST-CRITICAL.txt
@@ -27,6 +27,12 @@ src/sovereign_agent/_internal/__init__.py
 src/sovereign_agent/_internal/paths.py
 src/sovereign_agent/_internal/llm_client.py
 src/sovereign_agent/_internal/atomic.py
+src/sovereign_agent/contracts/__init__.py
+src/sovereign_agent/contracts/schemas/governed-execution-request.schema.json
+src/sovereign_agent/contracts/schemas/execution-receipt.schema.json
+src/sovereign_agent/contracts/schemas/capability-manifest.schema.json
+src/sovereign_agent/runtime/__init__.py
+src/sovereign_agent/runtime/root.py
 
 Makefile
 pyproject.toml

--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,7 @@ format-check: ## ruff format --check (does not modify files)
 typecheck: ## Enforce mypy on currently clean public runtime modules
 	@$(MYPY) \
 		$(PKG_DIR)/channels \
+		$(PKG_DIR)/contracts \
 		$(PKG_DIR)/discovery.py \
 		$(PKG_DIR)/errors.py \
 		$(PKG_DIR)/executor \
@@ -493,6 +494,7 @@ typecheck: ## Enforce mypy on currently clean public runtime modules
 		$(PKG_DIR)/memory \
 		$(PKG_DIR)/observability \
 		$(PKG_DIR)/planner \
+		$(PKG_DIR)/runtime \
 		$(PKG_DIR)/tickets \
 		$(PKG_DIR)/voice
 

--- a/docs/v0.3-unit1-contracts.md
+++ b/docs/v0.3-unit1-contracts.md
@@ -1,0 +1,15 @@
+# v0.3 Unit 1 — runtime identity and wire contracts
+
+Unit 1 introduces a versioned runtime root for seats, sessions, executions,
+relay state, receipts, and locks. Existing v0.2 session directories remain
+readable and are copied into the new root only when first written.
+
+The new `sovereign_agent.contracts` package provides immutable typed
+identifiers, governed execution requests, capability evidence, canonical JSON,
+recursive redaction, and execution receipts that can be finalized once.
+Corrections create a linked superseding receipt instead of changing prior
+evidence.
+
+The bundled JSON schemas are compatibility artifacts for the external Zero
+Employee wire contract. Sovereign Agent does not import Zero Employee runtime
+modules or decide organizational authority.

--- a/examples/classifier_rule/README.md
+++ b/examples/classifier_rule/README.md
@@ -39,10 +39,12 @@ classifier = FakeSentimentClassifier()
 
 # Use one of:
 from sklearn.pipeline import Pipeline
-classifier = joblib.load("sentiment.joblib")   # sklearn path
+
+classifier = joblib.load("sentiment.joblib")  # sklearn path
 
 # or:
 from transformers import pipeline
+
 classifier = pipeline(
     "text-classification",
     model="distilbert-base-uncased-finetuned-sst-2-english",
@@ -59,7 +61,7 @@ does not change.
 ```python
 Rule(
     name="manager_confirmed",
-    condition=manager_affirmative,   # <-- ClassifierVerifier, not a lambda
+    condition=manager_affirmative,  # <-- ClassifierVerifier, not a lambda
     action=_commit_booking,
 )
 ```

--- a/examples/hitl_deposit/README.md
+++ b/examples/hitl_deposit/README.md
@@ -73,7 +73,7 @@ return ToolResult(
         "approval_reason": "Deposit exceeds auto-approve ceiling.",
     },
     summary="proposed booking awaiting approval",
-    requires_human_approval=True,    # <-- that's it
+    requires_human_approval=True,  # <-- that's it
 )
 ```
 

--- a/examples/isolated_worker/README.md
+++ b/examples/isolated_worker/README.md
@@ -40,7 +40,7 @@ from sovereign_agent._internal.isolation import detect_best_policy
 from sovereign_agent.orchestrator.worker import SubprocessWorker
 
 worker = SubprocessWorker(
-    isolation_policy=detect_best_policy(),   # <-- picks the strongest available
+    isolation_policy=detect_best_policy(),  # <-- picks the strongest available
     allow_network=False,
 )
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ where = ["src"]              # was: where = ["."]
 include = ["sovereign_agent*"]
 exclude = ["tests*", "chapters*", "lessons*", "examples*"]
 
+[tool.setuptools.package-data]
+"sovereign_agent.contracts.schemas" = ["*.json"]
+
 # Tooling configuration ─────────────────────────────────────────────────
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -45,6 +45,7 @@ EXAMPLE_MODULES = [
 
 PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/channels",
+    "src/sovereign_agent/contracts",
     "src/sovereign_agent/discovery.py",
     "src/sovereign_agent/errors.py",
     "src/sovereign_agent/executor",
@@ -54,6 +55,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/memory",
     "src/sovereign_agent/observability",
     "src/sovereign_agent/planner",
+    "src/sovereign_agent/runtime",
     "src/sovereign_agent/tickets",
     "src/sovereign_agent/voice",
 ]

--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -45,6 +45,7 @@ QUALITY_PATHS = [
 ]
 PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/channels",
+    "src/sovereign_agent/contracts",
     "src/sovereign_agent/discovery.py",
     "src/sovereign_agent/errors.py",
     "src/sovereign_agent/executor",
@@ -54,6 +55,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/memory",
     "src/sovereign_agent/observability",
     "src/sovereign_agent/planner",
+    "src/sovereign_agent/runtime",
     "src/sovereign_agent/tickets",
     "src/sovereign_agent/voice",
 ]

--- a/src/sovereign_agent/config.py
+++ b/src/sovereign_agent/config.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from sovereign_agent.runtime import RuntimeRoot
 
 
 @dataclass
@@ -69,6 +72,11 @@ class Config:
     enable_voice: bool = False
     enable_structured_half: bool = True
 
+    # v0.3 runtime root. Appended after all v0.2 fields so positional Config
+    # construction keeps its historical argument order. ``sessions_dir`` is
+    # retained as the read-through, copy-on-write legacy source.
+    runtime_dir: Path = field(default_factory=lambda: Path("runtime"))
+
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> Config:
         """Load a Config from environment variables.
@@ -92,18 +100,22 @@ class Config:
     def from_toml(cls, path: Path) -> Config:
         import tomllib
 
-        with open(path, "rb") as f:
-            data = tomllib.load(f)
+        with open(path, "rb") as handle:
+            data = tomllib.load(handle)
         section = data.get("sovereign_agent", data)
         overrides: dict[str, Any] = {}
-        for f in fields(cls):
-            if f.name in section:
-                overrides[f.name] = _coerce(f.type, section[f.name])
+        for config_field in fields(cls):
+            if config_field.name in section:
+                overrides[config_field.name] = _coerce(
+                    config_field.type, section[config_field.name]
+                )
         return cls(**overrides)
 
     def validate(self) -> list[str]:
         """Return a list of problems with this config, empty if OK."""
         issues: list[str] = []
+        if not self.runtime_dir.parent.exists():
+            issues.append(f"runtime_dir parent does not exist: {self.runtime_dir.parent}")
         # Sessions directory can be created later, so only warn if its parent doesn't exist.
         if not self.sessions_dir.parent.exists():
             issues.append(f"sessions_dir parent does not exist: {self.sessions_dir.parent}")
@@ -122,6 +134,12 @@ class Config:
             else str(getattr(self, f.name))
             for f in fields(self)
         }
+
+    def make_runtime_root(self) -> RuntimeRoot:
+        """Build a side-effect-free runtime handle using the legacy session setting."""
+        from sovereign_agent.runtime import RuntimeRoot
+
+        return RuntimeRoot(self.runtime_dir, legacy_sessions_dir=self.sessions_dir)
 
 
 def _coerce(declared_type: Any, raw: str) -> Any:

--- a/src/sovereign_agent/contracts/__init__.py
+++ b/src/sovereign_agent/contracts/__init__.py
@@ -1,0 +1,47 @@
+"""Versioned wire contracts for governed execution and receipts."""
+
+from ._core import ContractValidationError, FrozenDict
+from .canonical import canonical_json_bytes
+from .capabilities import Capability, CapabilityManifest, EvidenceLevel
+from .execution import GovernedExecutionRequest
+from .ids import (
+    ExecutionId,
+    InvocationId,
+    ProviderSessionId,
+    RepositoryId,
+    SeatInstanceId,
+    SovereignSessionId,
+    WorkerHandleId,
+)
+from .receipts import (
+    ExecutionReceipt,
+    ReceiptStatus,
+    evidence_verified,
+    lifecycle_complete,
+)
+from .redaction import REDACTED, redact_json, redact_mapping, redact_text
+
+__all__ = [
+    "Capability",
+    "CapabilityManifest",
+    "ContractValidationError",
+    "EvidenceLevel",
+    "ExecutionId",
+    "ExecutionReceipt",
+    "FrozenDict",
+    "GovernedExecutionRequest",
+    "InvocationId",
+    "ProviderSessionId",
+    "REDACTED",
+    "ReceiptStatus",
+    "RepositoryId",
+    "SeatInstanceId",
+    "SovereignSessionId",
+    "WorkerHandleId",
+    "canonical_json_bytes",
+    "evidence_verified",
+    "lifecycle_complete",
+    "redact_json",
+    "redact_mapping",
+    "redact_text",
+]

--- a/src/sovereign_agent/contracts/_core.py
+++ b/src/sovereign_agent/contracts/_core.py
@@ -1,0 +1,132 @@
+"""Internal helpers shared by the wire-contract models."""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+JsonScalar = str | int | float | bool | None
+JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+class ContractValidationError(ValueError):
+    """A wire value does not satisfy its contract."""
+
+
+@dataclass(frozen=True)
+class FrozenDict(Mapping[str, Any]):
+    """Small immutable mapping used to make frozen contracts deeply immutable."""
+
+    _items: tuple[tuple[str, Any], ...] = ()
+
+    def __iter__(self) -> Iterator[str]:
+        return (key for key, _ in self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __getitem__(self, key: str) -> Any:
+        for item_key, value in self._items:
+            if item_key == key:
+                return value
+        raise KeyError(key)
+
+    def __hash__(self) -> int:
+        return hash(self._items)
+
+
+def freeze_json(value: Any, *, path: str = "$") -> Any:
+    """Validate and deeply freeze a JSON-compatible value."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise ContractValidationError(f"{path} contains a non-finite number")
+        return value
+    if isinstance(value, Mapping):
+        items: list[tuple[str, Any]] = []
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ContractValidationError(f"{path} has a non-string object key")
+            items.append((key, freeze_json(item, path=f"{path}.{key}")))
+        return FrozenDict(tuple(items))
+    if isinstance(value, (list, tuple)):
+        return tuple(freeze_json(item, path=f"{path}[{index}]") for index, item in enumerate(value))
+    raise ContractValidationError(f"{path} contains non-JSON value {type(value).__name__}")
+
+
+def thaw_json(value: Any) -> JsonValue:
+    """Return a detached mutable JSON representation of a frozen value."""
+    if isinstance(value, Mapping):
+        return {key: thaw_json(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [thaw_json(item) for item in value]
+    return copy.deepcopy(value)
+
+
+def require_object(data: object, name: str) -> Mapping[str, Any]:
+    if not isinstance(data, Mapping):
+        raise ContractValidationError(f"{name} must be a JSON object")
+    if not all(isinstance(key, str) for key in data):
+        raise ContractValidationError(f"{name} keys must be strings")
+    return data
+
+
+def require_string(value: object, name: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        qualifier = "a string" if allow_empty else "a non-empty string"
+        raise ContractValidationError(f"{name} must be {qualifier}")
+    return value
+
+
+def parse_datetime(value: object, name: str) -> datetime:
+    text = require_string(value, name)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ContractValidationError(f"{name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ContractValidationError(f"{name} must include a UTC offset")
+    return parsed.astimezone(UTC)
+
+
+def format_datetime(value: datetime, name: str) -> str:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ContractValidationError(f"{name} must be timezone-aware")
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Encode JSON deterministically as UTF-8, independent of insertion order."""
+    thawed = thaw_json(freeze_json(value))
+    return json.dumps(
+        thawed,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def split_known(
+    data: Mapping[str, Any], known: frozenset[str]
+) -> tuple[dict[str, Any], FrozenDict]:
+    values = {key: data[key] for key in known if key in data}
+    unknown = freeze_json({key: value for key, value in data.items() if key not in known})
+    assert isinstance(unknown, FrozenDict)
+    return values, unknown
+
+
+def merge_unknown(known: dict[str, JsonValue], unknown: Mapping[str, Any]) -> dict[str, JsonValue]:
+    collision = known.keys() & unknown.keys()
+    if collision:
+        raise ContractValidationError(
+            f"unknown fields collide with known fields: {sorted(collision)}"
+        )
+    result = {key: thaw_json(value) for key, value in unknown.items()}
+    result.update(known)
+    return result

--- a/src/sovereign_agent/contracts/canonical.py
+++ b/src/sovereign_agent/contracts/canonical.py
@@ -1,0 +1,5 @@
+"""Public canonical JSON encoding helpers."""
+
+from ._core import canonical_json_bytes
+
+__all__ = ["canonical_json_bytes"]

--- a/src/sovereign_agent/contracts/capabilities.py
+++ b/src/sovereign_agent/contracts/capabilities.py
@@ -1,0 +1,169 @@
+"""Capability declarations and the strength of evidence behind them."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any
+
+from ._core import (
+    ContractValidationError,
+    FrozenDict,
+    freeze_json,
+    merge_unknown,
+    require_object,
+    require_string,
+    split_known,
+    thaw_json,
+)
+
+
+class EvidenceLevel(IntEnum):
+    """Ordered evidence strength without conflating evidence and availability."""
+
+    UNKNOWN = 0
+    DECLARED = 1
+    PROBED = 2
+    ENFORCED = 3
+
+    def to_wire(self) -> str:
+        return self.name.lower()
+
+    @classmethod
+    def from_wire(cls, value: object) -> EvidenceLevel:
+        text = require_string(value, "evidence_level")
+        try:
+            return cls[text.upper()]
+        except KeyError as exc:
+            allowed = ", ".join(item.to_wire() for item in cls)
+            raise ContractValidationError(f"evidence_level must be one of: {allowed}") from exc
+
+
+@dataclass(frozen=True)
+class Capability:
+    """One capability assertion.
+
+    ``available`` is the assertion; ``evidence_level`` says how strongly that
+    assertion is supported. Keeping those fields independent avoids treating
+    an unverified declaration as either absent or enforced.
+    """
+
+    available: bool | None
+    evidence_level: EvidenceLevel = EvidenceLevel.UNKNOWN
+    details: FrozenDict = field(default_factory=FrozenDict)
+    unknown_fields: FrozenDict = field(default_factory=FrozenDict, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.available is not None and not isinstance(self.available, bool):
+            raise ContractValidationError("capability.available must be boolean or null")
+        if not isinstance(self.evidence_level, EvidenceLevel):
+            raise ContractValidationError("capability.evidence_level must be an EvidenceLevel")
+        object.__setattr__(
+            self,
+            "details",
+            freeze_json(
+                require_object(self.details, "capability.details"), path="capability.details"
+            ),
+        )
+        object.__setattr__(
+            self,
+            "unknown_fields",
+            freeze_json(
+                require_object(self.unknown_fields, "capability.unknown_fields"),
+                path="capability.unknown_fields",
+            ),
+        )
+
+    def has_evidence(self, minimum: EvidenceLevel = EvidenceLevel.DECLARED) -> bool:
+        return self.evidence_level >= minimum
+
+    def is_available(self) -> bool:
+        return self.available is True
+
+    def to_dict(self) -> dict[str, Any]:
+        return merge_unknown(
+            {
+                "available": self.available,
+                "evidence_level": self.evidence_level.to_wire(),
+                "details": thaw_json(self.details),
+            },
+            self.unknown_fields,
+        )
+
+    @classmethod
+    def from_dict(cls, value: object) -> Capability:
+        data = require_object(value, "capability")
+        known, unknown = split_known(data, frozenset({"available", "evidence_level", "details"}))
+        if "available" not in known:
+            raise ContractValidationError("capability.available is required")
+        details = require_object(known.get("details", {}), "capability.details")
+        return cls(
+            available=known["available"],
+            evidence_level=EvidenceLevel.from_wire(known.get("evidence_level", "unknown")),
+            details=freeze_json(details),
+            unknown_fields=unknown,
+        )
+
+
+@dataclass(frozen=True)
+class CapabilityManifest:
+    """Immutable named capability assertions for one execution."""
+
+    capabilities: FrozenDict
+    unknown_fields: FrozenDict = field(default_factory=FrozenDict, repr=False)
+
+    def __post_init__(self) -> None:
+        source = require_object(self.capabilities, "capabilities")
+        normalized: dict[str, Capability] = {}
+        for name, value in source.items():
+            require_string(name, "capability name")
+            normalized[name] = (
+                value if isinstance(value, Capability) else Capability.from_dict(value)
+            )
+        object.__setattr__(self, "capabilities", FrozenDict(tuple(normalized.items())))
+        object.__setattr__(
+            self,
+            "unknown_fields",
+            freeze_json(
+                require_object(self.unknown_fields, "manifest.unknown_fields"),
+                path="manifest.unknown_fields",
+            ),
+        )
+
+    def get(self, name: str) -> Capability | None:
+        value = self.capabilities.get(name)
+        return value if isinstance(value, Capability) else None
+
+    def is_available(self, name: str) -> bool:
+        capability = self.get(name)
+        return capability is not None and capability.is_available()
+
+    def has_evidence(self, name: str, minimum: EvidenceLevel = EvidenceLevel.DECLARED) -> bool:
+        capability = self.get(name)
+        return capability is not None and capability.has_evidence(minimum)
+
+    def to_dict(self) -> dict[str, Any]:
+        capabilities = {
+            name: capability.to_dict()
+            for name, capability in self.capabilities.items()
+            if isinstance(capability, Capability)
+        }
+        known: dict[str, Any] = {"capabilities": capabilities}
+        return merge_unknown(known, self.unknown_fields)
+
+    @classmethod
+    def from_dict(cls, value: object) -> CapabilityManifest:
+        data = require_object(value, "capability_manifest")
+        known, unknown = split_known(data, frozenset({"capabilities"}))
+        if "capabilities" not in known:
+            raise ContractValidationError("capability_manifest.capabilities is required")
+        capabilities = require_object(known["capabilities"], "capability_manifest.capabilities")
+        return cls(
+            capabilities=FrozenDict(
+                tuple((name, Capability.from_dict(item)) for name, item in capabilities.items())
+            ),
+            unknown_fields=unknown,
+        )
+
+
+__all__ = ["Capability", "CapabilityManifest", "EvidenceLevel"]

--- a/src/sovereign_agent/contracts/execution.py
+++ b/src/sovereign_agent/contracts/execution.py
@@ -1,0 +1,174 @@
+"""The governed request passed across an execution boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, ClassVar
+
+from ._core import (
+    ContractValidationError,
+    FrozenDict,
+    format_datetime,
+    freeze_json,
+    merge_unknown,
+    parse_datetime,
+    require_object,
+    require_string,
+    split_known,
+    thaw_json,
+)
+from .capabilities import CapabilityManifest
+from .ids import (
+    ExecutionId,
+    InvocationId,
+    ProviderSessionId,
+    RepositoryId,
+    SeatInstanceId,
+    SovereignSessionId,
+    WorkerHandleId,
+)
+
+
+@dataclass(frozen=True)
+class GovernedExecutionRequest:
+    """Complete immutable input to a governed provider invocation."""
+
+    SCHEMA_VERSION: ClassVar[str] = "1.0"
+
+    seat_instance_id: SeatInstanceId
+    sovereign_session_id: SovereignSessionId
+    execution_id: ExecutionId
+    invocation_id: InvocationId
+    repository_id: RepositoryId
+    operation: str
+    input: FrozenDict
+    governance: FrozenDict
+    capability_manifest: CapabilityManifest
+    requested_at: datetime
+    provider_session_id: ProviderSessionId | None = None
+    worker_handle_id: WorkerHandleId | None = None
+    schema_version: str = SCHEMA_VERSION
+    unknown_fields: FrozenDict = field(default_factory=FrozenDict, repr=False)
+
+    _KNOWN: ClassVar[frozenset[str]] = frozenset(
+        {
+            "schema_version",
+            "seat_instance_id",
+            "sovereign_session_id",
+            "execution_id",
+            "invocation_id",
+            "provider_session_id",
+            "worker_handle_id",
+            "repository_id",
+            "operation",
+            "input",
+            "governance",
+            "capability_manifest",
+            "requested_at",
+        }
+    )
+
+    def __post_init__(self) -> None:
+        id_types = (
+            ("seat_instance_id", self.seat_instance_id, SeatInstanceId),
+            ("sovereign_session_id", self.sovereign_session_id, SovereignSessionId),
+            ("execution_id", self.execution_id, ExecutionId),
+            ("invocation_id", self.invocation_id, InvocationId),
+            ("repository_id", self.repository_id, RepositoryId),
+        )
+        for name, value, expected in id_types:
+            if not isinstance(value, expected):
+                raise ContractValidationError(f"{name} must be {expected.__name__}")
+        if self.provider_session_id is not None and not isinstance(
+            self.provider_session_id, ProviderSessionId
+        ):
+            raise ContractValidationError("provider_session_id must be ProviderSessionId or null")
+        if self.worker_handle_id is not None and not isinstance(
+            self.worker_handle_id, WorkerHandleId
+        ):
+            raise ContractValidationError("worker_handle_id must be WorkerHandleId or null")
+        require_string(self.operation, "operation")
+        if self.schema_version != self.SCHEMA_VERSION:
+            raise ContractValidationError(
+                f"schema_version must be {self.SCHEMA_VERSION!r}, got {self.schema_version!r}"
+            )
+        format_datetime(self.requested_at, "requested_at")
+        if not isinstance(self.capability_manifest, CapabilityManifest):
+            raise ContractValidationError("capability_manifest must be CapabilityManifest")
+        object.__setattr__(self, "input", freeze_json(require_object(self.input, "input")))
+        object.__setattr__(
+            self, "governance", freeze_json(require_object(self.governance, "governance"))
+        )
+        object.__setattr__(
+            self,
+            "unknown_fields",
+            freeze_json(
+                require_object(self.unknown_fields, "unknown_fields"), path="unknown_fields"
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        known: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "seat_instance_id": str(self.seat_instance_id),
+            "sovereign_session_id": str(self.sovereign_session_id),
+            "execution_id": str(self.execution_id),
+            "invocation_id": str(self.invocation_id),
+            "provider_session_id": (
+                str(self.provider_session_id) if self.provider_session_id is not None else None
+            ),
+            "worker_handle_id": (
+                str(self.worker_handle_id) if self.worker_handle_id is not None else None
+            ),
+            "repository_id": str(self.repository_id),
+            "operation": self.operation,
+            "input": thaw_json(self.input),
+            "governance": thaw_json(self.governance),
+            "capability_manifest": self.capability_manifest.to_dict(),
+            "requested_at": format_datetime(self.requested_at, "requested_at"),
+        }
+        return merge_unknown(known, self.unknown_fields)
+
+    @classmethod
+    def from_dict(cls, value: object) -> GovernedExecutionRequest:
+        data = require_object(value, "governed_execution_request")
+        known, unknown = split_known(data, cls._KNOWN)
+        required = cls._KNOWN - {"provider_session_id", "worker_handle_id"}
+        missing = sorted(required - known.keys())
+        if missing:
+            raise ContractValidationError(f"missing required fields: {', '.join(missing)}")
+
+        provider = known.get("provider_session_id")
+        worker = known.get("worker_handle_id")
+        return cls(
+            schema_version=require_string(known["schema_version"], "schema_version"),
+            seat_instance_id=SeatInstanceId(
+                require_string(known["seat_instance_id"], "seat_instance_id")
+            ),
+            sovereign_session_id=SovereignSessionId(
+                require_string(known["sovereign_session_id"], "sovereign_session_id")
+            ),
+            execution_id=ExecutionId(require_string(known["execution_id"], "execution_id")),
+            invocation_id=InvocationId(require_string(known["invocation_id"], "invocation_id")),
+            provider_session_id=(
+                ProviderSessionId(require_string(provider, "provider_session_id"))
+                if provider is not None
+                else None
+            ),
+            worker_handle_id=(
+                WorkerHandleId(require_string(worker, "worker_handle_id"))
+                if worker is not None
+                else None
+            ),
+            repository_id=RepositoryId(require_string(known["repository_id"], "repository_id")),
+            operation=require_string(known["operation"], "operation"),
+            input=freeze_json(require_object(known["input"], "input")),
+            governance=freeze_json(require_object(known["governance"], "governance")),
+            capability_manifest=CapabilityManifest.from_dict(known["capability_manifest"]),
+            requested_at=parse_datetime(known["requested_at"], "requested_at"),
+            unknown_fields=unknown,
+        )
+
+
+__all__ = ["GovernedExecutionRequest"]

--- a/src/sovereign_agent/contracts/ids.py
+++ b/src/sovereign_agent/contracts/ids.py
@@ -1,0 +1,68 @@
+"""Validated, non-interchangeable identifiers used by execution contracts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import ClassVar
+
+from ._core import ContractValidationError
+
+_ID_PATTERN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._:/-]{0,126}[A-Za-z0-9])?$")
+
+
+@dataclass(frozen=True, order=True)
+class _ValidatedId:
+    value: str
+    kind: ClassVar[str] = "identifier"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise ContractValidationError(f"{self.kind} must be a string")
+        if not _ID_PATTERN.fullmatch(self.value):
+            raise ContractValidationError(
+                f"{self.kind} must be 1-128 visible identifier characters "
+                "(letters, digits, '.', '_', ':', '/', or '-')"
+            )
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class SeatInstanceId(_ValidatedId):
+    kind = "seat_instance_id"
+
+
+class SovereignSessionId(_ValidatedId):
+    kind = "sovereign_session_id"
+
+
+class ExecutionId(_ValidatedId):
+    kind = "execution_id"
+
+
+class InvocationId(_ValidatedId):
+    kind = "invocation_id"
+
+
+class ProviderSessionId(_ValidatedId):
+    kind = "provider_session_id"
+
+
+class WorkerHandleId(_ValidatedId):
+    kind = "worker_handle_id"
+
+
+class RepositoryId(_ValidatedId):
+    kind = "repository_id"
+
+
+__all__ = [
+    "ExecutionId",
+    "InvocationId",
+    "ProviderSessionId",
+    "RepositoryId",
+    "SeatInstanceId",
+    "SovereignSessionId",
+    "WorkerHandleId",
+]

--- a/src/sovereign_agent/contracts/receipts.py
+++ b/src/sovereign_agent/contracts/receipts.py
@@ -1,0 +1,278 @@
+"""Immutable execution receipts with one-time cryptographic finalization."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, ClassVar
+
+from ._core import (
+    ContractValidationError,
+    FrozenDict,
+    canonical_json_bytes,
+    format_datetime,
+    freeze_json,
+    merge_unknown,
+    parse_datetime,
+    require_object,
+    require_string,
+    split_known,
+    thaw_json,
+)
+from .ids import ExecutionId, InvocationId
+
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReceiptStatus(StrEnum):
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self is not ReceiptStatus.RUNNING
+
+
+@dataclass(frozen=True)
+class ExecutionReceipt:
+    """A deeply immutable observation of an execution.
+
+    Draft receipts have no ``evidence_sha256``. A terminal draft can be
+    finalized once, yielding a new immutable object whose digest covers every
+    wire field except the digest itself. Corrections create a new finalized
+    receipt linked by ``supersedes_sha256``.
+    """
+
+    SCHEMA_VERSION: ClassVar[str] = "1.0"
+
+    execution_id: ExecutionId
+    invocation_id: InvocationId
+    status: ReceiptStatus
+    started_at: datetime
+    completed_at: datetime | None
+    result: Any = None
+    error: Mapping[str, Any] | None = None
+    evidence: Mapping[str, Any] = field(default_factory=FrozenDict)
+    evidence_sha256: str | None = None
+    supersedes_sha256: str | None = None
+    correction_sequence: int = 0
+    schema_version: str = SCHEMA_VERSION
+    unknown_fields: FrozenDict = field(default_factory=FrozenDict, repr=False)
+
+    _KNOWN: ClassVar[frozenset[str]] = frozenset(
+        {
+            "schema_version",
+            "execution_id",
+            "invocation_id",
+            "status",
+            "started_at",
+            "completed_at",
+            "result",
+            "error",
+            "evidence",
+            "evidence_sha256",
+            "supersedes_sha256",
+            "correction_sequence",
+        }
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.execution_id, ExecutionId):
+            raise ContractValidationError("execution_id must be ExecutionId")
+        if not isinstance(self.invocation_id, InvocationId):
+            raise ContractValidationError("invocation_id must be InvocationId")
+        if not isinstance(self.status, ReceiptStatus):
+            raise ContractValidationError("status must be ReceiptStatus")
+        if self.schema_version != self.SCHEMA_VERSION:
+            raise ContractValidationError(f"schema_version must be {self.SCHEMA_VERSION!r}")
+        format_datetime(self.started_at, "started_at")
+        if self.completed_at is not None:
+            format_datetime(self.completed_at, "completed_at")
+            if self.completed_at < self.started_at:
+                raise ContractValidationError("completed_at cannot precede started_at")
+        if self.status.is_terminal != (self.completed_at is not None):
+            raise ContractValidationError(
+                "terminal statuses require completed_at; running status forbids it"
+            )
+        if self.status is ReceiptStatus.SUCCEEDED and self.error is not None:
+            raise ContractValidationError("a succeeded receipt cannot contain an error")
+        if self.status is not ReceiptStatus.SUCCEEDED and self.result is not None:
+            raise ContractValidationError("only a succeeded receipt may contain a result")
+        if self.status is ReceiptStatus.FAILED and self.error is None:
+            raise ContractValidationError("a failed receipt requires an error object")
+        if not isinstance(self.correction_sequence, int) or isinstance(
+            self.correction_sequence, bool
+        ):
+            raise ContractValidationError("correction_sequence must be an integer")
+        if self.correction_sequence < 0:
+            raise ContractValidationError("correction_sequence cannot be negative")
+        if (self.correction_sequence == 0) != (self.supersedes_sha256 is None):
+            raise ContractValidationError(
+                "a correction must have both a positive sequence and supersedes_sha256"
+            )
+        for name, digest in (
+            ("evidence_sha256", self.evidence_sha256),
+            ("supersedes_sha256", self.supersedes_sha256),
+        ):
+            if digest is not None and not _SHA256_PATTERN.fullmatch(digest):
+                raise ContractValidationError(f"{name} must be a lowercase SHA-256 hex digest")
+        object.__setattr__(self, "result", freeze_json(self.result, path="result"))
+        if self.error is not None:
+            object.__setattr__(
+                self, "error", freeze_json(require_object(self.error, "error"), path="error")
+            )
+        object.__setattr__(
+            self,
+            "evidence",
+            freeze_json(require_object(self.evidence, "evidence"), path="evidence"),
+        )
+        object.__setattr__(
+            self,
+            "unknown_fields",
+            freeze_json(
+                require_object(self.unknown_fields, "unknown_fields"), path="unknown_fields"
+            ),
+        )
+        if self.evidence_sha256 is not None and not self.verify_evidence():
+            raise ContractValidationError("evidence_sha256 does not match receipt contents")
+
+    @property
+    def is_finalized(self) -> bool:
+        return self.evidence_sha256 is not None
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status.is_terminal
+
+    @property
+    def is_successful(self) -> bool:
+        return self.status is ReceiptStatus.SUCCEEDED
+
+    def _unsigned_dict(self) -> dict[str, Any]:
+        value = self.to_dict()
+        value.pop("evidence_sha256")
+        return value
+
+    def expected_evidence_sha256(self) -> str:
+        return hashlib.sha256(canonical_json_bytes(self._unsigned_dict())).hexdigest()
+
+    def verify_evidence(self) -> bool:
+        return (
+            self.evidence_sha256 is not None
+            and self.evidence_sha256 == self.expected_evidence_sha256()
+        )
+
+    def finalize(self) -> ExecutionReceipt:
+        """Finalize a terminal draft exactly once."""
+        if self.is_finalized:
+            raise ContractValidationError("receipt has already been finalized")
+        if not self.is_terminal:
+            raise ContractValidationError("a running receipt cannot be finalized")
+        digest = self.expected_evidence_sha256()
+        return replace(self, evidence_sha256=digest)
+
+    def supersede(
+        self,
+        *,
+        status: ReceiptStatus,
+        completed_at: datetime,
+        result: Any = None,
+        error: Mapping[str, Any] | None = None,
+        evidence: Mapping[str, Any] | None = None,
+    ) -> ExecutionReceipt:
+        """Create and finalize a linked correction; never alter this receipt."""
+        if not self.is_finalized:
+            raise ContractValidationError("only a finalized receipt can be superseded")
+        correction = ExecutionReceipt(
+            execution_id=self.execution_id,
+            invocation_id=self.invocation_id,
+            status=status,
+            started_at=self.started_at,
+            completed_at=completed_at,
+            result=result,
+            error=error,
+            evidence=self.evidence if evidence is None else evidence,
+            supersedes_sha256=self.evidence_sha256,
+            correction_sequence=self.correction_sequence + 1,
+            unknown_fields=self.unknown_fields,
+        )
+        return correction.finalize()
+
+    def to_dict(self) -> dict[str, Any]:
+        known: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "execution_id": str(self.execution_id),
+            "invocation_id": str(self.invocation_id),
+            "status": self.status.value,
+            "started_at": format_datetime(self.started_at, "started_at"),
+            "completed_at": (
+                format_datetime(self.completed_at, "completed_at")
+                if self.completed_at is not None
+                else None
+            ),
+            "result": thaw_json(self.result),
+            "error": thaw_json(self.error) if self.error is not None else None,
+            "evidence": thaw_json(self.evidence),
+            "evidence_sha256": self.evidence_sha256,
+            "supersedes_sha256": self.supersedes_sha256,
+            "correction_sequence": self.correction_sequence,
+        }
+        return merge_unknown(known, self.unknown_fields)
+
+    @classmethod
+    def from_dict(cls, value: object) -> ExecutionReceipt:
+        data = require_object(value, "execution_receipt")
+        known, unknown = split_known(data, cls._KNOWN)
+        required = cls._KNOWN - {"result", "error", "evidence_sha256", "supersedes_sha256"}
+        missing = sorted(required - known.keys())
+        if missing:
+            raise ContractValidationError(f"missing required fields: {', '.join(missing)}")
+        try:
+            status = ReceiptStatus(require_string(known["status"], "status"))
+        except ValueError as exc:
+            raise ContractValidationError("status is not a recognized receipt status") from exc
+        completed = known["completed_at"]
+        sequence = known["correction_sequence"]
+        if not isinstance(sequence, int) or isinstance(sequence, bool):
+            raise ContractValidationError("correction_sequence must be an integer")
+        return cls(
+            schema_version=require_string(known["schema_version"], "schema_version"),
+            execution_id=ExecutionId(require_string(known["execution_id"], "execution_id")),
+            invocation_id=InvocationId(require_string(known["invocation_id"], "invocation_id")),
+            status=status,
+            started_at=parse_datetime(known["started_at"], "started_at"),
+            completed_at=(
+                parse_datetime(completed, "completed_at") if completed is not None else None
+            ),
+            result=known.get("result"),
+            error=known.get("error"),
+            evidence=freeze_json(require_object(known["evidence"], "evidence")),
+            evidence_sha256=known.get("evidence_sha256"),
+            supersedes_sha256=known.get("supersedes_sha256"),
+            correction_sequence=sequence,
+            unknown_fields=unknown,
+        )
+
+
+def lifecycle_complete(receipt: ExecutionReceipt) -> bool:
+    """Lifecycle predicate; deliberately independent of evidence validity."""
+    return receipt.is_terminal
+
+
+def evidence_verified(receipt: ExecutionReceipt) -> bool:
+    """Evidence predicate; deliberately independent of lifecycle outcome."""
+    return receipt.verify_evidence()
+
+
+__all__ = [
+    "ExecutionReceipt",
+    "ReceiptStatus",
+    "evidence_verified",
+    "lifecycle_complete",
+]

--- a/src/sovereign_agent/contracts/redaction.py
+++ b/src/sovereign_agent/contracts/redaction.py
@@ -1,0 +1,87 @@
+"""Non-mutating redaction helpers for contract payloads and logs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ._core import ContractValidationError, freeze_json, thaw_json
+
+REDACTED = "[REDACTED]"
+
+DEFAULT_SENSITIVE_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "authorization",
+        "client_secret",
+        "cookie",
+        "password",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "set-cookie",
+        "token",
+    }
+)
+
+_CREDENTIAL_TEXT = re.compile(
+    r"(?i)\b(bearer\s+|(?:api[_-]?key|token|password|secret)\s*[=:]\s*)"
+    r"([^\s,;\"']+)"
+)
+
+
+def _normalize_key(key: str) -> str:
+    return key.casefold().replace("-", "_")
+
+
+def redact_json(
+    value: object,
+    *,
+    sensitive_keys: Iterable[str] = DEFAULT_SENSITIVE_KEYS,
+    replacement: str = REDACTED,
+) -> Any:
+    """Return a detached JSON value with sensitive object members replaced."""
+    if not isinstance(replacement, str):
+        raise ContractValidationError("redaction replacement must be a string")
+    normalized = {_normalize_key(key) for key in sensitive_keys}
+
+    def visit(item: Any) -> Any:
+        if isinstance(item, Mapping):
+            return {
+                key: replacement if _normalize_key(key) in normalized else visit(child)
+                for key, child in item.items()
+            }
+        if isinstance(item, (list, tuple)):
+            return [visit(child) for child in item]
+        return item
+
+    return visit(thaw_json(freeze_json(value)))
+
+
+def redact_mapping(
+    value: Mapping[str, Any],
+    *,
+    sensitive_keys: Iterable[str] = DEFAULT_SENSITIVE_KEYS,
+    replacement: str = REDACTED,
+) -> dict[str, Any]:
+    redacted = redact_json(value, sensitive_keys=sensitive_keys, replacement=replacement)
+    assert isinstance(redacted, dict)
+    return redacted
+
+
+def redact_text(value: str, *, replacement: str = REDACTED) -> str:
+    """Redact common inline credentials without changing unrelated text."""
+    if not isinstance(value, str):
+        raise ContractValidationError("text to redact must be a string")
+    return _CREDENTIAL_TEXT.sub(lambda match: f"{match.group(1)}{replacement}", value)
+
+
+__all__ = [
+    "DEFAULT_SENSITIVE_KEYS",
+    "REDACTED",
+    "redact_json",
+    "redact_mapping",
+    "redact_text",
+]

--- a/src/sovereign_agent/contracts/schemas/__init__.py
+++ b/src/sovereign_agent/contracts/schemas/__init__.py
@@ -1,0 +1,29 @@
+"""Bundled JSON Schema resources for the external wire contracts."""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+
+SCHEMA_NAMES = (
+    "capability-manifest.schema.json",
+    "execution-receipt.schema.json",
+    "governed-execution-request.schema.json",
+)
+
+
+def schema_path(name: str) -> Path:
+    """Return a filesystem path when resources are installed unpacked."""
+    if name not in SCHEMA_NAMES:
+        raise ValueError(f"unknown contract schema: {name}")
+    resource = files(__package__).joinpath(name)
+    return Path(str(resource))
+
+
+def read_schema(name: str) -> bytes:
+    if name not in SCHEMA_NAMES:
+        raise ValueError(f"unknown contract schema: {name}")
+    return files(__package__).joinpath(name).read_bytes()
+
+
+__all__ = ["SCHEMA_NAMES", "read_schema", "schema_path"]

--- a/src/sovereign_agent/contracts/schemas/capability-manifest.schema.json
+++ b/src/sovereign_agent/contracts/schemas/capability-manifest.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zeroemployee.org/schemas/sovereign-agent/v1/capability-manifest.schema.json",
+  "title": "Capability Manifest",
+  "type": "object",
+  "required": ["capabilities"],
+  "properties": {
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["available", "evidence_level"],
+        "properties": {
+          "available": {"type": ["boolean", "null"]},
+          "evidence_level": {
+            "enum": ["unknown", "declared", "probed", "enforced"]
+          },
+          "details": {"type": "object"}
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/sovereign_agent/contracts/schemas/execution-receipt.schema.json
+++ b/src/sovereign_agent/contracts/schemas/execution-receipt.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zeroemployee.org/schemas/sovereign-agent/v1/execution-receipt.schema.json",
+  "title": "Execution Receipt",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "execution_id",
+    "invocation_id",
+    "status",
+    "started_at",
+    "completed_at",
+    "result",
+    "error",
+    "evidence",
+    "evidence_sha256",
+    "supersedes_sha256",
+    "correction_sequence"
+  ],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "execution_id": {"$ref": "#/$defs/id"},
+    "invocation_id": {"$ref": "#/$defs/id"},
+    "status": {"enum": ["running", "succeeded", "failed", "cancelled"]},
+    "started_at": {"type": "string", "format": "date-time"},
+    "completed_at": {"type": ["string", "null"], "format": "date-time"},
+    "result": {},
+    "error": {"type": ["object", "null"]},
+    "evidence": {"type": "object"},
+    "evidence_sha256": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "supersedes_sha256": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "correction_sequence": {"type": "integer", "minimum": 0}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "running"}}},
+      "then": {
+        "properties": {
+          "completed_at": {"type": "null"},
+          "result": {"type": "null"}
+        }
+      },
+      "else": {
+        "properties": {"completed_at": {"type": "string", "format": "date-time"}}
+      }
+    },
+    {
+      "if": {"properties": {"status": {"const": "succeeded"}}},
+      "then": {"properties": {"error": {"type": "null"}}},
+      "else": {"properties": {"result": {"type": "null"}}}
+    },
+    {
+      "if": {"properties": {"status": {"const": "failed"}}},
+      "then": {"properties": {"error": {"type": "object"}}}
+    },
+    {
+      "if": {"properties": {"correction_sequence": {"const": 0}}},
+      "then": {"properties": {"supersedes_sha256": {"type": "null"}}},
+      "else": {
+        "properties": {
+          "supersedes_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9._:/-]{0,126}[A-Za-z0-9])?$"
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/sovereign_agent/contracts/schemas/governed-execution-request.schema.json
+++ b/src/sovereign_agent/contracts/schemas/governed-execution-request.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zeroemployee.org/schemas/sovereign-agent/v1/governed-execution-request.schema.json",
+  "title": "Governed Execution Request",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "seat_instance_id",
+    "sovereign_session_id",
+    "execution_id",
+    "invocation_id",
+    "repository_id",
+    "operation",
+    "input",
+    "governance",
+    "capability_manifest",
+    "requested_at"
+  ],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "seat_instance_id": {"$ref": "#/$defs/id"},
+    "sovereign_session_id": {"$ref": "#/$defs/id"},
+    "execution_id": {"$ref": "#/$defs/id"},
+    "invocation_id": {"$ref": "#/$defs/id"},
+    "provider_session_id": {
+      "oneOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]
+    },
+    "worker_handle_id": {
+      "oneOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]
+    },
+    "repository_id": {"$ref": "#/$defs/id"},
+    "operation": {"type": "string", "minLength": 1},
+    "input": {"type": "object"},
+    "governance": {"type": "object"},
+    "capability_manifest": {
+      "$ref": "capability-manifest.schema.json"
+    },
+    "requested_at": {"type": "string", "format": "date-time"}
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9._:/-]{0,126}[A-Za-z0-9])?$"
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/sovereign_agent/runtime/__init__.py
+++ b/src/sovereign_agent/runtime/__init__.py
@@ -1,0 +1,21 @@
+"""Versioned runtime-root filesystem contract."""
+
+from sovereign_agent.runtime.root import (
+    RUNTIME_DIRECTORIES,
+    RUNTIME_LAYOUT_VERSION,
+    RUNTIME_METADATA_FILENAME,
+    RUNTIME_SCHEMA_VERSION,
+    RuntimeRoot,
+    RuntimeRootError,
+    UnsupportedRuntimeVersionError,
+)
+
+__all__ = [
+    "RUNTIME_DIRECTORIES",
+    "RUNTIME_LAYOUT_VERSION",
+    "RUNTIME_METADATA_FILENAME",
+    "RUNTIME_SCHEMA_VERSION",
+    "RuntimeRoot",
+    "RuntimeRootError",
+    "UnsupportedRuntimeVersionError",
+]

--- a/src/sovereign_agent/runtime/root.py
+++ b/src/sovereign_agent/runtime/root.py
@@ -1,0 +1,259 @@
+"""Versioned, durable filesystem root for sovereign-agent runtime state."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sovereign_agent._internal.atomic import atomic_write_json
+
+RUNTIME_SCHEMA_VERSION = 1
+RUNTIME_LAYOUT_VERSION = 1
+RUNTIME_METADATA_FILENAME = "runtime.json"
+RUNTIME_DIRECTORIES = ("seats", "sessions", "executions", "relay", "receipts", "locks")
+
+_SAFE_COMPONENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class RuntimeRootError(ValueError):
+    """The runtime root or one of its paths violates the filesystem contract."""
+
+
+class UnsupportedRuntimeVersionError(RuntimeRootError):
+    """The on-disk root uses a version this package cannot safely operate on."""
+
+
+@dataclass(frozen=True)
+class RuntimeRoot:
+    """A handle to a versioned runtime filesystem tree.
+
+    Constructing a handle is side-effect free. Call :meth:`initialize` before
+    writing. ``legacy_sessions_dir`` makes an existing v0.2 session tree
+    readable; a legacy session is copied into this root only on its first
+    write, leaving the original tree and its ``session.json`` untouched.
+    """
+
+    root: Path
+    legacy_sessions_dir: Path | None = None
+    schema_version: int = RUNTIME_SCHEMA_VERSION
+    layout_version: int = RUNTIME_LAYOUT_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "root", Path(self.root))
+        if self.legacy_sessions_dir is not None:
+            object.__setattr__(self, "legacy_sessions_dir", Path(self.legacy_sessions_dir))
+        if self.schema_version <= 0 or self.layout_version <= 0:
+            raise RuntimeRootError("runtime versions must be positive integers")
+
+    @property
+    def metadata_path(self) -> Path:
+        return self.root / RUNTIME_METADATA_FILENAME
+
+    @property
+    def seats_dir(self) -> Path:
+        return self.root / "seats"
+
+    @property
+    def sessions_dir(self) -> Path:
+        return self.root / "sessions"
+
+    @property
+    def executions_dir(self) -> Path:
+        return self.root / "executions"
+
+    @property
+    def relay_dir(self) -> Path:
+        return self.root / "relay"
+
+    @property
+    def receipts_dir(self) -> Path:
+        return self.root / "receipts"
+
+    @property
+    def locks_dir(self) -> Path:
+        return self.root / "locks"
+
+    def initialize(self) -> RuntimeRoot:
+        """Create and validate the durable layout and atomic root metadata."""
+        if self.root.is_symlink():
+            raise RuntimeRootError(f"runtime root must not be a symlink: {self.root}")
+        if self.root.exists() and not self.root.is_dir():
+            raise RuntimeRootError(f"runtime root is not a directory: {self.root}")
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        existing = self._read_metadata()
+        if existing is not None:
+            self._validate_metadata(existing)
+
+        for name in RUNTIME_DIRECTORIES:
+            directory = self.root / name
+            if directory.is_symlink():
+                raise RuntimeRootError(f"runtime directory must not be a symlink: {directory}")
+            directory.mkdir(mode=0o700, parents=False, exist_ok=True)
+            if not directory.is_dir():
+                raise RuntimeRootError(f"runtime path is not a directory: {directory}")
+
+        if existing is None:
+            atomic_write_json(self.metadata_path, self._metadata())
+            _fsync_directory(self.root)
+        return self
+
+    @classmethod
+    def open(
+        cls,
+        root: Path,
+        *,
+        legacy_sessions_dir: Path | None = None,
+    ) -> RuntimeRoot:
+        """Open and validate an initialized runtime root without modifying it."""
+        runtime = cls(root, legacy_sessions_dir=legacy_sessions_dir)
+        metadata = runtime._read_metadata()
+        if metadata is None:
+            raise RuntimeRootError(f"runtime metadata not found: {runtime.metadata_path}")
+        runtime._validate_metadata(metadata)
+        for name in RUNTIME_DIRECTORIES:
+            directory = runtime.root / name
+            if directory.is_symlink() or not directory.is_dir():
+                raise RuntimeRootError(f"runtime directory missing or unsafe: {directory}")
+        return runtime
+
+    def path(self, relative: str | Path) -> Path:
+        """Resolve a relative path inside this root, rejecting every escape."""
+        rel = Path(relative)
+        if rel.is_absolute():
+            raise RuntimeRootError(f"absolute runtime path is not allowed: {relative!r}")
+        base = self.root.resolve()
+        candidate = (base / rel).resolve()
+        try:
+            candidate.relative_to(base)
+        except ValueError as exc:
+            raise RuntimeRootError(f"path escapes runtime root: {relative!r}") from exc
+        return candidate
+
+    def session_directory(self, session_id: str, *, for_write: bool = False) -> Path:
+        """Return a current or legacy session path, migrating on first write."""
+        _validate_component(session_id, "session_id")
+        current = self.sessions_dir / session_id
+        if current.exists():
+            return current
+
+        legacy = self._legacy_session_directory(session_id)
+        if legacy is None or not legacy.exists():
+            return current
+        if not for_write:
+            return legacy
+        self.initialize()
+        return self._copy_legacy_session(legacy, current)
+
+    def create_session(self, *args: Any, **kwargs: Any) -> Any:
+        """Create a session in this root (lazy import avoids import cycles)."""
+        from sovereign_agent.session.directory import create_session
+
+        kwargs["runtime_root"] = self
+        return create_session(*args, **kwargs)
+
+    def load_session(self, session_id: str) -> Any:
+        """Load a current or legacy session through this root."""
+        from sovereign_agent.session.directory import load_session
+
+        return load_session(session_id, runtime_root=self)
+
+    def list_sessions(self, **kwargs: Any) -> list[Any]:
+        """List current and legacy sessions, preferring current copies."""
+        from sovereign_agent.session.directory import list_sessions
+
+        return list_sessions(runtime_root=self, **kwargs)
+
+    def _metadata(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "layout_version": self.layout_version,
+            "directories": list(RUNTIME_DIRECTORIES),
+        }
+
+    def _read_metadata(self) -> dict[str, Any] | None:
+        if not self.metadata_path.exists():
+            return None
+        if self.metadata_path.is_symlink():
+            raise RuntimeRootError(f"runtime metadata must not be a symlink: {self.metadata_path}")
+        try:
+            data = json.loads(self.metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeRootError(f"invalid runtime metadata: {self.metadata_path}") from exc
+        if not isinstance(data, dict):
+            raise RuntimeRootError("runtime metadata must be a JSON object")
+        return data
+
+    def _validate_metadata(self, metadata: dict[str, Any]) -> None:
+        schema = metadata.get("schema_version")
+        layout = metadata.get("layout_version")
+        if schema != self.schema_version or layout != self.layout_version:
+            raise UnsupportedRuntimeVersionError(
+                "unsupported runtime version: "
+                f"schema={schema!r}, layout={layout!r}; "
+                f"expected schema={self.schema_version}, layout={self.layout_version}"
+            )
+        if metadata.get("directories") != list(RUNTIME_DIRECTORIES):
+            raise RuntimeRootError("runtime metadata directory layout does not match this version")
+
+    def _legacy_session_directory(self, session_id: str) -> Path | None:
+        if self.legacy_sessions_dir is None:
+            return None
+        legacy_root = self.legacy_sessions_dir.resolve()
+        candidate = (legacy_root / session_id).resolve()
+        try:
+            candidate.relative_to(legacy_root)
+        except ValueError as exc:
+            raise RuntimeRootError(f"legacy session path escapes its root: {session_id!r}") from exc
+        return candidate
+
+    def _copy_legacy_session(self, source: Path, destination: Path) -> Path:
+        staging = self.sessions_dir / f".{destination.name}.migrate-{secrets.token_hex(6)}"
+        try:
+            shutil.copytree(source, staging, symlinks=True)
+            try:
+                staging.replace(destination)
+            except FileExistsError:
+                shutil.rmtree(staging)
+            _fsync_directory(self.sessions_dir)
+        except Exception:
+            if staging.exists():
+                shutil.rmtree(staging)
+            raise
+        return destination
+
+
+def _validate_component(value: str, label: str) -> None:
+    if not _SAFE_COMPONENT.fullmatch(value) or value in {".", ".."}:
+        raise RuntimeRootError(f"unsafe {label}: {value!r}")
+
+
+def _fsync_directory(path: Path) -> None:
+    """Best-effort directory sync after metadata or migration rename."""
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+__all__ = [
+    "RUNTIME_DIRECTORIES",
+    "RUNTIME_LAYOUT_VERSION",
+    "RUNTIME_METADATA_FILENAME",
+    "RUNTIME_SCHEMA_VERSION",
+    "RuntimeRoot",
+    "RuntimeRootError",
+    "UnsupportedRuntimeVersionError",
+]

--- a/src/sovereign_agent/session/directory.py
+++ b/src/sovereign_agent/session/directory.py
@@ -11,6 +11,7 @@ discouraged because Session.path() enforces traversal safety.
 from __future__ import annotations
 
 import json
+import re
 import secrets
 import shutil
 from pathlib import Path
@@ -27,9 +28,10 @@ from sovereign_agent.session.state import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from sovereign_agent.runtime import RuntimeRoot
 
 DEFAULT_SESSIONS_DIR = Path("sessions")
+_SAFE_SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 _DEFAULT_SESSION_MD_TEMPLATE = """# Session {session_id}
 
@@ -99,10 +101,12 @@ class Session:
         session_id: str,
         directory: Path,
         state: SessionState,
+        runtime_root: RuntimeRoot | None = None,
     ) -> None:
         self.session_id = session_id
         self.directory = directory
         self.state = state
+        self._runtime_root = runtime_root
 
     # ------------------------------------------------------------------
     # Path safety
@@ -211,6 +215,11 @@ class Session:
         """
         if self.state.resumed_from is None:
             return None
+        if self._runtime_root is not None:
+            try:
+                return load_session(self.state.resumed_from, runtime_root=self._runtime_root)
+            except SessionNotFoundError:
+                return None
         parent_dir = self.directory.parent / self.state.resumed_from
         parent_json = parent_dir / "session.json"
         if not parent_dir.exists() or not parent_json.exists():
@@ -243,9 +252,10 @@ class Session:
         If `state` is among the changes, validates the transition.
         Always updates `updated_at`.
         """
+        self._ensure_writable()
         if "state" in changes:
             proposed = str(changes["state"])
-            if not is_transition_allowed(self.state.state, proposed):  # type: ignore[arg-type]
+            if not is_transition_allowed(self.state.state, proposed):
                 raise InvalidStateTransition(self.state.state, proposed)
 
         # Apply changes to the in-memory state object.
@@ -262,6 +272,7 @@ class Session:
     # ------------------------------------------------------------------
     def append_trace_event(self, event: dict) -> None:
         """Append one event to logs/trace.jsonl. O_APPEND, atomic per-write."""
+        self._ensure_writable()
         atomic_append_jsonl(self.trace_path, event)
 
     @property
@@ -276,6 +287,7 @@ class Session:
 
     def append_inbox_event(self, event: dict) -> None:
         """Append one inbound channel message to inbox/messages.jsonl."""
+        self._ensure_writable()
         atomic_append_jsonl(self.inbox_path, event)
 
     def iter_inbox_events(self) -> list[dict]:
@@ -311,6 +323,14 @@ class Session:
     def mark_escalated(self, reason: str) -> None:
         self.update_state(state="escalated", result={"reason": reason})
 
+    def _ensure_writable(self) -> None:
+        """Copy a legacy tree into the runtime root immediately before writing."""
+        if self._runtime_root is None:
+            return
+        writable = self._runtime_root.session_directory(self.session_id, for_write=True)
+        if writable != self.directory:
+            self.directory = writable
+
     def __repr__(self) -> str:
         return f"Session(id={self.session_id!r}, state={self.state.state!r})"
 
@@ -323,6 +343,14 @@ class Session:
 def _generate_session_id() -> str:
     """Generate a 12-hex session id. Collision probability is vanishingly small."""
     return f"sess_{secrets.token_hex(6)}"
+
+
+def _validate_session_id(session_id: str) -> None:
+    if not _SAFE_SESSION_ID.fullmatch(session_id) or session_id in {".", ".."}:
+        raise SessionEscapeError(
+            f"unsafe session id: {session_id!r}",
+            {"session_id": session_id},
+        )
 
 
 def _make_subdirs(directory: Path) -> None:
@@ -353,6 +381,7 @@ def create_session(
     sessions_dir: Path | None = None,
     session_id: str | None = None,
     resumed_from: str | None = None,
+    runtime_root: RuntimeRoot | None = None,
 ) -> Session:
     """Create a new session directory and return a Session handle.
 
@@ -366,8 +395,15 @@ def create_session(
     touched. Use sovereign_agent.session.resume.resume_session() for the
     higher-level API that also populates parent-context hints.
     """
-    sessions_root = sessions_dir or DEFAULT_SESSIONS_DIR
+    if runtime_root is not None and sessions_dir is not None:
+        raise ValueError("pass either runtime_root or sessions_dir, not both")
+    if runtime_root is not None:
+        runtime_root.initialize()
+        sessions_root = runtime_root.sessions_dir
+    else:
+        sessions_root = sessions_dir or DEFAULT_SESSIONS_DIR
     sid = session_id or _generate_session_id()
+    _validate_session_id(sid)
     directory = sessions_root / sid
     if directory.exists():
         # Extremely unlikely; still, fail loudly rather than overwrite.
@@ -401,52 +437,73 @@ def create_session(
     )
     (directory / "SESSION.md").write_text(md, encoding="utf-8")
 
-    return Session(sid, directory, state)
+    return Session(sid, directory, state, runtime_root=runtime_root)
 
 
 def load_session(
     session_id: str,
     sessions_dir: Path | None = None,
+    runtime_root: RuntimeRoot | None = None,
 ) -> Session:
     """Load an existing session by id."""
-    sessions_root = sessions_dir or DEFAULT_SESSIONS_DIR
-    directory = sessions_root / session_id
+    _validate_session_id(session_id)
+    if runtime_root is not None and sessions_dir is not None:
+        raise ValueError("pass either runtime_root or sessions_dir, not both")
+    if runtime_root is not None:
+        directory = runtime_root.session_directory(session_id)
+    else:
+        sessions_root = sessions_dir or DEFAULT_SESSIONS_DIR
+        directory = sessions_root / session_id
     session_json = directory / "session.json"
     if not directory.exists() or not session_json.exists():
         raise SessionNotFoundError(session_id)
     with open(session_json, encoding="utf-8") as f:
         data = json.load(f)
     state = SessionState.from_dict(data)
-    return Session(session_id, directory, state)
+    return Session(session_id, directory, state, runtime_root=runtime_root)
 
 
 def list_sessions(
     state_filter: SessionStateName | None = None,
     sessions_dir: Path | None = None,
+    runtime_root: RuntimeRoot | None = None,
 ) -> list[Session]:
     """List all sessions under sessions_dir.
 
     Returned ordered by created_at descending (newest first).
     """
-    sessions_root = sessions_dir or DEFAULT_SESSIONS_DIR
-    if not sessions_root.exists():
-        return []
+    if runtime_root is not None and sessions_dir is not None:
+        raise ValueError("pass either runtime_root or sessions_dir, not both")
+    if runtime_root is None:
+        roots = [sessions_dir or DEFAULT_SESSIONS_DIR]
+    else:
+        roots = [runtime_root.sessions_dir]
+        if runtime_root.legacy_sessions_dir is not None:
+            roots.append(runtime_root.legacy_sessions_dir)
     sessions: list[Session] = []
-    for entry in sessions_root.iterdir():
-        if not entry.is_dir() or not entry.name.startswith("sess_"):
+    seen: set[str] = set()
+    for sessions_root in roots:
+        if not sessions_root.exists():
             continue
-        if not (entry / "session.json").exists():
-            continue
-        try:
-            session = load_session(entry.name, sessions_dir=sessions_root)
-        except Exception:
-            # Corrupt session dirs are skipped silently — list should be safe
-            # even when some sessions are broken. Doctor will surface them
-            # separately.
-            continue
-        if state_filter is not None and session.state.state != state_filter:
-            continue
-        sessions.append(session)
+        for entry in sessions_root.iterdir():
+            if not entry.is_dir() or not entry.name.startswith("sess_") or entry.name in seen:
+                continue
+            if not (entry / "session.json").exists():
+                continue
+            try:
+                if runtime_root is None:
+                    session = load_session(entry.name, sessions_dir=sessions_root)
+                else:
+                    session = load_session(entry.name, runtime_root=runtime_root)
+            except Exception:
+                # Corrupt session dirs are skipped silently — list should be safe
+                # even when some sessions are broken. Doctor will surface them
+                # separately.
+                continue
+            seen.add(entry.name)
+            if state_filter is not None and session.state.state != state_filter:
+                continue
+            sessions.append(session)
     sessions.sort(key=lambda s: s.state.created_at, reverse=True)
     return sessions
 
@@ -463,6 +520,7 @@ def archive_session(session: Session, archive_dir: Path | None = None) -> Path:
             message=f"cannot archive non-terminal session (state={session.state.state})",
             context={"session_id": session.session_id, "state": session.state.state},
         )
+    session._ensure_writable()
     archive = archive_dir or (session.directory.parent / "archive")
     archive.mkdir(parents=True, exist_ok=True)
     dest = archive / session.directory.name

--- a/src/sovereign_agent/session/resume.py
+++ b/src/sovereign_agent/session/resume.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from sovereign_agent.errors import ValidationError
 from sovereign_agent.session.directory import (
@@ -52,6 +53,9 @@ from sovereign_agent.session.directory import (
     create_session,
     load_session,
 )
+
+if TYPE_CHECKING:
+    from sovereign_agent.runtime import RuntimeRoot
 
 # Cap the parent-trace summary we inline into SESSION.md. Very long traces
 # can blow out planner context windows. If users want the full trace they
@@ -70,6 +74,7 @@ def resume_session(
     session_id: str | None = None,
     allow_unfinished_parent: bool = False,
     trace_summary_lines: int = DEFAULT_TRACE_SUMMARY_LINES,
+    runtime_root: RuntimeRoot | None = None,
 ) -> Session:
     """Create a new session that resumes from `parent_id`.
 
@@ -92,10 +97,15 @@ def resume_session(
       SessionNotFoundError: parent doesn't exist.
       ValidationError: parent is unfinished and allow_unfinished_parent=False.
     """
+    if runtime_root is not None and sessions_dir is not None:
+        raise ValueError("pass either runtime_root or sessions_dir, not both")
     sessions_root = sessions_dir or DEFAULT_SESSIONS_DIR
 
     # Fetch parent (raises if missing).
-    parent = load_session(parent_id, sessions_dir=sessions_root)
+    if runtime_root is None:
+        parent = load_session(parent_id, sessions_dir=sessions_root)
+    else:
+        parent = load_session(parent_id, runtime_root=runtime_root)
 
     if not parent.state.is_terminal() and not allow_unfinished_parent:
         raise ValidationError(
@@ -113,15 +123,26 @@ def resume_session(
 
     resolved_scenario = scenario or parent.state.scenario
 
-    child = create_session(
-        scenario=resolved_scenario,
-        task=task,
-        user_id=user_id or parent.state.user_id,
-        config_overrides=config_overrides,
-        sessions_dir=sessions_root,
-        session_id=session_id,
-        resumed_from=parent_id,
-    )
+    if runtime_root is None:
+        child = create_session(
+            scenario=resolved_scenario,
+            task=task,
+            user_id=user_id or parent.state.user_id,
+            config_overrides=config_overrides,
+            sessions_dir=sessions_root,
+            session_id=session_id,
+            resumed_from=parent_id,
+        )
+    else:
+        child = create_session(
+            scenario=resolved_scenario,
+            task=task,
+            user_id=user_id or parent.state.user_id,
+            config_overrides=config_overrides,
+            session_id=session_id,
+            resumed_from=parent_id,
+            runtime_root=runtime_root,
+        )
 
     # Inline a context summary into SESSION.md. The planner reads SESSION.md
     # at the start of every run, so this is the natural place to surface

--- a/tests/contracts/test_contracts.py
+++ b/tests/contracts/test_contracts.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from sovereign_agent.contracts import (
+    Capability,
+    CapabilityManifest,
+    ContractValidationError,
+    EvidenceLevel,
+    ExecutionId,
+    ExecutionReceipt,
+    GovernedExecutionRequest,
+    InvocationId,
+    ReceiptStatus,
+    RepositoryId,
+    SeatInstanceId,
+    SovereignSessionId,
+    canonical_json_bytes,
+    evidence_verified,
+    lifecycle_complete,
+    redact_json,
+    redact_text,
+)
+
+NOW = datetime(2026, 8, 22, 12, 0, tzinfo=UTC)
+
+
+def manifest() -> CapabilityManifest:
+    return CapabilityManifest(
+        {
+            "network": Capability(
+                available=False,
+                evidence_level=EvidenceLevel.ENFORCED,
+                details={"mechanism": "sandbox"},
+            ),
+            "shell": Capability(
+                available=True,
+                evidence_level=EvidenceLevel.DECLARED,
+            ),
+        }
+    )
+
+
+def request() -> GovernedExecutionRequest:
+    return GovernedExecutionRequest(
+        seat_instance_id=SeatInstanceId("seat-01"),
+        sovereign_session_id=SovereignSessionId("session-01"),
+        execution_id=ExecutionId("execution-01"),
+        invocation_id=InvocationId("invocation-01"),
+        repository_id=RepositoryId("repo:zeroemployee/sovereign-agent"),
+        operation="run",
+        input={"prompt": "check", "paths": ["src"]},
+        governance={"network": "deny"},
+        capability_manifest=manifest(),
+        requested_at=NOW,
+    )
+
+
+def terminal_receipt() -> ExecutionReceipt:
+    return ExecutionReceipt(
+        execution_id=ExecutionId("execution-01"),
+        invocation_id=InvocationId("invocation-01"),
+        status=ReceiptStatus.SUCCEEDED,
+        started_at=NOW,
+        completed_at=NOW + timedelta(seconds=2),
+        result={"exit_code": 0},
+        evidence={"stdout": "ok"},
+    )
+
+
+def test_typed_ids_validate_and_do_not_compare_as_plain_strings() -> None:
+    assert str(SeatInstanceId("seat-01")) == "seat-01"
+    assert SeatInstanceId("same") != ExecutionId("same")
+    for invalid in ("", " spaces ", "trailing-", "x" * 129):
+        with pytest.raises(ContractValidationError):
+            SeatInstanceId(invalid)
+
+
+def test_request_strict_round_trip_and_unknown_preservation() -> None:
+    wire = request().to_dict()
+    wire["future_contract_field"] = {"mode": "new"}
+    restored = GovernedExecutionRequest.from_dict(wire)
+    assert restored.to_dict() == wire
+    assert restored.unknown_fields["future_contract_field"]["mode"] == "new"
+
+
+def test_request_rejects_missing_wrong_and_naive_values() -> None:
+    wire = request().to_dict()
+    del wire["governance"]
+    with pytest.raises(ContractValidationError, match="missing required"):
+        GovernedExecutionRequest.from_dict(wire)
+    with pytest.raises(ContractValidationError, match="timezone-aware"):
+        GovernedExecutionRequest(**{**request().__dict__, "requested_at": datetime(2026, 1, 1)})
+
+
+def test_capability_availability_and_evidence_are_independent() -> None:
+    capabilities = manifest()
+    assert not capabilities.is_available("network")
+    assert capabilities.has_evidence("network", EvidenceLevel.ENFORCED)
+    assert capabilities.is_available("shell")
+    assert not capabilities.has_evidence("shell", EvidenceLevel.PROBED)
+
+
+def test_capability_unknown_fields_round_trip() -> None:
+    wire = {
+        "capabilities": {
+            "gpu": {
+                "available": None,
+                "evidence_level": "unknown",
+                "details": {},
+                "future": 7,
+            }
+        },
+        "manifest_extension": True,
+    }
+    assert CapabilityManifest.from_dict(wire).to_dict() == wire
+
+
+def test_canonical_json_is_byte_stable_and_rejects_non_json() -> None:
+    left = canonical_json_bytes({"b": [2, 1], "a": "é"})
+    right = canonical_json_bytes({"a": "é", "b": [2, 1]})
+    assert left == right == b'{"a":"\xc3\xa9","b":[2,1]}'
+    with pytest.raises(ContractValidationError):
+        canonical_json_bytes({"bad": {1, 2}})
+
+
+def test_redaction_is_recursive_case_insensitive_and_non_mutating() -> None:
+    source = {
+        "Authorization": "Bearer abc",
+        "nested": [{"api-key": "secret"}, {"safe": "kept"}],
+    }
+    redacted = redact_json(source)
+    assert redacted == {
+        "Authorization": "[REDACTED]",
+        "nested": [{"api-key": "[REDACTED]"}, {"safe": "kept"}],
+    }
+    assert source["Authorization"] == "Bearer abc"
+    assert redact_text("token=abc123 safe=yes") == "token=[REDACTED] safe=yes"
+
+
+def test_receipt_invalid_lifecycle_combinations_are_rejected() -> None:
+    with pytest.raises(ContractValidationError, match="terminal statuses"):
+        ExecutionReceipt(
+            execution_id=ExecutionId("execution-01"),
+            invocation_id=InvocationId("invocation-01"),
+            status=ReceiptStatus.SUCCEEDED,
+            started_at=NOW,
+            completed_at=None,
+        )
+    with pytest.raises(ContractValidationError, match="requires an error"):
+        ExecutionReceipt(
+            execution_id=ExecutionId("execution-01"),
+            invocation_id=InvocationId("invocation-01"),
+            status=ReceiptStatus.FAILED,
+            started_at=NOW,
+            completed_at=NOW,
+        )
+
+
+def test_lifecycle_and_evidence_predicates_are_independent() -> None:
+    receipt = terminal_receipt()
+    assert lifecycle_complete(receipt)
+    assert not evidence_verified(receipt)
+    finalized = receipt.finalize()
+    assert lifecycle_complete(finalized)
+    assert evidence_verified(finalized)
+
+
+def test_receipt_finalizes_exactly_once_and_round_trips() -> None:
+    finalized = terminal_receipt().finalize()
+    assert finalized.evidence_sha256 is not None
+    assert len(finalized.evidence_sha256) == 64
+    assert ExecutionReceipt.from_dict(finalized.to_dict()) == finalized
+    with pytest.raises(ContractValidationError, match="already"):
+        finalized.finalize()
+
+
+def test_receipt_rejects_tampered_finalized_wire_data() -> None:
+    wire = terminal_receipt().finalize().to_dict()
+    wire["evidence"]["stdout"] = "tampered"
+    with pytest.raises(ContractValidationError, match="does not match"):
+        ExecutionReceipt.from_dict(wire)
+
+
+def test_receipt_is_deeply_immutable_and_corrections_supersede() -> None:
+    original = terminal_receipt().finalize()
+    with pytest.raises(TypeError):
+        original.evidence["stdout"] = "changed"
+    with pytest.raises(FrozenInstanceError):
+        original.status = ReceiptStatus.FAILED
+
+    correction = original.supersede(
+        status=ReceiptStatus.FAILED,
+        completed_at=NOW + timedelta(seconds=3),
+        error={"code": "POST_CHECK_FAILED"},
+        evidence={"check": "failed"},
+    )
+    assert correction.is_finalized
+    assert correction.supersedes_sha256 == original.evidence_sha256
+    assert correction.correction_sequence == 1
+    assert original.status is ReceiptStatus.SUCCEEDED
+
+
+def test_receipt_unknown_fields_are_preserved_and_covered_by_digest() -> None:
+    draft_wire = terminal_receipt().to_dict()
+    draft_wire["future_attestation"] = {"issuer": "zeo"}
+    finalized = ExecutionReceipt.from_dict(draft_wire).finalize()
+    assert finalized.to_dict()["future_attestation"] == {"issuer": "zeo"}
+    tampered = finalized.to_dict()
+    tampered["future_attestation"]["issuer"] = "other"
+    with pytest.raises(ContractValidationError):
+        ExecutionReceipt.from_dict(tampered)

--- a/tests/contracts/test_schema_package.py
+++ b/tests/contracts/test_schema_package.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+
+from sovereign_agent.contracts.schemas import SCHEMA_NAMES, read_schema, schema_path
+
+
+def test_all_contract_schemas_are_bundled_and_valid_json() -> None:
+    assert set(SCHEMA_NAMES) == {
+        "capability-manifest.schema.json",
+        "execution-receipt.schema.json",
+        "governed-execution-request.schema.json",
+    }
+    for name in SCHEMA_NAMES:
+        payload = json.loads(read_schema(name))
+        assert payload["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert payload["$id"].startswith("https://zeroemployee.org/schemas/")
+        assert schema_path(name).is_file()
+
+
+def test_schemas_preserve_forward_compatible_unknown_fields() -> None:
+    for name in SCHEMA_NAMES:
+        payload = json.loads(read_schema(name))
+        assert payload["additionalProperties"] is True
+
+
+def test_schemas_do_not_reference_an_internal_or_invented_corpus_path() -> None:
+    for name in SCHEMA_NAMES:
+        text = read_schema(name).decode()
+        assert "sovereign_agent." not in text
+        assert "/corpus/" not in text
+        assert "../" not in text

--- a/tests/unit/test_parallelism.py
+++ b/tests/unit/test_parallelism.py
@@ -182,13 +182,68 @@ async def test_policy_always_overrides_flag(fresh_session: Session) -> None:
 async def test_unsafe_tool_serialises_around_parallel_batch(fresh_session: Session) -> None:
     """Mixed [safe, safe, UNSAFE, safe, safe] should become runs:
         [safe, safe] | [UNSAFE] | [safe, safe]
-    Total ≈ 0.3 + 0.3 + 0.3 = 0.9s, not 0.3s (full parallel) or 1.5s (sequential)."""
+    Each safe pair uses a barrier that fails if it is dispatched sequentially;
+    phase markers prove the unsafe call remains between the two batches."""
     reg = ToolRegistry()
-    reg.register(_make_slow_tool("read1", 0.3, parallel_safe=True))
-    reg.register(_make_slow_tool("read2", 0.3, parallel_safe=True))
-    reg.register(_make_slow_tool("writeX", 0.3, parallel_safe=False))
-    reg.register(_make_slow_tool("read3", 0.3, parallel_safe=True))
-    reg.register(_make_slow_tool("read4", 0.3, parallel_safe=True))
+    phases: list[str] = []
+
+    def barrier_pair(first: str, second: str, phase: str) -> None:
+        entered: set[str] = set()
+        both_entered = asyncio.Event()
+
+        def build(name: str) -> _RegisteredTool:
+            async def _impl(label: str) -> ToolResult:
+                entered.add(name)
+                phases.append(f"{phase}:{name}:start")
+                if entered == {first, second}:
+                    both_entered.set()
+                await asyncio.wait_for(both_entered.wait(), timeout=0.5)
+                phases.append(f"{phase}:{name}:end")
+                return ToolResult(success=True, output={"label": label}, summary=name)
+
+            return _RegisteredTool(
+                name=name,
+                description=name,
+                fn=_impl,
+                parameters_schema={
+                    "type": "object",
+                    "properties": {"label": {"type": "string"}},
+                    "required": ["label"],
+                },
+                returns_schema={"type": "object"},
+                is_async=True,
+                parallel_safe=True,
+                examples=[],
+            )
+
+        reg.register(build(first))
+        reg.register(build(second))
+
+    barrier_pair("read1", "read2", "before")
+
+    async def write_x(label: str) -> ToolResult:
+        phases.append("write:start")
+        await asyncio.sleep(0)
+        phases.append("write:end")
+        return ToolResult(success=True, output={"label": label}, summary="writeX")
+
+    reg.register(
+        _RegisteredTool(
+            name="writeX",
+            description="writeX",
+            fn=write_x,
+            parameters_schema={
+                "type": "object",
+                "properties": {"label": {"type": "string"}},
+                "required": ["label"],
+            },
+            returns_schema={"type": "object"},
+            is_async=True,
+            parallel_safe=False,
+            examples=[],
+        )
+    )
+    barrier_pair("read3", "read4", "after")
 
     client = FakeLLMClient(
         [
@@ -206,13 +261,15 @@ async def test_unsafe_tool_serialises_around_parallel_batch(fresh_session: Sessi
     )
 
     executor = DefaultExecutor(model="fake", client=client, tools=reg)
-    t0 = time.monotonic()
     result = await executor.execute(_sg(), fresh_session, max_turns=4)
-    elapsed = time.monotonic() - t0
 
     assert result.success
-    # 3 sequential runs of ≈0.3s each = 0.9s. Generous bounds.
-    assert 0.75 <= elapsed < 1.25, f"expected three 0.3s runs ≈0.9s total, got {elapsed:.2f}s"
+    assert max(
+        index for index, item in enumerate(phases) if item.startswith("before:")
+    ) < phases.index("write:start")
+    assert phases.index("write:end") < min(
+        index for index, item in enumerate(phases) if item.startswith("after:")
+    )
     # Order must be preserved in the tool_calls_made trace.
     names = [c["name"] for c in result.tool_calls_made]
     assert names == ["read1", "read2", "writeX", "read3", "read4"]

--- a/tests/unit/test_runtime_root.py
+++ b/tests/unit/test_runtime_root.py
@@ -1,0 +1,129 @@
+"""Focused tests for the versioned runtime-root slice."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sovereign_agent.config import Config
+from sovereign_agent.runtime import (
+    RUNTIME_DIRECTORIES,
+    RUNTIME_LAYOUT_VERSION,
+    RUNTIME_SCHEMA_VERSION,
+    RuntimeRoot,
+    RuntimeRootError,
+    UnsupportedRuntimeVersionError,
+)
+from sovereign_agent.session.directory import SessionEscapeError, create_session, load_session
+
+
+def test_constructing_runtime_root_has_no_filesystem_side_effect(tmp_path: Path) -> None:
+    path = tmp_path / "runtime"
+    runtime = RuntimeRoot(path)
+    assert runtime.root == path
+    assert not path.exists()
+
+
+def test_initialize_writes_versioned_layout(tmp_path: Path) -> None:
+    runtime = RuntimeRoot(tmp_path / "runtime").initialize()
+
+    metadata = json.loads(runtime.metadata_path.read_text(encoding="utf-8"))
+    assert metadata["schema_version"] == RUNTIME_SCHEMA_VERSION
+    assert metadata["layout_version"] == RUNTIME_LAYOUT_VERSION
+    assert metadata["directories"] == list(RUNTIME_DIRECTORIES)
+    for name in RUNTIME_DIRECTORIES:
+        assert (runtime.root / name).is_dir()
+
+    assert RuntimeRoot.open(runtime.root) == runtime
+
+
+def test_initialize_rejects_unknown_on_disk_version(tmp_path: Path) -> None:
+    runtime = RuntimeRoot(tmp_path / "runtime").initialize()
+    metadata = json.loads(runtime.metadata_path.read_text(encoding="utf-8"))
+    metadata["layout_version"] = 999
+    runtime.metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    with pytest.raises(UnsupportedRuntimeVersionError):
+        runtime.initialize()
+
+
+def test_runtime_path_rejects_absolute_traversal_and_symlink(
+    tmp_path: Path,
+) -> None:
+    runtime = RuntimeRoot(tmp_path / "runtime").initialize()
+    with pytest.raises(RuntimeRootError):
+        runtime.path("/etc/passwd")
+    with pytest.raises(RuntimeRootError):
+        runtime.path("../outside")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (runtime.root / "escape").symlink_to(outside)
+    with pytest.raises(RuntimeRootError):
+        runtime.path("escape/file")
+
+
+def test_config_keeps_legacy_sessions_while_exposing_runtime(tmp_path: Path) -> None:
+    cfg = Config(runtime_dir=tmp_path / "new", sessions_dir=tmp_path / "old")
+    runtime = cfg.make_runtime_root()
+    assert runtime.root == cfg.runtime_dir
+    assert runtime.legacy_sessions_dir == cfg.sessions_dir
+    assert not cfg.runtime_dir.exists()
+
+
+def test_runtime_dir_does_not_change_v02_positional_config_order(tmp_path: Path) -> None:
+    legacy_sessions = tmp_path / "legacy"
+    cfg = Config(legacy_sessions)
+    assert cfg.sessions_dir == legacy_sessions
+    assert cfg.runtime_dir == Path("runtime")
+
+
+def test_legacy_session_is_read_without_rewrite_then_copied_on_write(
+    tmp_path: Path,
+) -> None:
+    legacy = tmp_path / "sessions"
+    parent = create_session(
+        scenario="legacy",
+        sessions_dir=legacy,
+        session_id="sess_legacy01",
+    )
+    original_json = parent.session_json_path.read_bytes()
+    runtime = RuntimeRoot(tmp_path / "runtime", legacy_sessions_dir=legacy).initialize()
+
+    loaded = load_session(parent.session_id, runtime_root=runtime)
+    assert loaded.directory == parent.directory
+    assert loaded.state.scenario == "legacy"
+    assert parent.session_json_path.read_bytes() == original_json
+    assert not (runtime.sessions_dir / parent.session_id).exists()
+
+    loaded.update_state(state="executing")
+    assert loaded.directory == runtime.sessions_dir / parent.session_id
+    assert loaded.state.state == "executing"
+    assert parent.session_json_path.read_bytes() == original_json
+    assert json.loads(loaded.session_json_path.read_text())["state"] == "executing"
+
+
+def test_current_session_wins_over_legacy_copy(tmp_path: Path) -> None:
+    legacy = tmp_path / "sessions"
+    old = create_session(
+        scenario="old",
+        sessions_dir=legacy,
+        session_id="sess_duplicate",
+    )
+    runtime = RuntimeRoot(tmp_path / "runtime", legacy_sessions_dir=legacy).initialize()
+    current = create_session(
+        scenario="new",
+        runtime_root=runtime,
+        session_id=old.session_id,
+    )
+
+    loaded = runtime.load_session(current.session_id)
+    assert loaded.state.scenario == "new"
+    assert [session.session_id for session in runtime.list_sessions()] == [current.session_id]
+
+
+def test_session_ids_cannot_escape_any_sessions_root(tmp_path: Path) -> None:
+    with pytest.raises(SessionEscapeError):
+        load_session("../outside", sessions_dir=tmp_path)


### PR DESCRIPTION
## Summary
- add a versioned runtime root with copy-on-write compatibility for v0.2 session trees
- add immutable typed execution requests, capability evidence, canonical JSON, redaction, and finalized receipts
- bundle versioned wire schemas and enforce their tests and typing in release gates

## Test plan
- [x] `make ci` (394 passed, 1 skipped)
- [x] focused contracts/runtime tests (25 passed)
- [x] wheel build includes all three JSON schemas
- [x] `make typecheck`, format, lint, and `git diff --check`

Stacked on #3; retarget to `main` after #3 lands.

Made with [Cursor](https://cursor.com)