### PR TITLE
Add native Codex and Claude Code providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           mypy \
             src/sovereign_agent/channels \
+            src/sovereign_agent/config.py \
             src/sovereign_agent/contracts \
             src/sovereign_agent/discovery.py \
             src/sovereign_agent/errors.py \
@@ -46,6 +47,7 @@ jobs:
             src/sovereign_agent/memory \
             src/sovereign_agent/observability \
             src/sovereign_agent/orchestrator/lifecycle.py \
+            src/sovereign_agent/orchestrator/main.py \
             src/sovereign_agent/orchestrator/worker.py \
             src/sovereign_agent/orchestrator/worker_factory.py \
             src/sovereign_agent/planner \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,18 @@ a feature-branch tip rather than the pre-v0.3 state of `main`.
   forward-only states, cancellation and bounded teardown, timeout reasons,
   fail-closed native isolation, allowlisted subprocess environments, and
   redacted diagnostics. See `docs/v0.3-unit3-worker-lifecycle.md`.
+- Unit 4 native CLI providers: Codex CLI JSONL and Claude Code stream-json
+  adapters, evidence-bearing version/help probes, capability-gated fresh and
+  resumed sessions, strict normalized event parsing, observer containment, and
+  execution through the Unit 3 backend seam without Sandcastle or `shell=True`.
+  Default tests use committed fixtures and fake backends; no live provider
+  checks run in CI. See `docs/v0.3-unit4-cli-providers.md`.
 - `LivenessMonitor` — stalled-session detection and heartbeat. Importable but not
   in `__all__`.
 - Move to `src/` layout.
 
-`sovereign_agent.__all__` now has 95 symbols, up from the 67 that shipped in
-0.2.0. The 28 additions carry no stability promise until 0.3.0 is tagged.
+`sovereign_agent.__all__` now has 100 symbols, up from the 67 that shipped in
+0.2.0. The 33 additions carry no stability promise until 0.3.0 is tagged.
 
 ### Documentation and truth repair
 
@@ -41,9 +47,9 @@ a feature-branch tip rather than the pre-v0.3 state of `main`.
   `pyproject.toml` URLs, `mkdocs.yml`, and the docs tree. Old
   `sovereignagents/...` links still resolve by GitHub redirect but are no longer
   canonical.
