### PR TITLE
Introduce the native agent provider seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
             src/sovereign_agent/memory \
             src/sovereign_agent/observability \
             src/sovereign_agent/planner \
+            src/sovereign_agent/providers \
             src/sovereign_agent/runtime \
             src/sovereign_agent/tickets \
             src/sovereign_agent/voice

--- a/Makefile
+++ b/Makefile
@@ -494,6 +494,7 @@ typecheck: ## Enforce mypy on currently clean public runtime modules
 		$(PKG_DIR)/memory \
 		$(PKG_DIR)/observability \
 		$(PKG_DIR)/planner \
+		$(PKG_DIR)/providers \
 		$(PKG_DIR)/runtime \
 		$(PKG_DIR)/tickets \
 		$(PKG_DIR)/voice

--- a/README.md
+++ b/README.md
@@ -347,17 +347,17 @@ Override via `SOVEREIGN_AGENT_DATA_DIR=<path>`.
 
 **v0.2.0 alpha, with unreleased v0.3 work on `main`.** PyPI has one release
 (`0.2.0`); `pyproject.toml` still declares `0.2.0`. The published 0.2.0 semver
-surface was 67 symbols. The working tree now exports **76** symbols in
-`sovereign_agent.__all__` — the 9 additions are unreleased v0.3 work and are not
+surface was 67 symbols. The working tree now exports **84** symbols in
+`sovereign_agent.__all__` — the 17 additions are unreleased v0.3 work and are not
 covered by the 0.2.x stability promise. See [`docs/API.md`](docs/API.md) for the
 full contract and the symbol-by-symbol breakdown.
 
 - ✅ Framework: sessions, tickets, IPC, parallelism, isolation, resume, verifiers, HITL
-- ✅ 370 tests collected — 369 pass, 1 skipped (library + chapters + integration)
+- ✅ 401 tests collected — 400 pass, 1 skipped (library + chapters + integration)
 - ✅ 8 reference scenarios, all with dataflow integrity checks
 - ✅ 5 tutorial chapters, drift-checked against production code in CI
 - 🚧 Voice pipeline, observability backends (Evidently/OTel) — skeletons, not implementations
-- 🚧 Channels, plugin registries, worker-backend dispatch, liveness monitor — in-tree, unreleased
+- 🚧 Channels, providers, plugin registries, worker-backend dispatch, liveness monitor — in-tree, unreleased
 - ❌ Docker worker backend — stub only; `DockerWorker.run_session()` raises `NotImplementedError`
 - ❌ Vector-DB memory backends — not started, and a [v0.3 non-goal](docs/v0.3-non-goals.md)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
 
 !!! warning "The tree is ahead of the last release"
     The only published release is **0.2.0**, whose semver surface was **67**
-    symbols. The working tree exports **76**. The 9 extra symbols are unreleased
+    symbols. The working tree exports **84**. The 17 extra symbols are unreleased
     v0.3 work and carry **no** stability promise until v0.3.0 is tagged. Both
     sets are listed below, separately, so you can tell which is which.
 
@@ -98,7 +98,7 @@ Category | Symbols
 
 ---
 
-## The 9 unreleased additions (in-tree, not covered)
+## The 17 unreleased additions (in-tree, not covered)
 
 These are in `sovereign_agent.__all__` on `main` but were not in the published
 0.2.0 surface. They may be renamed, resignatured, or removed before v0.3.0 is
@@ -109,6 +109,7 @@ Category | Symbols
 **Channels** (v0.3 M1) | `CHANNEL_REGISTRY`
 **Plugin registries** (v0.3 M3) | `Plugin`, `Registry`
 **Worker backends** (v0.3 M4a) | `WorkerBackend`, `WorkerOutcome`, `BareWorker`, `SubprocessWorker`, `DockerWorker`, `make_worker_backend`
+**Agent providers** (v0.3 Unit 2) | `AgentProvider`, `InvocationRequest`, `InvocationResult`, `NativeProvider`, `ProviderCapabilities`, `ProviderEvent`, `ProviderRegistry`, `PROVIDER_REGISTRY`
 
 `DockerWorker` is a stub. It satisfies the `WorkerBackend` protocol so that
 `Config.worker_backend='docker'` constructs without an import error, but

--- a/docs/v0.3-unit2-native-provider.md
+++ b/docs/v0.3-unit2-native-provider.md
@@ -1,0 +1,14 @@
+# v0.3 Unit 2 — native provider boundary
+
+Unit 2 introduces `AgentProvider`, a generic provider registry, immutable
+invocation models, and a strict normalized event stream. Text, tool calls,
+tool results, usage, provider sessions, structured results, warnings, and raw
+provider events share execution and invocation identity, contiguous sequence
+numbers, and UTC timestamps.
+
+`NativeProvider` adapts the existing planner/executor `LoopHalf`; `run_task()`
+now reaches that loop through the provider boundary without changing its v0.2
+signature, return type, session artifacts, custom client/tools, channels, or
+worker-backend recursion guard. Observer and activity callback failures are
+recorded and logged, but cannot interrupt provider execution or other
+callbacks.

--- a/examples/classifier_rule/README.md
+++ b/examples/classifier_rule/README.md
@@ -39,10 +39,12 @@ classifier = FakeSentimentClassifier()
 
 # Use one of:
 from sklearn.pipeline import Pipeline
-classifier = joblib.load("sentiment.joblib")   # sklearn path
+
+classifier = joblib.load("sentiment.joblib")  # sklearn path
 
 # or:
 from transformers import pipeline