-- Corrected test-count claims: the suite collects **413** tests (412 pass, 1
+- Corrected test-count claims: the suite collects **428** tests (427 pass, 1
   skipped). Previous docs claimed 267, 220, and 120 in different places.
-- Corrected public-API claims: **95** symbols in `__all__`, of which 67 are the
+- Corrected public-API claims: **100** symbols in `__all__`, of which 67 are the
   stable 0.2.0 surface. `docs/API.md` now lists both sets separately, and names
   the v0.3 symbols that are importable but not in `__all__`.
 - Removed links to files that do not exist: `docs/class-slides.md`,

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #
 # Quick start:
 #   make first-run           # install uv project + dev tools + run preflight
-#   make test                # 257 tests, ~16s
+#   make test                # 428 tests
 #   make demo-ch5            # full working agent end-to-end
 #   make example-research    # research-assistant example end-to-end
 #   make bundle              # tar the repo for sharing
@@ -484,6 +484,7 @@ format-check: ## ruff format --check (does not modify files)
 typecheck: ## Enforce mypy on currently clean public runtime modules
 	@$(MYPY) \
 		$(PKG_DIR)/channels \
+		$(PKG_DIR)/config.py \
 		$(PKG_DIR)/contracts \
 		$(PKG_DIR)/discovery.py \
 		$(PKG_DIR)/errors.py \
@@ -494,6 +495,7 @@ typecheck: ## Enforce mypy on currently clean public runtime modules
 		$(PKG_DIR)/memory \
 		$(PKG_DIR)/observability \
 		$(PKG_DIR)/orchestrator/lifecycle.py \
+		$(PKG_DIR)/orchestrator/main.py \
 		$(PKG_DIR)/orchestrator/worker.py \
 		$(PKG_DIR)/orchestrator/worker_factory.py \
 		$(PKG_DIR)/planner \

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Each is ~200-400 lines of code with tests. See `examples/` for end-to-end scenar
 - **Plugin registries** — a generic `Plugin` protocol and `Registry[T]`.
 - **Worker backend integration** — orchestrator dispatch routes through
   `WorkerBackend` via `make_worker_backend()`.
+- **Native CLI providers** — Codex CLI and Claude Code are probed, capability
+  gated, parsed into normalized events, and executed through `WorkerBackend`
+  without Sandcastle.
 - **Liveness monitor** — stalled-session detection and heartbeat
   (`LivenessMonitor`, importable but not in `__all__`).
 
@@ -236,7 +239,7 @@ sovereign-agent/
 ├── chapters/             # 5 tutorial chapters (minitorch-style, fill in the TODOs)
 ├── examples/             # 8 reference scenarios (research, code review, HITL, etc.)
 ├── docs/                 # architecture, API stability, deployment
-└── tests/                # 370 collected tests — library + chapters + examples
+└── tests/                # 428 collected tests — library + chapters + examples
 ```
 
 - **If you want to ship an agent today** → read `src/sovereign_agent/` and pick scenarios from `examples/`
@@ -317,7 +320,7 @@ The Makefile is also the documentation for the release workflow:
 ```
 make doctor           # tabular status — Python, uv, .env, deps, imports, CI
 make preflight        # lint + drift + pytest collection + demo importability
-make test             # full suite (370 collected: 369 pass, 1 skip)
+make test             # full suite (428 collected: 427 pass, 1 skip)
 make ci-real-estimate # cost preview for a full ci-real run (no API calls)
 make ci-real          # run every -real scenario against a live LLM
 make pre-publish      # audit for secrets, PII, forbidden files before public push
@@ -347,17 +350,17 @@ Override via `SOVEREIGN_AGENT_DATA_DIR=<path>`.
 
 **v0.2.0 alpha, with unreleased v0.3 work on `main`.** PyPI has one release
 (`0.2.0`); `pyproject.toml` still declares `0.2.0`. The published 0.2.0 semver
-surface was 67 symbols. The working tree now exports **95** symbols in
-`sovereign_agent.__all__` — the 28 additions are unreleased v0.3 work and are not
+surface was 67 symbols. The working tree now exports **100** symbols in
+`sovereign_agent.__all__` — the 33 additions are unreleased v0.3 work and are not
 covered by the 0.2.x stability promise. See [`docs/API.md`](docs/API.md) for the
 full contract and the symbol-by-symbol breakdown.
 
 - ✅ Framework: sessions, tickets, IPC, parallelism, isolation, resume, verifiers, HITL
-- ✅ 413 tests collected — 412 pass, 1 skipped (library + chapters + integration)
+- ✅ 428 tests collected — 427 pass, 1 skipped (library + chapters + integration)
 - ✅ 8 reference scenarios, all with dataflow integrity checks
 - ✅ 5 tutorial chapters, drift-checked against production code in CI
 - 🚧 Voice pipeline, observability backends (Evidently/OTel) — skeletons, not implementations
-- 🚧 Channels, providers, plugin registries, worker-backend dispatch, liveness monitor — in-tree, unreleased
+- 🚧 Channels, native Codex/Claude CLI providers, plugin registries, worker-backend dispatch, liveness monitor — in-tree, unreleased
 - ❌ Docker worker backend — stub only; `DockerWorker.run_session()` raises `NotImplementedError`
 - ❌ Vector-DB memory backends — not started, and a [v0.3 non-goal](docs/v0.3-non-goals.md)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
 
 !!! warning "The tree is ahead of the last release"
     The only published release is **0.2.0**, whose semver surface was **67**
-    symbols. The working tree exports **95**. The 28 extra symbols are unreleased
+    symbols. The working tree exports **100**. The 33 extra symbols are unreleased
     v0.3 work and carry **no** stability promise until v0.3.0 is tagged. Both
     sets are listed below, separately, so you can tell which is which.
 
@@ -98,7 +98,7 @@ Category | Symbols
 
 ---
 
-## The 28 unreleased additions (in-tree, not covered)
+## The 33 unreleased additions (in-tree, not covered)
 
 These are in `sovereign_agent.__all__` on `main` but were not in the published
 0.2.0 surface. They may be renamed, resignatured, or removed before v0.3.0 is
@@ -109,7 +109,7 @@ Category | Symbols
 **Channels** (v0.3 M1) | `CHANNEL_REGISTRY`
 **Plugin registries** (v0.3 M3) | `Plugin`, `Registry`
 **Worker lifecycle** (v0.3 Unit 3) | `WorkerBackend`, `WorkerOutcome`, `BareWorker`, `SubprocessWorker`, `OSIsolatedWorker`, `DockerWorker`, `make_worker_backend`, `WorkerRequest`, `RuntimeHandle`, `InvocationSpec`, `ExecResult`, `CloseResult`, `ExecutionLifecycle`, `LifecycleResult`, `LifecycleState`, `LifecycleTimeouts`, `TerminalReason`
-**Agent providers** (v0.3 Unit 2) | `AgentProvider`, `InvocationRequest`, `InvocationResult`, `NativeProvider`, `ProviderCapabilities`, `ProviderEvent`, `ProviderRegistry`, `PROVIDER_REGISTRY`
+**Agent providers** (v0.3 Units 2 and 4) | `AgentProvider`, `InvocationRequest`, `InvocationResult`, `NativeProvider`, `ProviderCapabilities`, `ProviderEvent`, `ProviderRegistry`, `PROVIDER_REGISTRY`, `CliProvider`, `CodexCliProvider`, `ClaudeCodeProvider`, `ProbeEvidence`, `ProviderUnavailable`
 
 `DockerWorker` is an unavailable placeholder. It remains discoverable, but
 refuses during lifecycle preparation and its legacy `run_session()` raises

--- a/docs/v0.3-unit4-cli-providers.md
+++ b/docs/v0.3-unit4-cli-providers.md
@@ -1,0 +1,47 @@
+# v0.3 Unit 4 — native CLI providers
+
+Unit 4 adds direct adapters for the OpenAI Codex CLI and Anthropic Claude Code.
+They have no Sandcastle dependency. Each adapter builds an explicit
+`InvocationSpec` (argv, environment, working directory, and optional stdin) and
+runs it through the Unit 3 `WorkerBackend` / `ExecutionLifecycle` seam. The
+default backend uses `create_subprocess_exec`; no provider path uses
+`shell=True`.
+
+Select a provider with `Config.agent_provider` or
+`SOVEREIGN_AGENT_AGENT_PROVIDER` (`native`, `codex`, or `claude`). Executable
+paths and invocation timeout have corresponding `codex_executable`,
+`claude_executable`, and `provider_timeout_s` settings. `run_task()` keeps its
+v0.2 signature.
+
+## Probe and refusal policy
+
+Before its first invocation, a CLI adapter executes side-effect-free version and
+help commands through the same lifecycle seam. Availability and feature claims
+are published at `EvidenceLevel.PROBED`. An unavailable executable, an
+unproven output mode, an unproven resume flag, or a requested feature absent
+from the probed help is rejected before task invocation.
+
+Provider session IDs are distinct from sovereign session IDs. A fresh request
+does not invent one. A `ProviderSessionEvent` is emitted only after a valid ID
+is observed in provider output. Resume requires a validated
+`ProviderSessionId` and probe evidence for the provider's resume option.
+
+## Parsing policy
+
+`CodexCliProvider` consumes Codex `exec --json` JSONL. `ClaudeCodeProvider`
+consumes Claude print-mode `stream-json`. Their strict parsers preserve source
+order while normalizing documented text, tool use/results, token usage,
+provider sessions, structured output, warnings, and otherwise meaningful raw
+events into Unit 2 immutable events.
+
+Blank lines are ignored. A malformed, truncated, non-JSON, or non-object line
+creates exactly one `malformed_provider_line` warning and parsing continues.
+Invalid documented evidence (for example, a non-integer token count or invalid
+session ID) creates an explicit warning; the parser never substitutes or
+fabricates evidence. Unknown well-formed event objects become `RawEvent`s.
+Stderr and non-zero exits become explicit warnings while retaining any valid
+stdout events. Observer failures remain contained.
+
+All default tests use committed fixtures and fake backends. They do not require
+provider binaries, credentials, network access, or token spend. Live checks are
+intentionally outside default CI.

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -45,6 +45,7 @@ EXAMPLE_MODULES = [
 
 PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/channels",
+    "src/sovereign_agent/config.py",
     "src/sovereign_agent/contracts",
     "src/sovereign_agent/discovery.py",
     "src/sovereign_agent/errors.py",
@@ -55,6 +56,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/memory",
     "src/sovereign_agent/observability",
     "src/sovereign_agent/orchestrator/lifecycle.py",
+    "src/sovereign_agent/orchestrator/main.py",
     "src/sovereign_agent/orchestrator/worker.py",
     "src/sovereign_agent/orchestrator/worker_factory.py",
     "src/sovereign_agent/planner",

--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -45,6 +45,7 @@ QUALITY_PATHS = [
 ]
 PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/channels",
+    "src/sovereign_agent/config.py",
     "src/sovereign_agent/contracts",
     "src/sovereign_agent/discovery.py",
     "src/sovereign_agent/errors.py",
@@ -55,6 +56,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/memory",
     "src/sovereign_agent/observability",
     "src/sovereign_agent/orchestrator/lifecycle.py",
+    "src/sovereign_agent/orchestrator/main.py",
     "src/sovereign_agent/orchestrator/worker.py",
     "src/sovereign_agent/orchestrator/worker_factory.py",
     "src/sovereign_agent/planner",

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -132,12 +132,17 @@ from sovereign_agent.planner import DefaultPlanner, Planner, Subgoal
 from sovereign_agent.providers import (
     PROVIDER_REGISTRY,
     AgentProvider,
+    ClaudeCodeProvider,
+    CliProvider,
+    CodexCliProvider,
     InvocationRequest,
     InvocationResult,
     NativeProvider,
+    ProbeEvidence,
     ProviderCapabilities,
     ProviderEvent,
     ProviderRegistry,
+    ProviderUnavailable,
 )
 
 # Plugin registries (v0.3 Module 3)
@@ -232,12 +237,17 @@ __all__ = [
     "DefaultPlanner",
     # providers (v0.3 Unit 2)
     "AgentProvider",
+    "ClaudeCodeProvider",
+    "CliProvider",
+    "CodexCliProvider",
     "InvocationRequest",
     "InvocationResult",
     "NativeProvider",
     "ProviderCapabilities",
     "ProviderEvent",
     "ProviderRegistry",
+    "ProviderUnavailable",
+    "ProbeEvidence",
     "PROVIDER_REGISTRY",
     "Executor",
     "ExecutorResult",

--- a/src/sovereign_agent/config.py
+++ b/src/sovereign_agent/config.py
@@ -77,6 +77,14 @@ class Config:
     # retained as the read-through, copy-on-write legacy source.
     runtime_dir: Path = field(default_factory=lambda: Path("runtime"))
 
+    # v0.3 Unit 4: provider selection. CLI providers are probed before use and
+    # execute through WorkerBackend; no binary, network, or credential check is
+    # performed during Config construction.
+    agent_provider: Literal["native", "codex", "claude"] = "native"
+    codex_executable: str = "codex"
+    claude_executable: str = "claude"
+    provider_timeout_s: float | None = None
+
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> Config:
         """Load a Config from environment variables.

--- a/src/sovereign_agent/orchestrator/main.py
+++ b/src/sovereign_agent/orchestrator/main.py
@@ -19,7 +19,7 @@ import logging
 import signal
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 from sovereign_agent._internal.llm_client import LLMClient, OpenAICompatibleClient
 from sovereign_agent.config import Config
@@ -38,7 +38,14 @@ from sovereign_agent.orchestrator.worker import (
 )
 from sovereign_agent.orchestrator.worker_factory import make_worker_backend
 from sovereign_agent.planner import DefaultPlanner
-from sovereign_agent.providers import InvocationRequest, NativeProvider
+from sovereign_agent.providers import (
+    AgentProvider,
+    ClaudeCodeProvider,
+    CodexCliProvider,
+    InvocationRequest,
+    NativeProvider,
+    ProviderRegistry,
+)
 from sovereign_agent.scheduler.drift_corrected import DriftCorrectedScheduler
 from sovereign_agent.session.directory import (
     Session,
@@ -119,6 +126,7 @@ class Orchestrator:
         self._subtasks: list[asyncio.Task] = []
         # Session-scoped caches so repeated dispatches don't rebuild tools.
         self._per_session_tools: dict[str, ToolRegistry] = {}
+        self.providers = ProviderRegistry()
 
         # v0.3 Module 1: channels. adapters=None means NO channels — a
         # bare Orchestrator, run_task(), and every v0.2 test path behave
@@ -199,10 +207,13 @@ class Orchestrator:
         loop = asyncio.get_event_loop()
         try:
             for sig in (signal.SIGTERM, signal.SIGINT):
-                loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(self._on_signal(s)))
+                loop.add_signal_handler(sig, self._schedule_signal, sig)
         except NotImplementedError:
             # Signal handlers don't work on all platforms (e.g. Windows).
             pass
+
+    def _schedule_signal(self, sig: signal.Signals) -> None:
+        asyncio.create_task(self._on_signal(sig))
 
     async def _on_signal(self, sig: signal.Signals) -> None:
         log.info("received %s; initiating graceful shutdown", sig.name)
@@ -365,15 +376,12 @@ class Orchestrator:
             return self._worker_backend
         import dataclasses
 
-        override_config = dataclasses.replace(self.config, worker_backend=override)
+        backend_name = cast(Literal["bare", "subprocess", "docker"], override)
+        override_config = dataclasses.replace(self.config, worker_backend=backend_name)
         return make_worker_backend(override_config, advance_fn=self._bare_advance)
 
     async def _dispatch_loop_half(self, session: Session) -> bool:
-        llm = self._ensure_llm_client()
-        tools = self._tools_for(session)
-        planner = DefaultPlanner(model=self.config.llm_planner_model, client=llm)
-        executor = DefaultExecutor(model=self.config.llm_executor_model, client=llm, tools=tools)
-        provider = NativeProvider(planner=planner, executor=executor)
+        provider = self._provider_for(session)
 
         # Read the task from SESSION.md (simplest source) if present.
         task = _read_task_from_session_md(session)
@@ -403,6 +411,35 @@ class Orchestrator:
             session.mark_escalated(result.summary)
             return True
         return True
+
+    def _provider_for(self, session: Session) -> AgentProvider:
+        name = self.config.agent_provider
+        if name == "native":
+            # Native tools can capture session-local state, so this adapter must
+            # not be reused across sovereign sessions.
+            llm = self._ensure_llm_client()
+            tools = self._tools_for(session)
+            planner = DefaultPlanner(model=self.config.llm_planner_model, client=llm)
+            executor = DefaultExecutor(
+                model=self.config.llm_executor_model, client=llm, tools=tools
+            )
+            return NativeProvider(planner=planner, executor=executor)
+        if name in self.providers:
+            return self.providers.get(name)
+        if name == "codex":
+            provider: AgentProvider = CodexCliProvider(
+                executable=self.config.codex_executable,
+                timeout_s=self.config.provider_timeout_s,
+            )
+        elif name == "claude":
+            provider = ClaudeCodeProvider(
+                executable=self.config.claude_executable,
+                timeout_s=self.config.provider_timeout_s,
+            )
+        else:
+            raise ValueError(f"unknown agent provider {name!r}")
+        self.providers.register(provider)
+        return provider
 
     async def _dispatch_structured_half(self, session: Session) -> bool:
         # Skeleton: the structured half has no default rules, so for now we

--- a/src/sovereign_agent/providers/__init__.py
+++ b/src/sovereign_agent/providers/__init__.py
@@ -1,5 +1,8 @@
 """Agent provider contracts, normalized events, and native implementation."""
 
+from .claude import ClaudeCodeProvider
+from .cli import CliProvider, ProbeEvidence, ProviderUnavailable
+from .codex import CodexCliProvider
 from .events import (
     ProviderEvent,
     ProviderEventType,
@@ -21,6 +24,9 @@ from .registry import PROVIDER_REGISTRY, ProviderRegistry
 __all__ = [
     "PROVIDER_REGISTRY",
     "AgentProvider",
+    "ClaudeCodeProvider",
+    "CliProvider",
+    "CodexCliProvider",
     "EventCallback",
     "EventFanout",
     "InvocationRequest",
@@ -31,6 +37,8 @@ __all__ = [
     "ProviderEvent",
     "ProviderEventType",
     "ProviderRegistry",
+    "ProviderUnavailable",
+    "ProbeEvidence",
     "ProviderSessionEvent",
     "RawEvent",
     "StructuredResultEvent",

--- a/src/sovereign_agent/providers/_parse.py
+++ b/src/sovereign_agent/providers/_parse.py
@@ -1,0 +1,164 @@
+"""Deterministic helpers shared by fixture-driven CLI event parsers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from sovereign_agent.contracts import FrozenDict, ProviderSessionId
+from sovereign_agent.contracts._core import freeze_json
+
+from .events import (
+    ProviderEventType,
+    ProviderSessionEvent,
+    RawEvent,
+    StructuredResultEvent,
+    TextEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    UsageEvent,
+    WarningEvent,
+    utc_now,
+)
+from .models import InvocationRequest
+
+
+class EventBuilder:
+    """Append normalized events with contiguous sequence numbers."""
+
+    def __init__(self, request: InvocationRequest) -> None:
+        self.request = request
+        self.events: list[ProviderEventType] = []
+        self._sessions: set[str] = set()
+        self._tool_names: dict[str, str] = {}
+
+    def _common(self) -> dict[str, Any]:
+        return {
+            "execution_id": self.request.execution_id,
+            "invocation_id": self.request.invocation_id,
+            "sequence": len(self.events),
+            "timestamp": utc_now(),
+        }
+
+    def text(self, text: str) -> None:
+        self.events.append(TextEvent(**self._common(), text=text))
+
+    @property
+    def has_text(self) -> bool:
+        return any(isinstance(event, TextEvent) for event in self.events)
+
+    def tool_call(self, call_id: str, name: str, arguments: Mapping[str, Any]) -> None:
+        self._tool_names[call_id] = name
+        self.events.append(
+            ToolCallEvent(
+                **self._common(),
+                tool_call_id=call_id,
+                name=name,
+                arguments=freeze_json(dict(arguments)),
+            )
+        )
+
+    def tool_name(self, call_id: str) -> str | None:
+        return self._tool_names.get(call_id)
+
+    def tool_result(self, call_id: str, name: str, result: Mapping[str, Any]) -> None:
+        self.events.append(
+            ToolResultEvent(
+                **self._common(),
+                tool_call_id=call_id,
+                name=name,
+                result=freeze_json(dict(result)),
+            )
+        )
+
+    def usage(self, input_tokens: object, output_tokens: object) -> bool:
+        if not _nonnegative_int(input_tokens) or not _nonnegative_int(output_tokens):
+            self.warning("invalid_usage", "usage token counts must be non-negative integers")
+            return False
+        assert isinstance(input_tokens, int)
+        assert isinstance(output_tokens, int)
+        input_count = input_tokens
+        output_count = output_tokens
+        self.events.append(
+            UsageEvent(
+                **self._common(),
+                input_tokens=input_count,
+                output_tokens=output_count,
+                total_tokens=input_count + output_count,
+            )
+        )
+        return True
+
+    def session(self, value: object) -> bool:
+        if not isinstance(value, str):
+            self.warning("invalid_provider_session", "provider session ID must be a string")
+            return False
+        try:
+            session_id = ProviderSessionId(value)
+        except (TypeError, ValueError) as exc:
+            self.warning("invalid_provider_session", str(exc))
+            return False
+        if value in self._sessions:
+            return True
+        self._sessions.add(value)
+        self.events.append(ProviderSessionEvent(**self._common(), provider_session_id=session_id))
+        return True
+
+    def structured(self, result: Mapping[str, Any]) -> None:
+        self.events.append(
+            StructuredResultEvent(**self._common(), result=freeze_json(dict(result)))
+        )
+
+    def warning(self, code: str, message: str) -> None:
+        self.events.append(WarningEvent(**self._common(), code=code, message=message))
+
+    def raw(self, provider_type: str, payload: Mapping[str, Any]) -> None:
+        self.events.append(
+            RawEvent(
+                **self._common(),
+                provider_type=provider_type,
+                payload=FrozenDict(tuple(payload.items())),
+            )
+        )
+
+
+def parse_json_lines(stdout: str, builder: EventBuilder) -> list[dict[str, Any]]:
+    """Parse JSONL with a stable recovery policy.
+
+    Blank lines are ignored. Every malformed, truncated, or non-object line
+    produces one ``malformed_provider_line`` warning and parsing continues.
+    No evidence is inferred from a failed line.
+    """
+
+    objects: list[dict[str, Any]] = []
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            builder.warning(
+                "malformed_provider_line",
+                f"line {line_number}: JSON decode failed at column {exc.colno}",
+            )
+            continue
+        if not isinstance(value, dict):
+            builder.warning(
+                "malformed_provider_line",
+                f"line {line_number}: expected a JSON object",
+            )
+            continue
+        objects.append(value)
+    return objects
+
+
+def object_value(value: object) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _nonnegative_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+__all__ = ["EventBuilder", "object_value", "parse_json_lines"]

--- a/src/sovereign_agent/providers/claude.py
+++ b/src/sovereign_agent/providers/claude.py
@@ -1,0 +1,184 @@
+"""Native Anthropic Claude Code CLI provider (no Sandcastle dependency)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sovereign_agent.contracts import EvidenceLevel
+from sovereign_agent.contracts._core import thaw_json
+from sovereign_agent.orchestrator.lifecycle import ExecResult, InvocationSpec
+
+from ._parse import EventBuilder, object_value, parse_json_lines
+from .cli import CliProvider, ProviderUnavailable
+from .events import ProviderEventType
+from .models import InvocationRequest, ProviderCapabilities
+
+
+class ClaudeCodeProvider(CliProvider):
+    """Execute Claude Code print mode and normalize documented stream-json."""
+
+    credential_names = ("ANTHROPIC_API_KEY",)
+    environment_names = ("CLAUDE_CONFIG_DIR",)
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            executable=str(kwargs.pop("executable", "claude")),
+            name=str(kwargs.pop("name", "claude")),
+            **kwargs,
+        )
+
+    def version_spec(self) -> InvocationSpec:
+        return self.spec((self.executable, "--version"))
+
+    def help_spec(self) -> InvocationSpec:
+        return self.spec((self.executable, "--help"))
+
+    def capabilities_from_probe(
+        self, version: ExecResult, help_result: ExecResult
+    ) -> ProviderCapabilities:
+        help_text = f"{help_result.stdout}\n{help_result.stderr}".lower()
+        available = version.succeeded and help_result.succeeded
+        stream_json = available and "--output-format" in help_text and "stream-json" in help_text
+        return ProviderCapabilities(
+            available=available,
+            streaming=stream_json,
+            tools=stream_json,
+            usage=stream_json,
+            provider_session=stream_json,
+            structured_result=stream_json and "--json-schema" in help_text,
+            resume=stream_json and "--resume" in help_text,
+            evidence_level=EvidenceLevel.PROBED,
+        )
+
+    def invocation_spec(self, request: InvocationRequest) -> InvocationSpec:
+        context = thaw_json(request.context)
+        assert isinstance(context, dict)
+        schema = object_value(context.get("json_schema"))
+        if context.get("require_structured_result") and schema is None:
+            raise ProviderUnavailable("claude structured results require context.json_schema")
+        command = [
+            self.executable,
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+        ]
+        if request.provider_session_id is not None:
+            command.extend(("--resume", str(request.provider_session_id)))
+        if schema is not None:
+            command.extend(("--json-schema", json.dumps(schema, sort_keys=True)))
+        command.append(request.task)
+        return self.spec(command, cwd=request.session.directory)
+
+    def parse_output(self, stdout: str, request: InvocationRequest) -> list[ProviderEventType]:
+        builder = EventBuilder(request)
+        for event in parse_json_lines(stdout, builder):
+            event_type = event.get("type")
+            if event_type == "system":
+                if event.get("subtype") == "init":
+                    builder.session(event.get("session_id"))
+                else:
+                    builder.raw("system", event)
+            elif event_type == "assistant":
+                self._message(event, builder, assistant=True)
+            elif event_type == "user":
+                self._message(event, builder, assistant=False)
+            elif event_type == "result":
+                self._result(event, builder)
+            elif event_type in {"error", "warning"}:
+                builder.warning(
+                    "provider_error" if event_type == "error" else "provider_warning",
+                    str(event.get("message") or event.get("error") or event_type),
+                )
+            elif isinstance(event_type, str):
+                builder.raw(event_type, event)
+            else:
+                builder.warning("missing_event_type", "Claude event requires a string type")
+        return builder.events
+
+    def _message(self, event: dict[str, Any], builder: EventBuilder, *, assistant: bool) -> None:
+        message = object_value(event.get("message"))
+        if message is None:
+            builder.warning("invalid_message", "message event requires an object message")
+            return
+        content = message.get("content")
+        if not isinstance(content, list):
+            builder.warning("invalid_message", "message content must be a list")
+            return
+        for block in content:
+            if not isinstance(block, dict):
+                builder.warning("invalid_content_block", "content block must be an object")
+                continue
+            block_type = block.get("type")
+            if assistant and block_type == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    builder.text(text)
+                else:
+                    builder.warning("invalid_text", "text block requires string text")
+            elif assistant and block_type == "tool_use":
+                call_id = block.get("id")
+                name = block.get("name")
+                arguments = object_value(block.get("input"))
+                if isinstance(call_id, str) and isinstance(name, str) and arguments is not None:
+                    builder.tool_call(call_id, name, arguments)
+                else:
+                    builder.warning(
+                        "invalid_tool_call",
+                        "tool_use requires string id/name and object input",
+                    )
+            elif not assistant and block_type == "tool_result":
+                call_id = block.get("tool_use_id")
+                if not isinstance(call_id, str):
+                    builder.warning(
+                        "invalid_tool_result", "tool_result requires string tool_use_id"
+                    )
+                    continue
+                content_value = block.get("content")
+                name_value = block.get("name")
+                name = name_value if isinstance(name_value, str) else builder.tool_name(call_id)
+                if name is None:
+                    builder.warning(
+                        "unmatched_tool_result",
+                        f"tool_result {call_id!r} has no observed tool call",
+                    )
+                    builder.raw("content.tool_result", block)
+                    continue
+                result = (
+                    content_value
+                    if isinstance(content_value, dict)
+                    else {
+                        "content": content_value,
+                        "is_error": bool(block.get("is_error", False)),
+                    }
+                )
+                builder.tool_result(call_id, name, result)
+            else:
+                builder.raw(f"content.{block_type or 'unknown'}", block)
+        usage = object_value(message.get("usage"))
+        if usage is not None:
+            builder.usage(usage.get("input_tokens"), usage.get("output_tokens"))
+
+    def _result(self, event: dict[str, Any], builder: EventBuilder) -> None:
+        if "session_id" in event:
+            builder.session(event.get("session_id"))
+        result_text = event.get("result")
+        if isinstance(result_text, str) and not builder.has_text:
+            builder.text(result_text)
+        structured = object_value(event.get("structured_output"))
+        if structured is not None:
+            builder.structured(structured)
+        usage = object_value(event.get("usage"))
+        if usage is not None:
+            builder.usage(usage.get("input_tokens"), usage.get("output_tokens"))
+        if event.get("is_error"):
+            builder.warning(
+                "provider_error",
+                str(event.get("result") or event.get("error") or "Claude reported an error"),
+            )
+        elif not structured and not usage and "session_id" not in event:
+            builder.raw("result", event)
+
+
+__all__ = ["ClaudeCodeProvider"]

--- a/src/sovereign_agent/providers/cli.py
+++ b/src/sovereign_agent/providers/cli.py
@@ -1,0 +1,262 @@
+"""Shared execution and probing machinery for native command-line providers."""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+from sovereign_agent.contracts import EvidenceLevel, FrozenDict
+from sovereign_agent.contracts._core import thaw_json
+from sovereign_agent.orchestrator.lifecycle import (
+    ExecResult,
+    ExecutionLifecycle,
+    InvocationSpec,
+    LifecycleTimeouts,
+    WorkerBackend,
+    WorkerRequest,
+)
+from sovereign_agent.orchestrator.worker import SubprocessWorker
+
+from .events import (
+    ProviderEventType,
+    StructuredResultEvent,
+    TextEvent,
+    WarningEvent,
+    utc_now,
+)
+from .models import InvocationRequest, InvocationResult, ProviderCapabilities
+from .observers import EventFanout, ObserverFailure
+from .protocol import EventCallback
+
+
+class ProviderUnavailable(RuntimeError):
+    """Raised before invocation when a requested CLI feature is unproven."""
+
+
+@dataclass(frozen=True)
+class ProbeEvidence:
+    executable: str
+    version: str | None
+    version_stdout: str
+    version_stderr: str
+    help_stdout: str
+    help_stderr: str
+    capabilities: ProviderCapabilities
+
+
+class CliProvider(ABC):
+    """A CLI provider executed exclusively through the Unit 3 lifecycle seam."""
+
+    kind: ClassVar[str] = "provider"
+    credential_names: ClassVar[tuple[str, ...]] = ()
+    environment_names: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(
+        self,
+        *,
+        executable: str,
+        name: str,
+        backend: WorkerBackend | None = None,
+        lifecycle: ExecutionLifecycle | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_s: float | None = None,
+    ) -> None:
+        self.executable = executable
+        self.name = name
+        self.backend = backend or SubprocessWorker(credential_allowlist=self.credential_names)
+        self.lifecycle = lifecycle or ExecutionLifecycle()
+        self.environment = (
+            dict(environment) if environment is not None else self._default_environment()
+        )
+        self.timeout_s = timeout_s
+        self.capabilities = ProviderCapabilities(
+            available=False, evidence_level=EvidenceLevel.UNKNOWN
+        )
+        self.probe_evidence: ProbeEvidence | None = None
+        self.last_observer_failures: tuple[ObserverFailure, ...] = ()
+
+    def _default_environment(self) -> dict[str, str]:
+        names = {
+            "PATH",
+            "HOME",
+            "LANG",
+            "LC_ALL",
+            "LC_CTYPE",
+            "TERM",
+            "TMPDIR",
+            "TEMP",
+            "TMP",
+            *self.credential_names,
+            *self.environment_names,
+        }
+        return {name: os.environ[name] for name in names if name in os.environ}
+
+    @abstractmethod
+    def version_spec(self) -> InvocationSpec:
+        """Return the side-effect-free version probe."""
+
+    @abstractmethod
+    def help_spec(self) -> InvocationSpec:
+        """Return the side-effect-free invocation help probe."""
+
+    @abstractmethod
+    def capabilities_from_probe(
+        self, version: ExecResult, help_result: ExecResult
+    ) -> ProviderCapabilities:
+        """Derive only capabilities evidenced by probe output."""
+
+    @abstractmethod
+    def invocation_spec(self, request: InvocationRequest) -> InvocationSpec:
+        """Build an argv/environment invocation without executing it."""
+
+    @abstractmethod
+    def parse_output(self, stdout: str, request: InvocationRequest) -> list[ProviderEventType]:
+        """Parse documented provider output into normalized immutable events."""
+
+    async def probe(self, request: InvocationRequest) -> ProbeEvidence:
+        version = await self._execute(request, self.version_spec())
+        help_result = await self._execute(request, self.help_spec())
+        capabilities = self.capabilities_from_probe(version, help_result)
+        version_text = (version.stdout or version.stderr).strip().splitlines()
+        evidence = ProbeEvidence(
+            executable=self.executable,
+            version=version_text[0] if version_text and version.succeeded else None,
+            version_stdout=version.stdout,
+            version_stderr=version.stderr,
+            help_stdout=help_result.stdout,
+            help_stderr=help_result.stderr,
+            capabilities=capabilities,
+        )
+        self.capabilities = capabilities
+        self.probe_evidence = evidence
+        return evidence
+
+    async def invoke(
+        self,
+        request: InvocationRequest,
+        *,
+        observers: Sequence[EventCallback] = (),
+        activity_callbacks: Sequence[EventCallback] = (),
+    ) -> InvocationResult:
+        if self.probe_evidence is None:
+            await self.probe(request)
+        self._refuse_unproven_features(request)
+        execution = await self._execute(request, self.invocation_spec(request))
+        events = self.parse_output(execution.stdout, request)
+        if execution.stderr.strip():
+            events.append(
+                self._warning(
+                    request,
+                    len(events),
+                    "provider_stderr",
+                    execution.stderr.strip(),
+                )
+            )
+        if not execution.succeeded:
+            detail = execution.stderr.strip() or execution.terminal_reason or execution.returncode
+            events.append(
+                self._warning(
+                    request,
+                    len(events),
+                    "provider_nonzero_exit",
+                    f"provider invocation failed: {detail}",
+                )
+            )
+
+        fanout = EventFanout(observers, activity_callbacks)
+        for event in events:
+            await fanout.emit(event)
+        self.last_observer_failures = fanout.failures
+
+        texts = [event.text for event in events if isinstance(event, TextEvent)]
+        structured = [
+            thaw_json(event.result) for event in events if isinstance(event, StructuredResultEvent)
+        ]
+        output: dict[str, Any] = {"final_answer": "".join(texts)}
+        if structured:
+            output["structured_result"] = structured[-1]
+        success = execution.succeeded
+        summary = output["final_answer"] or (
+            "provider invocation completed" if success else "provider invocation failed"
+        )
+        return InvocationResult(
+            success=success,
+            output=FrozenDict(tuple(output.items())),
+            summary=str(summary),
+            next_action="complete" if success else "escalate",
+            events=tuple(events),
+        )
+
+    async def _execute(self, request: InvocationRequest, spec: InvocationSpec) -> ExecResult:
+        worker_request = WorkerRequest(
+            execution_id=request.execution_id,
+            session_id=request.session.session_id,
+            session_dir=request.session.directory,
+            credential_allowlist=self.credential_names,
+            environment_allowlist=self.environment_names,
+            timeouts=LifecycleTimeouts(execute_s=self.timeout_s),
+        )
+        result = await self.lifecycle.run(self.backend, worker_request, spec)
+        if result.exec_result is not None:
+            return result.exec_result
+        return ExecResult(
+            returncode=None,
+            stderr=result.error or result.reason.value,
+            started=False,
+            terminal_reason=result.reason,
+        )
+
+    def _refuse_unproven_features(self, request: InvocationRequest) -> None:
+        if (
+            not self.capabilities.available
+            or self.capabilities.evidence_level < EvidenceLevel.PROBED
+        ):
+            raise ProviderUnavailable(
+                f"{self.name} executable/output mode was not proven by version and help probes"
+            )
+        if request.provider_session_id is not None and not self.capabilities.resume:
+            raise ProviderUnavailable(f"{self.name} resume support was not proven")
+        context = thaw_json(request.context)
+        assert isinstance(context, dict)
+        requested = {
+            "tools": bool(context.get("require_tools")),
+            "usage": bool(context.get("require_usage")),
+            "structured_result": bool(context.get("require_structured_result")),
+            "streaming": bool(context.get("require_streaming")),
+        }
+        for feature, required in requested.items():
+            if required and not bool(getattr(self.capabilities, feature)):
+                raise ProviderUnavailable(f"{self.name} capability {feature!r} is unavailable")
+
+    def _warning(
+        self, request: InvocationRequest, sequence: int, code: str, message: str
+    ) -> WarningEvent:
+        return WarningEvent(
+            execution_id=request.execution_id,
+            invocation_id=request.invocation_id,
+            sequence=sequence,
+            timestamp=utc_now(),
+            code=code,
+            message=message,
+        )
+
+    def spec(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        stdin: bytes | None = None,
+    ) -> InvocationSpec:
+        return InvocationSpec(
+            command=tuple(command),
+            environment=self.environment,
+            cwd=cwd,
+            stdin=stdin,
+        )
+
+
+__all__ = ["CliProvider", "ProbeEvidence", "ProviderUnavailable"]

--- a/src/sovereign_agent/providers/codex.py
+++ b/src/sovereign_agent/providers/codex.py
@@ -1,0 +1,189 @@
+"""Native OpenAI Codex CLI provider (no Sandcastle dependency)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sovereign_agent.contracts import EvidenceLevel
+from sovereign_agent.contracts._core import thaw_json
+from sovereign_agent.orchestrator.lifecycle import ExecResult, InvocationSpec
+
+from ._parse import EventBuilder, object_value, parse_json_lines
+from .cli import CliProvider, ProviderUnavailable
+from .events import ProviderEventType
+from .models import InvocationRequest, ProviderCapabilities
+
+
+class CodexCliProvider(CliProvider):
+    """Execute ``codex exec --json`` and normalize its documented JSONL."""
+
+    credential_names = ("OPENAI_API_KEY",)
+    environment_names = ("CODEX_HOME",)
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            executable=str(kwargs.pop("executable", "codex")),
+            name=str(kwargs.pop("name", "codex")),
+            **kwargs,
+        )
+
+    def version_spec(self) -> InvocationSpec:
+        return self.spec((self.executable, "--version"))
+
+    def help_spec(self) -> InvocationSpec:
+        return self.spec((self.executable, "exec", "--help"))
+
+    def capabilities_from_probe(
+        self, version: ExecResult, help_result: ExecResult
+    ) -> ProviderCapabilities:
+        help_text = f"{help_result.stdout}\n{help_result.stderr}".lower()
+        available = version.succeeded and help_result.succeeded
+        json_mode = available and "--json" in help_text
+        return ProviderCapabilities(
+            available=available,
+            streaming=json_mode,
+            tools=json_mode,
+            usage=json_mode,
+            provider_session=json_mode,
+            structured_result=json_mode and "--output-schema" in help_text,
+            resume=json_mode and "resume" in help_text,
+            evidence_level=EvidenceLevel.PROBED,
+        )
+
+    def invocation_spec(self, request: InvocationRequest) -> InvocationSpec:
+        context = thaw_json(request.context)
+        assert isinstance(context, dict)
+        schema_path = context.get("output_schema_path")
+        if context.get("require_structured_result") and not isinstance(schema_path, str):
+            raise ProviderUnavailable("codex structured results require context.output_schema_path")
+        command: tuple[str, ...]
+        if request.provider_session_id is None:
+            parts = [
+                self.executable,
+                "exec",
+                "--json",
+                "--skip-git-repo-check",
+            ]
+            if isinstance(schema_path, str):
+                parts.extend(("--output-schema", schema_path))
+            parts.append(request.task)
+            command = tuple(parts)
+        else:
+            parts = [
+                self.executable,
+                "exec",
+                "resume",
+                "--json",
+            ]
+            if isinstance(schema_path, str):
+                parts.extend(("--output-schema", schema_path))
+            parts.extend((str(request.provider_session_id), request.task))
+            command = tuple(parts)
+        return self.spec(command, cwd=request.session.directory)
+
+    def parse_output(self, stdout: str, request: InvocationRequest) -> list[ProviderEventType]:
+        builder = EventBuilder(request)
+        for event in parse_json_lines(stdout, builder):
+            event_type = event.get("type")
+            if event_type == "thread.started":
+                builder.session(event.get("thread_id"))
+            elif event_type == "item.completed":
+                self._completed_item(event, builder)
+            elif event_type == "item.started":
+                item = object_value(event.get("item"))
+                if item is None:
+                    builder.warning("invalid_item", "item.started requires an object item")
+                elif item.get("type") not in {"command_execution", "mcp_tool_call"}:
+                    builder.raw(str(event_type), event)
+            elif event_type == "turn.completed":
+                usage = object_value(event.get("usage"))
+                if usage is None:
+                    builder.warning("missing_usage", "turn.completed did not contain usage")
+                else:
+                    builder.usage(usage.get("input_tokens"), usage.get("output_tokens"))
+            elif event_type in {"turn.started"}:
+                builder.raw(str(event_type), event)
+            elif event_type in {"error", "turn.failed"}:
+                message = event.get("message") or event.get("error") or "Codex reported an error"
+                builder.warning("provider_error", str(message))
+            elif isinstance(event_type, str):
+                builder.raw(event_type, event)
+            else:
+                builder.warning("missing_event_type", "Codex event requires a string type")
+        return builder.events
+
+    def _completed_item(self, event: dict[str, Any], builder: EventBuilder) -> None:
+        item = object_value(event.get("item"))
+        if item is None:
+            builder.warning("invalid_item", "item.completed requires an object item")
+            return
+        item_type = item.get("type")
+        if item_type == "agent_message":
+            text = item.get("text")
+            if isinstance(text, str):
+                builder.text(text)
+                context = thaw_json(builder.request.context)
+                assert isinstance(context, dict)
+                if context.get("require_structured_result"):
+                    try:
+                        structured = json.loads(text)
+                    except json.JSONDecodeError:
+                        structured = None
+                    if isinstance(structured, dict):
+                        builder.structured(structured)
+                    else:
+                        builder.warning(
+                            "invalid_structured_result",
+                            "schema-constrained Codex answer must be a JSON object",
+                        )
+            else:
+                builder.warning("invalid_text", "agent_message text must be a string")
+            return
+        if item_type == "command_execution":
+            call_id = item.get("id")
+            command = item.get("command")
+            if not isinstance(call_id, str) or not isinstance(command, str):
+                builder.warning(
+                    "invalid_tool_call", "command_execution requires string id and command"
+                )
+                return
+            builder.tool_call(call_id, "shell", {"command": command})
+            builder.tool_result(
+                call_id,
+                "shell",
+                {
+                    "output": item.get("aggregated_output", ""),
+                    "exit_code": item.get("exit_code"),
+                    "status": item.get("status"),
+                },
+            )
+            return
+        if item_type == "mcp_tool_call":
+            call_id = item.get("id")
+            name = item.get("tool")
+            arguments = object_value(item.get("arguments"))
+            if not isinstance(call_id, str) or not isinstance(name, str) or arguments is None:
+                builder.warning(
+                    "invalid_tool_call",
+                    "mcp_tool_call requires string id/tool and object arguments",
+                )
+                return
+            builder.tool_call(call_id, name, arguments)
+            result = object_value(item.get("result"))
+            if result is not None:
+                builder.tool_result(call_id, name, result)
+            elif item.get("error") is not None:
+                builder.tool_result(call_id, name, {"error": item["error"]})
+            return
+        if item_type == "structured_output":
+            value = object_value(item.get("value"))
+            if value is None:
+                builder.warning("invalid_structured_result", "structured output must be an object")
+            else:
+                builder.structured(value)
+            return
+        builder.raw("item.completed", event)
+
+
+__all__ = ["CodexCliProvider"]

--- a/src/sovereign_agent/providers/models.py
+++ b/src/sovereign_agent/providers/models.py
@@ -13,6 +13,7 @@ from sovereign_agent.contracts import (
     ExecutionId,
     FrozenDict,
     InvocationId,
+    ProviderSessionId,
 )
 from sovereign_agent.contracts._core import freeze_json, require_object, require_string, thaw_json
 from sovereign_agent.session.directory import Session
@@ -29,6 +30,8 @@ class ProviderCapabilities:
     provider_session: bool = False
     structured_result: bool = False
     streaming: bool = False
+    resume: bool = False
+    available: bool = True
     evidence_level: EvidenceLevel = EvidenceLevel.DECLARED
 
     def to_manifest(self) -> CapabilityManifest:
@@ -40,6 +43,8 @@ class ProviderCapabilities:
                 ("provider_session", self.provider_session),
                 ("structured_result", self.structured_result),
                 ("streaming", self.streaming),
+                ("resume", self.resume),
+                ("available", self.available),
             )
         }
         return CapabilityManifest(capabilities=FrozenDict(tuple(values.items())))