+
 classifier = pipeline(
     "text-classification",
     model="distilbert-base-uncased-finetuned-sst-2-english",
@@ -59,7 +61,7 @@ does not change.
 ```python
 Rule(
     name="manager_confirmed",
-    condition=manager_affirmative,   # <-- ClassifierVerifier, not a lambda
+    condition=manager_affirmative,  # <-- ClassifierVerifier, not a lambda
     action=_commit_booking,
 )
 ```

--- a/examples/hitl_deposit/README.md
+++ b/examples/hitl_deposit/README.md
@@ -73,7 +73,7 @@ return ToolResult(
         "approval_reason": "Deposit exceeds auto-approve ceiling.",
     },
     summary="proposed booking awaiting approval",
-    requires_human_approval=True,    # <-- that's it
+    requires_human_approval=True,  # <-- that's it
 )
 ```
 

--- a/examples/isolated_worker/README.md
+++ b/examples/isolated_worker/README.md
@@ -40,7 +40,7 @@ from sovereign_agent._internal.isolation import detect_best_policy
 from sovereign_agent.orchestrator.worker import SubprocessWorker
 
 worker = SubprocessWorker(
-    isolation_policy=detect_best_policy(),   # <-- picks the strongest available
+    isolation_policy=detect_best_policy(),  # <-- picks the strongest available
     allow_network=False,
 )
 ```

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -55,6 +55,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/memory",
     "src/sovereign_agent/observability",
     "src/sovereign_agent/planner",
+    "src/sovereign_agent/providers",
     "src/sovereign_agent/runtime",
     "src/sovereign_agent/tickets",
     "src/sovereign_agent/voice",

--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -55,6 +55,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/memory",
     "src/sovereign_agent/observability",
     "src/sovereign_agent/planner",
+    "src/sovereign_agent/providers",
     "src/sovereign_agent/runtime",
     "src/sovereign_agent/tickets",
     "src/sovereign_agent/voice",

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -4,8 +4,8 @@ Alpha. The declared version is 0.2.0 and that is the only release on PyPI,
 but this tree also carries unreleased v0.3 work (channels, plugin
 registries, worker-backend dispatch, liveness monitor).
 
-The 76 names in __all__ are the public API surface. Of those, 67 shipped in
-0.2.0 and are stable across 0.2.x; the 9 v0.3 additions carry no stability
+The names in __all__ are the public API surface. Of those, 67 shipped in
+0.2.0 and are stable across 0.2.x; the v0.3 additions carry no stability
 promise until 0.3.0 is tagged. Anything not in __all__ is internal and may
 change between any two releases -- including names that happen to be
 importable from this module, such as the channel adapter types and