@@ -60,6 +65,10 @@ class ProviderCapabilities:
             provider_session=manifest.is_available("provider_session"),
             structured_result=manifest.is_available("structured_result"),
             streaming=manifest.is_available("streaming"),
+            resume=manifest.is_available("resume"),
+            available=(
+                True if manifest.get("available") is None else manifest.is_available("available")
+            ),
             evidence_level=level,
         )
 
@@ -78,6 +87,7 @@ class InvocationRequest:
     task: str
     session: Session
     context: FrozenDict = field(default_factory=FrozenDict)
+    provider_session_id: ProviderSessionId | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.execution_id, ExecutionId):
@@ -88,6 +98,14 @@ class InvocationRequest:
         if not isinstance(self.session, Session):
             raise ContractValidationError("session must be Session")
         object.__setattr__(self, "context", freeze_json(require_object(self.context, "context")))
+        if isinstance(self.provider_session_id, str):
+            object.__setattr__(
+                self, "provider_session_id", ProviderSessionId(self.provider_session_id)
+            )
+        if self.provider_session_id is not None and not isinstance(
+            self.provider_session_id, ProviderSessionId
+        ):
+            raise ContractValidationError("provider_session_id must be ProviderSessionId or None")
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -95,6 +113,9 @@ class InvocationRequest:
             "invocation_id": str(self.invocation_id),
             "task": self.task,
             "context": thaw_json(self.context),
+            "provider_session_id": (
+                str(self.provider_session_id) if self.provider_session_id is not None else None
+            ),
         }
 
 

--- a/src/sovereign_agent/providers/native.py
+++ b/src/sovereign_agent/providers/native.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import ClassVar
 
-from sovereign_agent.contracts import FrozenDict, ProviderSessionId
+from sovereign_agent.contracts import FrozenDict
 from sovereign_agent.contracts._core import thaw_json
 from sovereign_agent.executor import DefaultExecutor
 from sovereign_agent.halves.loop import LoopHalf
 from sovereign_agent.planner import DefaultPlanner
 
+from .cli import ProviderUnavailable
 from .events import (
     ProviderEventType,
-    ProviderSessionEvent,
     StructuredResultEvent,
     TextEvent,
     ToolCallEvent,
@@ -32,7 +32,6 @@ class NativeProvider:
     kind: ClassVar[str] = "provider"
     capabilities = ProviderCapabilities(
         tools=True,
-        provider_session=True,
         structured_result=True,
     )
 
@@ -59,22 +58,14 @@ class NativeProvider:
         observers: Sequence[EventCallback] = (),
         activity_callbacks: Sequence[EventCallback] = (),
     ) -> InvocationResult:
+        if request.provider_session_id is not None:
+            raise ProviderUnavailable("native provider has no external provider session to resume")
         fanout = EventFanout(observers, activity_callbacks)
         events: list[ProviderEventType] = []
 
         async def emit(event: ProviderEventType) -> None:
             events.append(event)
             await fanout.emit(event)