@@ -113,6 +113,18 @@ from sovereign_agent.orchestrator.worker_factory import (
 # Planner / Executor
 from sovereign_agent.planner import DefaultPlanner, Planner, Subgoal
 
+# Providers (v0.3 Unit 2)
+from sovereign_agent.providers import (
+    PROVIDER_REGISTRY,
+    AgentProvider,
+    InvocationRequest,
+    InvocationResult,
+    NativeProvider,
+    ProviderCapabilities,
+    ProviderEvent,
+    ProviderRegistry,
+)
+
 # Plugin registries (v0.3 Module 3)
 from sovereign_agent.registries import Plugin as Plugin
 from sovereign_agent.registries import Registry as Registry
@@ -203,6 +215,15 @@ __all__ = [
     "Planner",
     "Subgoal",
     "DefaultPlanner",
+    # providers (v0.3 Unit 2)
+    "AgentProvider",
+    "InvocationRequest",
+    "InvocationResult",
+    "NativeProvider",
+    "ProviderCapabilities",
+    "ProviderEvent",
+    "ProviderRegistry",
+    "PROVIDER_REGISTRY",
     "Executor",
     "ExecutorResult",
     "DefaultExecutor",

--- a/src/sovereign_agent/orchestrator/main.py
+++ b/src/sovereign_agent/orchestrator/main.py
@@ -23,9 +23,10 @@ from typing import TYPE_CHECKING
 
 from sovereign_agent._internal.llm_client import LLMClient, OpenAICompatibleClient
 from sovereign_agent.config import Config
+from sovereign_agent.contracts import ExecutionId, FrozenDict, InvocationId
+from sovereign_agent.contracts._core import thaw_json
 from sovereign_agent.errors import SovereignError, wrap_unexpected
 from sovereign_agent.executor import DefaultExecutor
-from sovereign_agent.halves.loop import LoopHalf
 from sovereign_agent.ipc.watcher import IpcWatcher
 from sovereign_agent.orchestrator.auto_approver import AutoApprover
 from sovereign_agent.orchestrator.credentials import CredentialGateway
@@ -33,6 +34,7 @@ from sovereign_agent.orchestrator.liveness import LivenessMonitor
 from sovereign_agent.orchestrator.worker import WorkerBackend, WorkerOutcome
 from sovereign_agent.orchestrator.worker_factory import make_worker_backend
 from sovereign_agent.planner import DefaultPlanner
+from sovereign_agent.providers import InvocationRequest, NativeProvider
 from sovereign_agent.scheduler.drift_corrected import DriftCorrectedScheduler
 from sovereign_agent.session.directory import (
     Session,
@@ -367,18 +369,28 @@ class Orchestrator:
         tools = self._tools_for(session)
         planner = DefaultPlanner(model=self.config.llm_planner_model, client=llm)
         executor = DefaultExecutor(model=self.config.llm_executor_model, client=llm, tools=tools)
-        loop_half = LoopHalf(planner=planner, executor=executor)
+        provider = NativeProvider(planner=planner, executor=executor)
 
         # Read the task from SESSION.md (simplest source) if present.
         task = _read_task_from_session_md(session)
-        result = await loop_half.run(session, {"task": task})
+        result = await provider.invoke(
+            InvocationRequest(
+                execution_id=ExecutionId(f"{session.session_id}:execution"),
+                invocation_id=InvocationId(f"{session.session_id}:invocation"),
+                task=task,
+                session=session,
+                context=FrozenDict(),
+            )
+        )
 
         # v0.3 Module 1: if this session arrived via a channel, send the
         # agent's reply back out. No-op for run_task / scripted sessions.
         await self._deliver_channel_response(session, result)
 
         if result.next_action == "complete":
-            session.mark_complete(result.output)
+            output = thaw_json(result.output)
+            assert isinstance(output, dict)
+            session.mark_complete(output)
             return True
         if result.next_action == "handoff_to_structured":
             session.update_state(state="handed_off_to_structured")

--- a/src/sovereign_agent/providers/__init__.py
+++ b/src/sovereign_agent/providers/__init__.py
@@ -1,0 +1,42 @@
+"""Agent provider contracts, normalized events, and native implementation."""
+
+from .events import (
+    ProviderEvent,
+    ProviderEventType,
+    ProviderSessionEvent,
+    RawEvent,
+    StructuredResultEvent,
+    TextEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    UsageEvent,
+    WarningEvent,
+)
+from .models import InvocationRequest, InvocationResult, ProviderCapabilities
+from .native import NativeProvider
+from .observers import EventFanout, ObserverFailure
+from .protocol import AgentProvider, EventCallback
+from .registry import PROVIDER_REGISTRY, ProviderRegistry
+
+__all__ = [
+    "PROVIDER_REGISTRY",
+    "AgentProvider",
+    "EventCallback",
+    "EventFanout",
+    "InvocationRequest",
+    "InvocationResult",
+    "NativeProvider",
+    "ObserverFailure",
+    "ProviderCapabilities",
+    "ProviderEvent",
+    "ProviderEventType",
+    "ProviderRegistry",
+    "ProviderSessionEvent",
+    "RawEvent",
+    "StructuredResultEvent",
+    "TextEvent",
+    "ToolCallEvent",
+    "ToolResultEvent",
+    "UsageEvent",
+    "WarningEvent",
+]

--- a/src/sovereign_agent/providers/events.py
+++ b/src/sovereign_agent/providers/events.py
@@ -1,0 +1,289 @@
+"""Immutable provider events with strict, deterministic wire serialization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+
+from sovereign_agent.contracts import (
+    ContractValidationError,
+    ExecutionId,
+    FrozenDict,
+    InvocationId,
+    ProviderSessionId,
+)
+from sovereign_agent.contracts._core import (
+    format_datetime,
+    freeze_json,
+    parse_datetime,
+    require_object,
+    require_string,
+    thaw_json,
+)
+
+
+@dataclass(frozen=True)
+class ProviderEvent:
+    """Common identity and ordering envelope carried by every provider event."""
+
+    execution_id: ExecutionId
+    invocation_id: InvocationId
+    sequence: int
+    timestamp: datetime
+    EVENT_TYPE: ClassVar[str] = "raw"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.execution_id, ExecutionId):
+            raise ContractValidationError("execution_id must be ExecutionId")
+        if not isinstance(self.invocation_id, InvocationId):
+            raise ContractValidationError("invocation_id must be InvocationId")
+        if (
+            not isinstance(self.sequence, int)
+            or isinstance(self.sequence, bool)
+            or self.sequence < 0
+        ):
+            raise ContractValidationError("sequence must be a non-negative integer")
+        format_datetime(self.timestamp, "timestamp")
+
+    @property
+    def event_type(self) -> str:
+        return self.EVENT_TYPE
+
+    def _payload(self) -> dict[str, Any]:
+        return {}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.EVENT_TYPE,
+            "execution_id": str(self.execution_id),
+            "invocation_id": str(self.invocation_id),
+            "sequence": self.sequence,
+            "timestamp": format_datetime(self.timestamp, "timestamp"),
+            **self._payload(),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> ProviderEvent:
+        data = require_object(value, "provider_event")
+        event_type = require_string(data.get("type"), "provider_event.type")
+        event_cls = _EVENT_TYPES.get(event_type)
+        if event_cls is None:
+            raise ContractValidationError(f"unknown provider event type {event_type!r}")
+        expected = _ENVELOPE_FIELDS | event_cls._PAYLOAD_FIELDS
+        missing = expected - data.keys()
+        extra = data.keys() - expected
+        if missing:
+            raise ContractValidationError(
+                f"provider event missing fields: {', '.join(sorted(missing))}"
+            )
+        if extra:
+            raise ContractValidationError(
+                f"provider event has unknown fields: {', '.join(sorted(extra))}"
+            )
+        common = {
+            "execution_id": ExecutionId(require_string(data["execution_id"], "execution_id")),
+            "invocation_id": InvocationId(require_string(data["invocation_id"], "invocation_id")),
+            "sequence": data["sequence"],
+            "timestamp": parse_datetime(data["timestamp"], "timestamp"),
+        }
+        payload = {name: data[name] for name in event_cls._PAYLOAD_FIELDS}
+        return event_cls(**common, **payload)
+
+
+@dataclass(frozen=True)
+class TextEvent(ProviderEvent):
+    text: str
+    EVENT_TYPE: ClassVar[str] = "text"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset({"text"})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        require_string(self.text, "text", allow_empty=True)
+
+    def _payload(self) -> dict[str, Any]:
+        return {"text": self.text}
+
+
+@dataclass(frozen=True)
+class ToolCallEvent(ProviderEvent):
+    tool_call_id: str
+    name: str
+    arguments: FrozenDict
+    EVENT_TYPE: ClassVar[str] = "tool_call"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset({"tool_call_id", "name", "arguments"})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        require_string(self.tool_call_id, "tool_call_id")
+        require_string(self.name, "name")
+        object.__setattr__(
+            self, "arguments", freeze_json(require_object(self.arguments, "arguments"))
+        )
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "tool_call_id": self.tool_call_id,
+            "name": self.name,
+            "arguments": thaw_json(self.arguments),
+        }
+
+
+@dataclass(frozen=True)
+class ToolResultEvent(ProviderEvent):
+    tool_call_id: str
+    name: str
+    result: FrozenDict
+    EVENT_TYPE: ClassVar[str] = "tool_result"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset({"tool_call_id", "name", "result"})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        require_string(self.tool_call_id, "tool_call_id")
+        require_string(self.name, "name")
+        object.__setattr__(self, "result", freeze_json(require_object(self.result, "result")))
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "tool_call_id": self.tool_call_id,
+            "name": self.name,
+            "result": thaw_json(self.result),
+        }
+
+
+@dataclass(frozen=True)
+class UsageEvent(ProviderEvent):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    EVENT_TYPE: ClassVar[str] = "usage"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"input_tokens", "output_tokens", "total_tokens"}
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        for name in self._PAYLOAD_FIELDS:
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ContractValidationError(f"{name} must be a non-negative integer")
+        if self.total_tokens != self.input_tokens + self.output_tokens:
+            raise ContractValidationError("total_tokens must equal input_tokens + output_tokens")
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderSessionEvent(ProviderEvent):
+    provider_session_id: ProviderSessionId
+    EVENT_TYPE: ClassVar[str] = "provider_session"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset({"provider_session_id"})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if isinstance(self.provider_session_id, str):
+            object.__setattr__(
+                self, "provider_session_id", ProviderSessionId(self.provider_session_id)
+            )
+        if not isinstance(self.provider_session_id, ProviderSessionId):
+            raise ContractValidationError("provider_session_id must be ProviderSessionId")
+
+    def _payload(self) -> dict[str, Any]:
+        return {"provider_session_id": str(self.provider_session_id)}
+
+
+@dataclass(frozen=True)
+class StructuredResultEvent(ProviderEvent):
+    result: FrozenDict
+    EVENT_TYPE: ClassVar[str] = "structured_result"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset({"result"})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "result", freeze_json(require_object(self.result, "result")))
+
+    def _payload(self) -> dict[str, Any]:
+        return {"result": thaw_json(self.result)}
+
+
+@dataclass(frozen=True)
+class WarningEvent(ProviderEvent):
+    code: str
+    message: str
+    EVENT_TYPE: ClassVar[str] = "warning"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset({"code", "message"})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        require_string(self.code, "code")
+        require_string(self.message, "message")
+
+    def _payload(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message}
+
+
+@dataclass(frozen=True)
+class RawEvent(ProviderEvent):
+    provider_type: str
+    payload: FrozenDict = field(default_factory=FrozenDict)
+    EVENT_TYPE: ClassVar[str] = "raw"
+    _PAYLOAD_FIELDS: ClassVar[frozenset[str]] = frozenset({"provider_type", "payload"})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        require_string(self.provider_type, "provider_type")
+        object.__setattr__(self, "payload", freeze_json(require_object(self.payload, "payload")))
+
+    def _payload(self) -> dict[str, Any]:
+        return {"provider_type": self.provider_type, "payload": thaw_json(self.payload)}
+
+
+ProviderEventType = (
+    TextEvent
+    | ToolCallEvent
+    | ToolResultEvent
+    | UsageEvent
+    | ProviderSessionEvent
+    | StructuredResultEvent
+    | WarningEvent
+    | RawEvent
+)
+
+_ENVELOPE_FIELDS = frozenset({"type", "execution_id", "invocation_id", "sequence", "timestamp"})
+_EVENT_TYPES: dict[str, type[ProviderEvent]] = {
+    event_cls.EVENT_TYPE: event_cls
+    for event_cls in (
+        TextEvent,
+        ToolCallEvent,
+        ToolResultEvent,
+        UsageEvent,
+        ProviderSessionEvent,
+        StructuredResultEvent,
+        WarningEvent,
+        RawEvent,
+    )
+}
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+__all__ = [
+    "ProviderEvent",
+    "ProviderEventType",
+    "ProviderSessionEvent",
+    "RawEvent",
+    "StructuredResultEvent",
+    "TextEvent",
+    "ToolCallEvent",
+    "ToolResultEvent",
+    "UsageEvent",
+    "WarningEvent",
+]

--- a/src/sovereign_agent/providers/models.py
+++ b/src/sovereign_agent/providers/models.py
@@ -1,0 +1,125 @@
+"""Provider capabilities and invocation boundary models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from sovereign_agent.contracts import (
+    Capability,
+    CapabilityManifest,
+    ContractValidationError,
+    EvidenceLevel,
+    ExecutionId,
+    FrozenDict,
+    InvocationId,
+)
+from sovereign_agent.contracts._core import freeze_json, require_object, require_string, thaw_json
+from sovereign_agent.session.directory import Session
+
+from .events import ProviderEventType
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Typed provider features convertible to the Unit 1 capability contract."""
+
+    tools: bool = False
+    usage: bool = False
+    provider_session: bool = False
+    structured_result: bool = False
+    streaming: bool = False
+    evidence_level: EvidenceLevel = EvidenceLevel.DECLARED
+
+    def to_manifest(self) -> CapabilityManifest:
+        values = {
+            name: Capability(available=value, evidence_level=self.evidence_level)
+            for name, value in (
+                ("tools", self.tools),
+                ("usage", self.usage),
+                ("provider_session", self.provider_session),
+                ("structured_result", self.structured_result),
+                ("streaming", self.streaming),
+            )
+        }
+        return CapabilityManifest(capabilities=FrozenDict(tuple(values.items())))
+
+    @classmethod
+    def from_manifest(cls, manifest: CapabilityManifest) -> ProviderCapabilities:
+        if not isinstance(manifest, CapabilityManifest):
+            raise ContractValidationError("manifest must be CapabilityManifest")
+        levels = [
+            capability.evidence_level
+            for capability in manifest.capabilities.values()
+            if isinstance(capability, Capability)
+        ]
+        level = min(levels, default=EvidenceLevel.UNKNOWN)
+        return cls(
+            tools=manifest.is_available("tools"),
+            usage=manifest.is_available("usage"),
+            provider_session=manifest.is_available("provider_session"),
+            structured_result=manifest.is_available("structured_result"),
+            streaming=manifest.is_available("streaming"),
+            evidence_level=level,
+        )
+
+
+@dataclass(frozen=True)
+class InvocationRequest:
+    """Immutable request to one agent provider invocation.
+
+    ``session`` is the local runtime handle. It is intentionally omitted from
+    ``to_dict`` because provider wire traffic carries only stable identity and
+    JSON input; NativeProvider requires it to preserve v0.2 artifacts.
+    """
+
+    execution_id: ExecutionId
+    invocation_id: InvocationId
+    task: str
+    session: Session
+    context: FrozenDict = field(default_factory=FrozenDict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.execution_id, ExecutionId):
+            raise ContractValidationError("execution_id must be ExecutionId")
+        if not isinstance(self.invocation_id, InvocationId):
+            raise ContractValidationError("invocation_id must be InvocationId")
+        require_string(self.task, "task", allow_empty=True)
+        if not isinstance(self.session, Session):
+            raise ContractValidationError("session must be Session")
+        object.__setattr__(self, "context", freeze_json(require_object(self.context, "context")))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "execution_id": str(self.execution_id),
+            "invocation_id": str(self.invocation_id),
+            "task": self.task,
+            "context": thaw_json(self.context),
+        }
+
+
+@dataclass(frozen=True)
+class InvocationResult:
+    """Completed provider result and its exact normalized event sequence."""
+
+    success: bool
+    output: FrozenDict
+    summary: str
+    next_action: str
+    events: tuple[ProviderEventType, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.success, bool):
+            raise ContractValidationError("success must be boolean")
+        object.__setattr__(self, "output", freeze_json(require_object(self.output, "output")))
+        require_string(self.summary, "summary", allow_empty=True)
+        require_string(self.next_action, "next_action")
+        expected = list(range(len(self.events)))
+        actual = [event.sequence for event in self.events]
+        if actual != expected:
+            raise ContractValidationError(
+                f"events must have contiguous sequence numbers from zero; got {actual}"
+            )
+
+
+__all__ = ["InvocationRequest", "InvocationResult", "ProviderCapabilities"]

--- a/src/sovereign_agent/providers/native.py
+++ b/src/sovereign_agent/providers/native.py
@@ -1,0 +1,175 @@
+"""Native provider adapter for the existing planner/executor LoopHalf."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import ClassVar
+
+from sovereign_agent.contracts import FrozenDict, ProviderSessionId
+from sovereign_agent.contracts._core import thaw_json
+from sovereign_agent.executor import DefaultExecutor
+from sovereign_agent.halves.loop import LoopHalf
+from sovereign_agent.planner import DefaultPlanner
+
+from .events import (
+    ProviderEventType,
+    ProviderSessionEvent,
+    StructuredResultEvent,
+    TextEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    WarningEvent,
+    utc_now,
+)
+from .models import InvocationRequest, InvocationResult, ProviderCapabilities
+from .observers import EventFanout, ObserverFailure
+from .protocol import EventCallback
+
+
+class NativeProvider:
+    """Expose Sovereign Agent's v0.2 loop through the provider contract."""
+
+    kind: ClassVar[str] = "provider"
+    capabilities = ProviderCapabilities(
+        tools=True,
+        provider_session=True,
+        structured_result=True,
+    )
+
+    def __init__(
+        self,
+        *,
+        loop_half: LoopHalf | None = None,
+        planner: DefaultPlanner | None = None,
+        executor: DefaultExecutor | None = None,
+        name: str = "native",
+    ) -> None:
+        if loop_half is None:
+            if planner is None or executor is None:
+                raise TypeError("provide loop_half or both planner and executor")
+            loop_half = LoopHalf(planner=planner, executor=executor)
+        self.name = name
+        self.loop_half = loop_half
+        self.last_observer_failures: tuple[ObserverFailure, ...] = ()
+
+    async def invoke(
+        self,
+        request: InvocationRequest,
+        *,
+        observers: Sequence[EventCallback] = (),
+        activity_callbacks: Sequence[EventCallback] = (),
+    ) -> InvocationResult:
+        fanout = EventFanout(observers, activity_callbacks)
+        events: list[ProviderEventType] = []
+
+        async def emit(event: ProviderEventType) -> None:
+            events.append(event)
+            await fanout.emit(event)
+
+        await emit(
+            ProviderSessionEvent(
+                execution_id=request.execution_id,
+                invocation_id=request.invocation_id,
+                sequence=len(events),
+                timestamp=utc_now(),
+                provider_session_id=ProviderSessionId(request.session.session_id),
+            )
+        )
+
+        context = thaw_json(request.context)
+        assert isinstance(context, dict)
+        result = await self.loop_half.run(
+            request.session,
+            {"task": request.task, "context": context},
+        )
+
+        for index, call in enumerate(_tool_calls(result.output)):
+            call_id = f"native-tool-{index}"
+            name = str(call.get("name") or "unknown")
+            arguments = call.get("arguments")
+            if not isinstance(arguments, dict):
+                arguments = {}
+            await emit(
+                ToolCallEvent(
+                    execution_id=request.execution_id,
+                    invocation_id=request.invocation_id,
+                    sequence=len(events),
+                    timestamp=utc_now(),
+                    tool_call_id=call_id,
+                    name=name,
+                    arguments=FrozenDict(tuple(arguments.items())),
+                )
+            )
+            await emit(
+                ToolResultEvent(
+                    execution_id=request.execution_id,
+                    invocation_id=request.invocation_id,
+                    sequence=len(events),
+                    timestamp=utc_now(),
+                    tool_call_id=call_id,
+                    name=name,
+                    result=FrozenDict(
+                        (
+                            ("success", bool(call.get("success", True))),
+                            ("summary", str(call.get("summary") or "")),
+                        )
+                    ),
+                )
+            )
+
+        text = str(result.output.get("final_answer") or result.summary)
+        await emit(
+            TextEvent(
+                execution_id=request.execution_id,
+                invocation_id=request.invocation_id,
+                sequence=len(events),
+                timestamp=utc_now(),
+                text=text,
+            )
+        )
+        await emit(
+            StructuredResultEvent(
+                execution_id=request.execution_id,
+                invocation_id=request.invocation_id,
+                sequence=len(events),
+                timestamp=utc_now(),
+                result=FrozenDict(tuple(result.output.items())),
+            )
+        )
+        if not result.success:
+            await emit(
+                WarningEvent(
+                    execution_id=request.execution_id,
+                    invocation_id=request.invocation_id,
+                    sequence=len(events),
+                    timestamp=utc_now(),
+                    code="native_invocation_failed",
+                    message=result.summary,
+                )
+            )
+
+        self.last_observer_failures = fanout.failures
+        return InvocationResult(
+            success=result.success,
+            output=FrozenDict(tuple(result.output.items())),
+            summary=result.summary,
+            next_action=result.next_action,
+            events=tuple(events),
+        )
+
+
+def _tool_calls(output: dict) -> list[dict]:
+    calls: list[dict] = []
+    executor_results = output.get("executor_results") or []
+    if not isinstance(executor_results, list):
+        return calls
+    for executor_result in executor_results:
+        if not isinstance(executor_result, dict):
+            continue
+        raw_calls = executor_result.get("tool_calls_made") or []
+        if isinstance(raw_calls, list):
+            calls.extend(call for call in raw_calls if isinstance(call, dict))
+    return calls
+
+
+__all__ = ["NativeProvider"]

--- a/src/sovereign_agent/providers/observers.py
+++ b/src/sovereign_agent/providers/observers.py
@@ -1,0 +1,63 @@
+"""Contained fan-out for provider event observers and activity callbacks."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .events import ProviderEventType
+from .protocol import EventCallback
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ObserverFailure:
+    callback: str
+    event_sequence: int
+    error: str
+
+
+class EventFanout:
+    """Deliver events without allowing instrumentation to break execution."""
+
+    def __init__(
+        self,
+        observers: Sequence[EventCallback] = (),
+        activity_callbacks: Sequence[EventCallback] = (),
+    ) -> None:
+        self._observers = tuple(observers)
+        self._activity_callbacks = tuple(activity_callbacks)
+        self._failures: list[ObserverFailure] = []
+
+    @property
+    def failures(self) -> tuple[ObserverFailure, ...]:
+        return tuple(self._failures)
+
+    async def emit(self, event: ProviderEventType) -> None:
+        # Keep the groups separate: an observer failure must never prevent
+        # activity callbacks from receiving the same event.
+        for callback in (*self._observers, *self._activity_callbacks):
+            try:
+                result = callback(event)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:  # noqa: BLE001
+                name = getattr(callback, "__qualname__", repr(callback))
+                self._failures.append(
+                    ObserverFailure(
+                        callback=name,
+                        event_sequence=event.sequence,
+                        error=f"{type(exc).__name__}: {exc}",
+                    )
+                )
+                log.exception(
+                    "provider event callback %s failed at sequence %d",
+                    name,
+                    event.sequence,
+                )
+
+
+__all__ = ["EventFanout", "ObserverFailure"]

--- a/src/sovereign_agent/providers/protocol.py
+++ b/src/sovereign_agent/providers/protocol.py
@@ -1,0 +1,31 @@
+"""Structural contract for pluggable agent providers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from typing import ClassVar, Protocol, runtime_checkable
+
+from .events import ProviderEventType
+from .models import InvocationRequest, InvocationResult, ProviderCapabilities
+
+type EventCallback = Callable[[ProviderEventType], None | Awaitable[None]]
+
+
+@runtime_checkable
+class AgentProvider(Protocol):
+    """A named provider that executes one normalized invocation."""
+
+    name: str
+    kind: ClassVar[str]
+    capabilities: ProviderCapabilities
+
+    async def invoke(
+        self,
+        request: InvocationRequest,
+        *,
+        observers: Sequence[EventCallback] = (),
+        activity_callbacks: Sequence[EventCallback] = (),
+    ) -> InvocationResult: ...
+
+
+__all__ = ["AgentProvider", "EventCallback"]

--- a/src/sovereign_agent/providers/registry.py
+++ b/src/sovereign_agent/providers/registry.py
@@ -1,0 +1,15 @@
+"""Provider registry built on the generic Plugin/Registry abstraction."""
+
+from sovereign_agent.registries import Registry
+
+from .protocol import AgentProvider
+
+
+class ProviderRegistry(Registry[AgentProvider]):
+    def __init__(self) -> None:
+        super().__init__(kind_filter="provider")
+
+
+PROVIDER_REGISTRY = ProviderRegistry()
+
+__all__ = ["PROVIDER_REGISTRY", "ProviderRegistry"]

--- a/tests/providers/test_provider_conformance.py
+++ b/tests/providers/test_provider_conformance.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import get_type_hints
+
+import pytest
+
+from sovereign_agent._internal.llm_client import FakeLLMClient, ScriptedResponse
+from sovereign_agent.config import Config
+from sovereign_agent.contracts import (
+    ContractValidationError,
+    ExecutionId,
+    FrozenDict,
+    InvocationId,
+)
+from sovereign_agent.halves import HalfResult
+from sovereign_agent.orchestrator import TaskResult, run_task
+from sovereign_agent.providers import (
+    AgentProvider,
+    InvocationRequest,
+    NativeProvider,
+    ProviderCapabilities,
+    ProviderEvent,
+    ProviderRegistry,
+    ProviderSessionEvent,
+    StructuredResultEvent,
+    UsageEvent,
+)
+
+
+def _common(sequence: int = 0) -> dict:
+    return {
+        "execution_id": ExecutionId("exec-1"),
+        "invocation_id": InvocationId("invoke-1"),
+        "sequence": sequence,
+        "timestamp": datetime(2026, 8, 22, tzinfo=UTC),
+    }
+
+
+def test_event_round_trip_is_strict_and_immutable() -> None:
+    event = UsageEvent(**_common(), input_tokens=2, output_tokens=3, total_tokens=5)
+    assert ProviderEvent.from_dict(event.to_dict()) == event
+    with pytest.raises(ContractValidationError, match="unknown fields"):
+        ProviderEvent.from_dict({**event.to_dict(), "surprise": True})
+    with pytest.raises(ContractValidationError, match="total_tokens"):
+        UsageEvent(**_common(), input_tokens=2, output_tokens=3, total_tokens=4)
+    with pytest.raises(AttributeError):
+        event.sequence = 2  # type: ignore[misc]
+
+
+def test_session_and_structured_events_round_trip() -> None:
+    session = ProviderSessionEvent(**_common(), provider_session_id="provider-session")
+    structured = StructuredResultEvent(**_common(1), result=FrozenDict((("answer", "done"),)))
+    assert ProviderEvent.from_dict(session.to_dict()) == session
+    assert ProviderEvent.from_dict(structured.to_dict()) == structured
+
+
+def test_capabilities_are_contract_compatible() -> None:
+    capabilities = ProviderCapabilities(tools=True, structured_result=True)
+    assert ProviderCapabilities.from_manifest(capabilities.to_manifest()) == capabilities
+
+
+class _FakeLoop:
+    async def run(self, session, input_payload):  # type: ignore[no-untyped-def]
+        return HalfResult(
+            success=True,
+            output={"final_answer": "done", "executor_results": []},
+            summary="complete",
+            next_action="complete",
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_provider_ordering_and_observer_containment(fresh_session) -> None:
+    provider = NativeProvider(loop_half=_FakeLoop())  # type: ignore[arg-type]
+    observed: list[int] = []
+    activity: list[int] = []
+
+    def broken(event):  # type: ignore[no-untyped-def]
+        observed.append(event.sequence)
+        raise RuntimeError("observer broke")
+
+    request = InvocationRequest(
+        execution_id=ExecutionId("exec-1"),
+        invocation_id=InvocationId("invoke-1"),
+        task="test",
+        session=fresh_session,
+    )
+    result = await provider.invoke(
+        request,
+        observers=[broken],
+        activity_callbacks=[lambda event: activity.append(event.sequence)],
+    )
+    assert [event.sequence for event in result.events] == list(range(len(result.events)))
+    assert [event.event_type for event in result.events] == [
+        "provider_session",
+        "text",
+        "structured_result",
+    ]
+    assert observed == activity == [0, 1, 2]
+    assert len(provider.last_observer_failures) == 3
+
+
+def test_provider_registry_uses_plugin_contract() -> None:
+    provider = NativeProvider(loop_half=_FakeLoop())  # type: ignore[arg-type]
+    registry = ProviderRegistry()
+    registry.register(provider)
+    assert registry.get("native") is provider
+    assert isinstance(provider, AgentProvider)
+
+
+def test_run_task_signature_and_result_are_backward_compatible(tmp_path: Path) -> None:
+    signature = inspect.signature(run_task)
+    assert list(signature.parameters) == [
+        "task",
+        "config",
+        "scenario",
+        "user_id",
+        "llm_client",
+        "extra_tools",
+    ]
+    assert signature.parameters["task"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert all(
+        parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        for parameter in list(signature.parameters.values())[1:]
+    )
+    assert signature.parameters["scenario"].default == "default"
+    assert get_type_hints(run_task)["return"] is TaskResult
+    client = FakeLLMClient(
+        [
+            ScriptedResponse(
+                content=(
+                    '[{"id":"sg_1","description":"answer","success_criterion":"answered",'
+                    '"estimated_tool_calls":1}]'
+                )
+            ),
+            ScriptedResponse(content="native provider answer"),
+        ]
+    )
+    result = run_task(
+        "answer",
+        config=Config(sessions_dir=tmp_path / "sessions"),
+        scenario="compat",
+        user_id="user-1",
+        llm_client=client,
+    )
+    assert isinstance(result, TaskResult)
+    assert result.success is True
+    assert result.output["final_answer"] == "native provider answer"
+    assert (result.session_dir / "SESSION.md").exists()

--- a/tests/unit/test_parallelism.py
+++ b/tests/unit/test_parallelism.py
@@ -182,13 +182,68 @@ async def test_policy_always_overrides_flag(fresh_session: Session) -> None:
 async def test_unsafe_tool_serialises_around_parallel_batch(fresh_session: Session) -> None:
     """Mixed [safe, safe, UNSAFE, safe, safe] should become runs:
         [safe, safe] | [UNSAFE] | [safe, safe]
-    Total ≈ 0.3 + 0.3 + 0.3 = 0.9s, not 0.3s (full parallel) or 1.5s (sequential)."""
+    Each safe pair uses a barrier that fails if it is dispatched sequentially;
+    phase markers prove the unsafe call remains between the two batches."""
     reg = ToolRegistry()
-    reg.register(_make_slow_tool("read1", 0.3, parallel_safe=True))
-    reg.register(_make_slow_tool("read2", 0.3, parallel_safe=True))
-    reg.register(_make_slow_tool("writeX", 0.3, parallel_safe=False))
-    reg.register(_make_slow_tool("read3", 0.3, parallel_safe=True))
-    reg.register(_make_slow_tool("read4", 0.3, parallel_safe=True))
+    phases: list[str] = []
+
+    def barrier_pair(first: str, second: str, phase: str) -> None:
+        entered: set[str] = set()
+        both_entered = asyncio.Event()
+
+        def build(name: str) -> _RegisteredTool:
+            async def _impl(label: str) -> ToolResult:
+                entered.add(name)
+                phases.append(f"{phase}:{name}:start")
+                if entered == {first, second}:
+                    both_entered.set()
+                await asyncio.wait_for(both_entered.wait(), timeout=0.5)
+                phases.append(f"{phase}:{name}:end")
+                return ToolResult(success=True, output={"label": label}, summary=name)
+
+            return _RegisteredTool(
+                name=name,
+                description=name,
+                fn=_impl,
+                parameters_schema={
+                    "type": "object",
+                    "properties": {"label": {"type": "string"}},
+                    "required": ["label"],
+                },
+                returns_schema={"type": "object"},
+                is_async=True,
+                parallel_safe=True,
+                examples=[],
+            )
+
+        reg.register(build(first))
+        reg.register(build(second))
+
+    barrier_pair("read1", "read2", "before")
+
+    async def write_x(label: str) -> ToolResult:
+        phases.append("write:start")
+        await asyncio.sleep(0)
+        phases.append("write:end")
+        return ToolResult(success=True, output={"label": label}, summary="writeX")
+
+    reg.register(
+        _RegisteredTool(
+            name="writeX",
+            description="writeX",
+            fn=write_x,
+            parameters_schema={
+                "type": "object",
+                "properties": {"label": {"type": "string"}},
+                "required": ["label"],
+            },
+            returns_schema={"type": "object"},
+            is_async=True,
+            parallel_safe=False,
+            examples=[],
+        )
+    )
+    barrier_pair("read3", "read4", "after")
 
     client = FakeLLMClient(
         [
@@ -206,13 +261,15 @@ async def test_unsafe_tool_serialises_around_parallel_batch(fresh_session: Sessi
     )
 
     executor = DefaultExecutor(model="fake", client=client, tools=reg)
-    t0 = time.monotonic()
     result = await executor.execute(_sg(), fresh_session, max_turns=4)
-    elapsed = time.monotonic() - t0
 
     assert result.success
-    # 3 sequential runs of ≈0.3s each = 0.9s. Generous bounds.
-    assert 0.75 <= elapsed < 1.25, f"expected three 0.3s runs ≈0.9s total, got {elapsed:.2f}s"
+    assert max(
+        index for index, item in enumerate(phases) if item.startswith("before:")
+    ) < phases.index("write:start")
+    assert phases.index("write:end") < min(
+        index for index, item in enumerate(phases) if item.startswith("after:")
+    )
     # Order must be preserved in the tool_calls_made trace.
     names = [c["name"] for c in result.tool_calls_made]
     assert names == ["read1", "read2", "writeX", "read3", "read4"]


### PR DESCRIPTION
## Summary
- add the provider protocol, capabilities, registry, invocation models, and strict normalized events
- adapt the existing planner/executor loop through NativeProvider while preserving run_task compatibility
- contain observer failures and add provider conformance coverage

## Test plan
- [x] `make ci` (400 passed, 1 skipped)
- [x] current Ruff format/lint over source, tests, examples, scripts, and tools
- [x] mypy over 46 enforced runtime modules
- [x] public export count and documentation agree at 84

Stacked on #4.

Made with [Cursor](https://cursor.com)