-
-        await emit(
-            ProviderSessionEvent(
-                execution_id=request.execution_id,
-                invocation_id=request.invocation_id,
-                sequence=len(events),
-                timestamp=utc_now(),
-                provider_session_id=ProviderSessionId(request.session.session_id),
-            )
-        )
 
         context = thaw_json(request.context)
         assert isinstance(context, dict)

--- a/tests/fixtures/providers/claude_result.json
+++ b/tests/fixtures/providers/claude_result.json
@@ -1,0 +1,1 @@
+{"type":"result","subtype":"success","is_error":false,"result":"Claude JSON answer","session_id":"claude-json-session","usage":{"input_tokens":8,"output_tokens":4}}

--- a/tests/fixtures/providers/claude_success.jsonl
+++ b/tests/fixtures/providers/claude_success.jsonl
@@ -1,0 +1,5 @@
+{"type":"system","subtype":"init","session_id":"claude-session-1","tools":["Read"]}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Checking. "},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"README.md"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","name":"Read","content":{"text":"readme"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Claude answer"}]}}
+{"type":"result","subtype":"success","session_id":"claude-session-1","usage":{"input_tokens":13,"output_tokens":5},"structured_output":{"answer":"Claude answer"}}

--- a/tests/fixtures/providers/claude_truncated.jsonl
+++ b/tests/fixtures/providers/claude_truncated.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"claude-session-2"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"partial"}]}}
+{"type":"result","subtype":"success"

--- a/tests/fixtures/providers/codex_malformed.jsonl
+++ b/tests/fixtures/providers/codex_malformed.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"codex-session-1"}
+{"type":"item.completed","item":{"type":"agent_message","text":"before"}}
+{"type":"item.completed","item":
+[]
+{"type":"item.completed","item":{"type":"agent_message","text":"after"}}

--- a/tests/fixtures/providers/codex_success.jsonl
+++ b/tests/fixtures/providers/codex_success.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"019abc12-3456-7890-abcd-ef1234567890"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"printf hello","aggregated_output":"hello","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"Codex answer"}}
+{"type":"turn.completed","usage":{"input_tokens":11,"cached_input_tokens":2,"output_tokens":7}}

--- a/tests/providers/test_cli_providers.py
+++ b/tests/providers/test_cli_providers.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sovereign_agent.config import Config
+from sovereign_agent.contracts import (
+    CapabilityManifest,
+    EvidenceLevel,
+    ExecutionId,
+    FrozenDict,
+    InvocationId,
+    ProviderSessionId,
+)
+from sovereign_agent.orchestrator.lifecycle import (
+    CloseResult,
+    ExecResult,
+    InvocationSpec,
+    RuntimeHandle,
+    WorkerRequest,
+)
+from sovereign_agent.providers import (
+    AgentProvider,
+    ClaudeCodeProvider,
+    CodexCliProvider,
+    InvocationRequest,
+    ProviderUnavailable,
+)
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "providers"
+
+
+class FakeBackend:
+    name = "fake-process"
+
+    def __init__(
+        self,
+        *,
+        help_stdout: str,
+        invocation_stdout: str = "",
+        invocation_stderr: str = "",
+        invocation_returncode: int = 0,
+        version_returncode: int = 0,
+    ) -> None:
+        self.help_stdout = help_stdout
+        self.invocation_stdout = invocation_stdout
+        self.invocation_stderr = invocation_stderr
+        self.invocation_returncode = invocation_returncode
+        self.version_returncode = version_returncode
+        self.specs: list[InvocationSpec] = []
+
+    def capabilities(self) -> CapabilityManifest:
+        return CapabilityManifest(capabilities=FrozenDict())
+
+    async def prepare(self, request: WorkerRequest) -> RuntimeHandle:
+        return RuntimeHandle(request=request, invocation=InvocationSpec())
+
+    async def execute(
+        self, handle: RuntimeHandle, invocation: InvocationSpec | None = None
+    ) -> ExecResult:
+        assert invocation is not None
+        self.specs.append(invocation)
+        command = invocation.command
+        if "--version" in command:
+            return ExecResult(
+                returncode=self.version_returncode,
+                stdout="provider 1.2.3\n" if self.version_returncode == 0 else "",
+                stderr="not found" if self.version_returncode else "",
+                started=self.version_returncode == 0,
+            )
+        if "--help" in command:
+            return ExecResult(returncode=0, stdout=self.help_stdout)
+        return ExecResult(
+            returncode=self.invocation_returncode,
+            stdout=self.invocation_stdout,
+            stderr=self.invocation_stderr,
+        )
+
+    async def close(self, handle: RuntimeHandle, preserve: bool = False) -> CloseResult:
+        handle.closed = True
+        return CloseResult(closed=True, preserved=preserve)
+
+
+def request(
+    fresh_session,
+    *,
+    provider_session_id: str | None = None,
+    context: FrozenDict | None = None,
+) -> InvocationRequest:
+    return InvocationRequest(
+        execution_id=ExecutionId("exec-cli-1"),
+        invocation_id=InvocationId("invoke-cli-1"),
+        task="fix the tests",
+        session=fresh_session,
+        context=context or FrozenDict(),
+        provider_session_id=(
+            ProviderSessionId(provider_session_id) if provider_session_id is not None else None
+        ),
+    )
+
+
+def fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_codex_command_construction_distinguishes_fresh_and_resume(fresh_session) -> None:
+    provider = CodexCliProvider(
+        executable="/opt/codex",
+        backend=FakeBackend(help_stdout=""),
+        environment={"PATH": "/bin"},
+    )
+    fresh = provider.invocation_spec(request(fresh_session))
+    resumed = provider.invocation_spec(
+        request(fresh_session, provider_session_id="codex-session-1")
+    )
+    assert fresh.command == (
+        "/opt/codex",
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "fix the tests",
+    )
+    assert resumed.command == (
+        "/opt/codex",
+        "exec",
+        "resume",
+        "--json",
+        "codex-session-1",
+        "fix the tests",
+    )
+    assert fresh.environment == {"PATH": "/bin"}
+    assert fresh.cwd == fresh_session.directory
+
+
+def test_claude_command_construction_distinguishes_fresh_and_resume(fresh_session) -> None:
+    provider = ClaudeCodeProvider(
+        executable="/opt/claude",
+        backend=FakeBackend(help_stdout=""),
+        environment={"HOME": "/home/test"},
+    )
+    fresh = provider.invocation_spec(request(fresh_session))
+    resumed = provider.invocation_spec(
+        request(fresh_session, provider_session_id="claude-session-1")
+    )
+    assert fresh.command[-1] == "fix the tests"
+    assert "--resume" not in fresh.command
+    assert resumed.command[-3:] == (
+        "--resume",
+        "claude-session-1",
+        "fix the tests",
+    )
+    assert resumed.environment == {"HOME": "/home/test"}
+
+
+def test_codex_fixture_parses_ordered_evidence(fresh_session) -> None:
+    provider = CodexCliProvider(backend=FakeBackend(help_stdout=""))
+    events = provider.parse_output(fixture("codex_success.jsonl"), request(fresh_session))
+    assert [event.sequence for event in events] == list(range(len(events)))
+    assert [event.event_type for event in events] == [
+        "provider_session",
+        "raw",
+        "tool_call",
+        "tool_result",
+        "text",
+        "usage",
+    ]
+    assert events[-1].to_dict()["total_tokens"] == 18
+
+
+def test_codex_schema_constrained_answer_emits_structured_result(fresh_session) -> None:
+    provider = CodexCliProvider(backend=FakeBackend(help_stdout=""))
+    stdout = (
+        '{"type":"item.completed","item":{"type":"agent_message",'
+        '"text":"{\\"answer\\":\\"done\\"}"}}\n'
+    )
+    events = provider.parse_output(
+        stdout,
+        request(
+            fresh_session,
+            context=FrozenDict((("require_structured_result", True),)),
+        ),
+    )
+    assert [event.event_type for event in events] == ["text", "structured_result"]
+    assert events[-1].to_dict()["result"] == {"answer": "done"}
+
+
+def test_claude_fixture_parses_all_normalized_forms(fresh_session) -> None:
+    provider = ClaudeCodeProvider(backend=FakeBackend(help_stdout=""))
+    events = provider.parse_output(fixture("claude_success.jsonl"), request(fresh_session))
+    assert [event.sequence for event in events] == list(range(len(events)))
+    assert [event.event_type for event in events] == [
+        "provider_session",
+        "text",
+        "tool_call",
+        "tool_result",
+        "text",
+        "structured_result",
+        "usage",
+    ]
+
+
+def test_claude_single_json_result_preserves_text_and_evidence(fresh_session) -> None:
+    provider = ClaudeCodeProvider(backend=FakeBackend(help_stdout=""))
+    events = provider.parse_output(fixture("claude_result.json"), request(fresh_session))
+    assert [event.event_type for event in events] == [
+        "provider_session",
+        "text",
+        "usage",
+    ]
+    assert events[1].to_dict()["text"] == "Claude JSON answer"
+
+
+@pytest.mark.parametrize(
+    ("provider_type", "fixture_name", "warning_count"),
+    [
+        (CodexCliProvider, "codex_malformed.jsonl", 2),
+        (ClaudeCodeProvider, "claude_truncated.jsonl", 1),
+    ],
+)
+def test_malformed_and_truncated_lines_become_explicit_warnings(
+    fresh_session, provider_type, fixture_name: str, warning_count: int
+) -> None:
+    provider = provider_type(backend=FakeBackend(help_stdout=""))
+    events = provider.parse_output(fixture(fixture_name), request(fresh_session))
+    warnings = [event for event in events if event.event_type == "warning"]
+    assert len(warnings) == warning_count
+    assert all(event.to_dict()["code"] == "malformed_provider_line" for event in warnings)
+    assert [event.sequence for event in events] == list(range(len(events)))
+
+
+@pytest.mark.asyncio
+async def test_probe_publishes_evidence_and_invocation_uses_backend(fresh_session) -> None:
+    backend = FakeBackend(help_stdout="Usage: codex exec [--json] [--output-schema FILE] resume")
+    provider = CodexCliProvider(backend=backend)
+    evidence = await provider.probe(request(fresh_session))
+    assert evidence.version == "provider 1.2.3"
+    assert evidence.capabilities.evidence_level is EvidenceLevel.PROBED
+    assert evidence.capabilities.resume is True
+    assert evidence.capabilities.structured_result is True
+    assert backend.specs[:2][0].command == ("codex", "--version")
+    assert backend.specs[:2][1].command == ("codex", "exec", "--help")
+
+
+@pytest.mark.asyncio
+async def test_unavailable_executable_is_refused_before_invocation(fresh_session) -> None:
+    backend = FakeBackend(help_stdout="--json resume", version_returncode=127)
+    provider = CodexCliProvider(backend=backend)
+    with pytest.raises(ProviderUnavailable, match="not proven"):
+        await provider.invoke(request(fresh_session))
+    assert len(backend.specs) == 2
+
+
+@pytest.mark.asyncio
+async def test_unproven_resume_is_refused_before_invocation(fresh_session) -> None:
+    backend = FakeBackend(help_stdout="--output-format stream-json")
+    provider = ClaudeCodeProvider(backend=backend)
+    with pytest.raises(ProviderUnavailable, match="resume support"):
+        await provider.invoke(request(fresh_session, provider_session_id="claude-session-1"))
+    assert len(backend.specs) == 2
+
+
+@pytest.mark.asyncio
+async def test_fresh_session_id_is_only_emitted_when_observed(fresh_session) -> None:
+    backend = FakeBackend(
+        help_stdout="--output-format stream-json --resume",
+        invocation_stdout='{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}\n',
+    )
+    provider = ClaudeCodeProvider(backend=backend)
+    result = await provider.invoke(request(fresh_session))
+    assert all(event.event_type != "provider_session" for event in result.events)
+
+
+@pytest.mark.asyncio
+async def test_stderr_nonzero_and_callback_failure_are_contained(fresh_session) -> None:
+    backend = FakeBackend(
+        help_stdout="--json resume",
+        invocation_stdout=fixture("codex_success.jsonl"),
+        invocation_stderr="provider diagnostic",
+        invocation_returncode=2,
+    )
+    provider = CodexCliProvider(backend=backend)
+    observed: list[int] = []
+
+    def broken(event) -> None:
+        observed.append(event.sequence)
+        raise RuntimeError("observer failed")
+
+    result = await provider.invoke(request(fresh_session), observers=[broken])
+    assert result.success is False
+    assert [event.to_dict().get("code") for event in result.events[-2:]] == [
+        "provider_stderr",
+        "provider_nonzero_exit",
+    ]
+    assert observed == list(range(len(result.events)))
+    assert len(provider.last_observer_failures) == len(result.events)
+
+
+def test_cli_providers_conform_and_config_is_selectable() -> None:
+    assert isinstance(CodexCliProvider(backend=FakeBackend(help_stdout="")), AgentProvider)
+    assert isinstance(ClaudeCodeProvider(backend=FakeBackend(help_stdout="")), AgentProvider)
+    config = Config.from_env(
+        {
+            "SOVEREIGN_AGENT_AGENT_PROVIDER": "codex",
+            "SOVEREIGN_AGENT_CODEX_EXECUTABLE": "/tools/codex",
+        }
+    )
+    assert config.agent_provider == "codex"
+    assert config.codex_executable == "/tools/codex"

--- a/tests/providers/test_provider_conformance.py
+++ b/tests/providers/test_provider_conformance.py
@@ -25,6 +25,7 @@ from sovereign_agent.providers import (
     ProviderEvent,
     ProviderRegistry,
     ProviderSessionEvent,
+    ProviderUnavailable,
     StructuredResultEvent,
     UsageEvent,
 )
@@ -95,12 +96,25 @@ async def test_native_provider_ordering_and_observer_containment(fresh_session) 
     )
     assert [event.sequence for event in result.events] == list(range(len(result.events)))
     assert [event.event_type for event in result.events] == [
-        "provider_session",
         "text",
         "structured_result",
     ]
-    assert observed == activity == [0, 1, 2]
-    assert len(provider.last_observer_failures) == 3
+    assert observed == activity == [0, 1]
+    assert len(provider.last_observer_failures) == 2
+
+
+@pytest.mark.asyncio
+async def test_native_provider_refuses_external_resume(fresh_session) -> None:
+    provider = NativeProvider(loop_half=_FakeLoop())  # type: ignore[arg-type]
+    request = InvocationRequest(
+        execution_id=ExecutionId("exec-1"),
+        invocation_id=InvocationId("invoke-1"),
+        task="test",
+        session=fresh_session,
+        provider_session_id="external-session",
+    )
+    with pytest.raises(ProviderUnavailable, match="no external provider session"):
+        await provider.invoke(request)
 
 
 def test_provider_registry_uses_plugin_contract() -> None:


### PR DESCRIPTION
## Summary
- add capability-probed Codex CLI and Claude Code providers executed through the worker lifecycle
- normalize fixture-tested JSONL and stream-json evidence with safe fresh/resume session handling
- expose provider selection while preserving the v0.2 run_task contract and offline CI

## Test plan
- [x] `make ci` (427 passed, 1 skipped)
- [x] 21 focused provider tests
- [x] current Ruff format/lint over source, tests, examples, scripts, and tools
- [x] mypy over 55 enforced runtime modules
- [x] public export count and documentation agree at 100

Stacked on #6.

Made with [Cursor](https://cursor.com)