### PR TITLE
Isolate governed repository execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
             src/sovereign_agent/orchestrator/worker_factory.py \
             src/sovereign_agent/planner \
             src/sovereign_agent/providers \
+            src/sovereign_agent/repository \
             src/sovereign_agent/runtime \
             src/sovereign_agent/tickets \
             src/sovereign_agent/voice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,17 @@ a feature-branch tip rather than the pre-v0.3 state of `main`.
   execution through the Unit 3 backend seam without Sandcastle or `shell=True`.
   Default tests use committed fixtures and fake backends; no live provider
   checks run in CI. See `docs/v0.3-unit4-cli-providers.md`.
+- Unit 5 governed repository execution: configured `RepositoryId` resolution,
+  fail-closed dirty policies, isolated execution branches and worktrees,
+  durable fenced repository leases, deterministic redacted Git evidence, and
+  opt-in non-force delivery with exact remote-SHA verification. See
+  `docs/v0.3-unit5-repository.md`.
 - `LivenessMonitor` — stalled-session detection and heartbeat. Importable but not
   in `__all__`.
 - Move to `src/` layout.
 
-`sovereign_agent.__all__` now has 100 symbols, up from the 67 that shipped in
-0.2.0. The 33 additions carry no stability promise until 0.3.0 is tagged.
+`sovereign_agent.__all__` now has 119 symbols, up from the 67 that shipped in
+0.2.0. The 52 additions carry no stability promise until 0.3.0 is tagged.
 
 ### Documentation and truth repair
 
@@ -47,9 +52,9 @@ a feature-branch tip rather than the pre-v0.3 state of `main`.
   `pyproject.toml` URLs, `mkdocs.yml`, and the docs tree. Old
   `sovereignagents/...` links still resolve by GitHub redirect but are no longer
   canonical.
-- Corrected test-count claims: the suite collects **428** tests (427 pass, 1
+- Corrected test-count claims: the suite collects **446** tests (445 pass, 1
   skipped). Previous docs claimed 267, 220, and 120 in different places.
-- Corrected public-API claims: **100** symbols in `__all__`, of which 67 are the
+- Corrected public-API claims: **119** symbols in `__all__`, of which 67 are the
   stable 0.2.0 surface. `docs/API.md` now lists both sets separately, and names
   the v0.3 symbols that are importable but not in `__all__`.
 - Removed links to files that do not exist: `docs/class-slides.md`,

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #
 # Quick start:
 #   make first-run           # install uv project + dev tools + run preflight
-#   make test                # 428 tests
+#   make test                # 446 tests
 #   make demo-ch5            # full working agent end-to-end
 #   make example-research    # research-assistant example end-to-end
 #   make bundle              # tar the repo for sharing
@@ -500,6 +500,7 @@ typecheck: ## Enforce mypy on currently clean public runtime modules
 		$(PKG_DIR)/orchestrator/worker_factory.py \
 		$(PKG_DIR)/planner \
 		$(PKG_DIR)/providers \
+		$(PKG_DIR)/repository \
 		$(PKG_DIR)/runtime \
 		$(PKG_DIR)/tickets \
 		$(PKG_DIR)/voice

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ sovereign-agent/
 ├── chapters/             # 5 tutorial chapters (minitorch-style, fill in the TODOs)
 ├── examples/             # 8 reference scenarios (research, code review, HITL, etc.)
 ├── docs/                 # architecture, API stability, deployment
-└── tests/                # 428 collected tests — library + chapters + examples
+└── tests/                # 446 collected tests — library + chapters + examples
 ```
 
 - **If you want to ship an agent today** → read `src/sovereign_agent/` and pick scenarios from `examples/`
@@ -320,7 +320,7 @@ The Makefile is also the documentation for the release workflow:
 ```
 make doctor           # tabular status — Python, uv, .env, deps, imports, CI
 make preflight        # lint + drift + pytest collection + demo importability
-make test             # full suite (428 collected: 427 pass, 1 skip)
+make test             # full suite (446 collected: 445 pass, 1 skip)
 make ci-real-estimate # cost preview for a full ci-real run (no API calls)
 make ci-real          # run every -real scenario against a live LLM
 make pre-publish      # audit for secrets, PII, forbidden files before public push
@@ -350,13 +350,13 @@ Override via `SOVEREIGN_AGENT_DATA_DIR=<path>`.
 
 **v0.2.0 alpha, with unreleased v0.3 work on `main`.** PyPI has one release
 (`0.2.0`); `pyproject.toml` still declares `0.2.0`. The published 0.2.0 semver
-surface was 67 symbols. The working tree now exports **100** symbols in
-`sovereign_agent.__all__` — the 33 additions are unreleased v0.3 work and are not
+surface was 67 symbols. The working tree now exports **119** symbols in
+`sovereign_agent.__all__` — the 52 additions are unreleased v0.3 work and are not
 covered by the 0.2.x stability promise. See [`docs/API.md`](docs/API.md) for the
 full contract and the symbol-by-symbol breakdown.
 
 - ✅ Framework: sessions, tickets, IPC, parallelism, isolation, resume, verifiers, HITL
-- ✅ 428 tests collected — 427 pass, 1 skipped (library + chapters + integration)
+- ✅ 446 tests collected — 445 pass, 1 skipped (library + chapters + integration)
 - ✅ 8 reference scenarios, all with dataflow integrity checks
 - ✅ 5 tutorial chapters, drift-checked against production code in CI
 - 🚧 Voice pipeline, observability backends (Evidently/OTel) — skeletons, not implementations

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
 
 !!! warning "The tree is ahead of the last release"
     The only published release is **0.2.0**, whose semver surface was **67**
-    symbols. The working tree exports **100**. The 33 extra symbols are unreleased
+    symbols. The working tree exports **119**. The 52 extra symbols are unreleased
     v0.3 work and carry **no** stability promise until v0.3.0 is tagged. Both
     sets are listed below, separately, so you can tell which is which.
 
@@ -98,7 +98,7 @@ Category | Symbols
 
 ---
 
-## The 33 unreleased additions (in-tree, not covered)
+## The 52 unreleased additions (in-tree, not covered)
 
 These are in `sovereign_agent.__all__` on `main` but were not in the published
 0.2.0 surface. They may be renamed, resignatured, or removed before v0.3.0 is
@@ -110,6 +110,7 @@ Category | Symbols
 **Plugin registries** (v0.3 M3) | `Plugin`, `Registry`
 **Worker lifecycle** (v0.3 Unit 3) | `WorkerBackend`, `WorkerOutcome`, `BareWorker`, `SubprocessWorker`, `OSIsolatedWorker`, `DockerWorker`, `make_worker_backend`, `WorkerRequest`, `RuntimeHandle`, `InvocationSpec`, `ExecResult`, `CloseResult`, `ExecutionLifecycle`, `LifecycleResult`, `LifecycleState`, `LifecycleTimeouts`, `TerminalReason`
 **Agent providers** (v0.3 Units 2 and 4) | `AgentProvider`, `InvocationRequest`, `InvocationResult`, `NativeProvider`, `ProviderCapabilities`, `ProviderEvent`, `ProviderRegistry`, `PROVIDER_REGISTRY`, `CliProvider`, `CodexCliProvider`, `ClaudeCodeProvider`, `ProbeEvidence`, `ProviderUnavailable`
+**Repository execution** (v0.3 Unit 5) | `RepositoryManager`, `RepositoryConfig`, `RepositoryExecution`, `RepositoryIdentity`, `GitEvidence`, `DirtyWorktreePolicy`, `DeliveryState`, `DeliveryResult`, `DeliveryFailureReason`, `RepositoryLease`, `RepositoryLockManager`, `RepositoryError`, `RepositoryConfigurationError`, `RepositoryValidationError`, `RepositoryDirtyError`, `RepositoryCommandError`, `RepositoryLockTimeout`, `RepositoryLockLost`, `RepositoryDeliveryError`
 
 `DockerWorker` is an unavailable placeholder. It remains discoverable, but
 refuses during lifecycle preparation and its legacy `run_session()` raises

--- a/docs/v0.3-unit5-repository.md
+++ b/docs/v0.3-unit5-repository.md
@@ -1,0 +1,45 @@
+# v0.3 Unit 5 — governed repository execution
+
+Unit 5 resolves an opaque `RepositoryId` only through an explicit
+`RepositoryConfig`. It validates the configured checkout and all Git-facing
+names before invoking Git. Commands are fixed argv sequences executed with
+`shell=False`; refs beginning with options, malformed Git names, path
+traversals, and symlink escapes are rejected.
+
+`RepositoryManager.prepare()` defaults to `DirtyWorktreePolicy.FAIL`. An
+explicit `ALLOW` ignores operator-checkout changes, but never copies them into
+the execution. Work happens on a deterministic, collision-resistant
+`sovereign-agent/*` branch in a linked worktree below the versioned runtime
+`executions/` directory. The operator checkout's branch and files are not
+changed.
+
+## Ownership and cleanup
+
+One execution owns a repository at a time through a durable lease below
+`runtime/locks/repositories/`. Atomic directory acquisition, owner metadata,
+heartbeats, bounded waiting, and random generation tokens provide stale-owner
+recovery. Generation transitions are serialized by an OS file lock. Release
+and cleanup compare the generation token, so an old owner cannot remove a
+successor's lock. Cleanup is idempotent.
+
+This implementation uses `fcntl`, and therefore supports the Unix platforms
+targeted by the current worker runtime. A future Windows worker backend will
+need an equivalent native guard implementation.
+
+## Evidence and delivery
+
+`capture_evidence()` records immutable repository identity, redacted remote
+URL, base ref and SHA, execution branch, HEAD SHA, raw porcelain status,
+sorted changed paths, diff statistics, a SHA-256 digest of the binary patch
+plus untracked bytes, commits, worktree path, and artifact references.
+
+Delivery is disabled unless `enabled=True`. It pushes exactly
+`refs/heads/<execution branch>:refs/heads/<execution branch>`, without force,
+and refuses protected branches or any destination other than the execution
+branch. A separate `ls-remote --refs` verifies that the remote ref equals the
+local commit. `DeliveryResult` reports local completion independently from
+delivery state and uses stable failure reasons.
+
+Unit 5 intentionally does not perform Unit 7 admission, orchestration, or
+receipt issuance. Its immutable preparation, evidence, delivery, and cleanup
+objects are the seams Unit 7 can consume.

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -61,6 +61,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/orchestrator/worker_factory.py",
     "src/sovereign_agent/planner",
     "src/sovereign_agent/providers",
+    "src/sovereign_agent/repository",
     "src/sovereign_agent/runtime",
     "src/sovereign_agent/tickets",
     "src/sovereign_agent/voice",

--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -61,6 +61,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/orchestrator/worker_factory.py",
     "src/sovereign_agent/planner",
     "src/sovereign_agent/providers",
+    "src/sovereign_agent/repository",
     "src/sovereign_agent/runtime",
     "src/sovereign_agent/tickets",
     "src/sovereign_agent/voice",

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -149,6 +149,29 @@ from sovereign_agent.providers import (
 from sovereign_agent.registries import Plugin as Plugin
 from sovereign_agent.registries import Registry as Registry
 
+# Repository execution (v0.3 Unit 5)
+from sovereign_agent.repository import (
+    DeliveryFailureReason,
+    DeliveryResult,
+    DeliveryState,
+    DirtyWorktreePolicy,
+    GitEvidence,
+    RepositoryCommandError,
+    RepositoryConfig,
+    RepositoryConfigurationError,
+    RepositoryDeliveryError,
+    RepositoryDirtyError,
+    RepositoryError,
+    RepositoryExecution,
+    RepositoryIdentity,
+    RepositoryLease,
+    RepositoryLockLost,
+    RepositoryLockManager,
+    RepositoryLockTimeout,
+    RepositoryManager,
+    RepositoryValidationError,
+)
+
 # Scheduler (Decision 6)
 from sovereign_agent.scheduler import DriftCorrectedScheduler, ScheduledTask
 
@@ -249,6 +272,26 @@ __all__ = [
     "ProviderUnavailable",
     "ProbeEvidence",
     "PROVIDER_REGISTRY",
+    # repository execution (v0.3 Unit 5)
+    "DeliveryFailureReason",
+    "DeliveryResult",
+    "DeliveryState",
+    "DirtyWorktreePolicy",
+    "GitEvidence",
+    "RepositoryCommandError",
+    "RepositoryConfig",
+    "RepositoryConfigurationError",
+    "RepositoryDeliveryError",
+    "RepositoryDirtyError",
+    "RepositoryError",
+    "RepositoryExecution",
+    "RepositoryIdentity",
+    "RepositoryLease",
+    "RepositoryLockLost",
+    "RepositoryLockManager",
+    "RepositoryLockTimeout",
+    "RepositoryManager",
+    "RepositoryValidationError",
     "Executor",
     "ExecutorResult",
     "DefaultExecutor",

--- a/src/sovereign_agent/repository/__init__.py
+++ b/src/sovereign_agent/repository/__init__.py
@@ -1,0 +1,46 @@
+"""Governed native repository execution."""
+
+from .errors import (
+    RepositoryCommandError,
+    RepositoryConfigurationError,
+    RepositoryDeliveryError,
+    RepositoryDirtyError,
+    RepositoryError,
+    RepositoryLockLost,
+    RepositoryLockTimeout,
+    RepositoryValidationError,
+)
+from .locking import RepositoryLease, RepositoryLockManager
+from .manager import RepositoryManager
+from .models import (
+    DeliveryFailureReason,
+    DeliveryResult,
+    DeliveryState,
+    DirtyWorktreePolicy,
+    GitEvidence,
+    RepositoryConfig,
+    RepositoryExecution,
+    RepositoryIdentity,
+)
+
+__all__ = [
+    "DeliveryFailureReason",
+    "DeliveryResult",
+    "DeliveryState",
+    "DirtyWorktreePolicy",
+    "GitEvidence",
+    "RepositoryCommandError",
+    "RepositoryConfig",
+    "RepositoryConfigurationError",
+    "RepositoryDeliveryError",
+    "RepositoryDirtyError",
+    "RepositoryError",
+    "RepositoryExecution",
+    "RepositoryIdentity",
+    "RepositoryLease",
+    "RepositoryLockLost",
+    "RepositoryLockManager",
+    "RepositoryLockTimeout",
+    "RepositoryManager",
+    "RepositoryValidationError",
+]

--- a/src/sovereign_agent/repository/errors.py
+++ b/src/sovereign_agent/repository/errors.py
@@ -1,0 +1,55 @@
+"""Typed repository subsystem failures."""
+
+from __future__ import annotations
+
+
+class RepositoryError(RuntimeError):
+    """Base repository execution failure with a stable reason."""
+
+    reason = "repository_error"
+
+
+class RepositoryConfigurationError(RepositoryError):
+    reason = "repository_configuration"
+
+
+class RepositoryValidationError(RepositoryError, ValueError):
+    reason = "repository_validation"
+
+
+class RepositoryDirtyError(RepositoryError):
+    reason = "dirty_worktree"
+
+
+class RepositoryCommandError(RepositoryError):
+    reason = "git_command_failed"
+
+    def __init__(self, operation: str, stderr: str, returncode: int) -> None:
+        self.operation = operation
+        self.stderr = stderr
+        self.returncode = returncode
+        super().__init__(f"{operation} failed ({returncode}): {stderr}")
+
+
+class RepositoryLockTimeout(RepositoryError, TimeoutError):
+    reason = "lock_timeout"
+
+
+class RepositoryLockLost(RepositoryError):
+    reason = "lock_lost"
+
+
+class RepositoryDeliveryError(RepositoryError):
+    reason = "delivery_failed"
+
+
+__all__ = [
+    "RepositoryCommandError",
+    "RepositoryConfigurationError",
+    "RepositoryDeliveryError",
+    "RepositoryDirtyError",
+    "RepositoryError",
+    "RepositoryLockLost",
+    "RepositoryLockTimeout",
+    "RepositoryValidationError",
+]

--- a/src/sovereign_agent/repository/locking.py
+++ b/src/sovereign_agent/repository/locking.py
@@ -1,0 +1,211 @@
+"""Durable lease locks with fenced stale-owner recovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import shutil
+import socket
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from sovereign_agent._internal.atomic import atomic_write_json
+
+from .errors import RepositoryLockLost, RepositoryLockTimeout
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - exercised on Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - exercised on POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class RepositoryLease:
+    """Ownership handle. Its random token is the fencing generation."""
+
+    path: Path
+    token: str
+    owner: str
+    lease_seconds: float
+
+    @property
+    def metadata_path(self) -> Path:
+        return self.path / "owner.json"
+
+    def heartbeat(self) -> None:
+        with _guard(self.path):
+            try:
+                metadata = _read_metadata(self.metadata_path)
+            except (FileNotFoundError, ValueError) as exc:
+                raise RepositoryLockLost("repository lock no longer exists") from exc
+            if metadata.get("token") != self.token:
+                raise RepositoryLockLost("repository lock ownership changed")
+            metadata["heartbeat_ns"] = time.time_ns()
+            atomic_write_json(self.metadata_path, metadata)
+
+    def release(self) -> bool:
+        """Release only this generation; an old owner cannot remove a successor."""
+        with _guard(self.path):
+            try:
+                metadata = _read_metadata(self.metadata_path)
+            except (FileNotFoundError, ValueError):
+                return False
+            if metadata.get("token") != self.token:
+                return False
+            tombstone = self.path.with_name(f".released-{self.token}")
+            try:
+                self.path.rename(tombstone)
+            except FileNotFoundError:
+                return False
+        shutil.rmtree(tombstone, ignore_errors=True)
+        return True
+
+    def __enter__(self) -> RepositoryLease:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.release()
+
+
+class RepositoryLockManager:
+    def __init__(self, locks_root: Path) -> None:
+        self._root = Path(locks_root)
+
+    def acquire(
+        self,
+        key: str,
+        *,
+        timeout: float = 30.0,
+        lease_seconds: float = 60.0,
+        poll_interval: float = 0.05,
+        owner: str | None = None,
+    ) -> RepositoryLease:
+        if not key or "/" in key or "\\" in key or key in {".", ".."}:
+            raise ValueError("lock key must be one safe path component")
+        if timeout < 0 or lease_seconds <= 0 or poll_interval <= 0:
+            raise ValueError("invalid lock timing")
+        self._root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        lock_path = self._root / key
+        deadline = time.monotonic() + timeout
+        owner_name = owner or f"{socket.gethostname()}:{os.getpid()}"
+
+        while True:
+            token = secrets.token_hex(16)
+            acquired = False
+            with _guard(lock_path):
+                try:
+                    lock_path.mkdir(mode=0o700)
+                    acquired = True
+                except FileExistsError:
+                    self._recover_if_stale(lock_path, lease_seconds)
+                if acquired:
+                    metadata = {
+                        "token": token,
+                        "owner": owner_name,
+                        "pid": os.getpid(),
+                        "hostname": socket.gethostname(),
+                        "acquired_ns": time.time_ns(),
+                        "heartbeat_ns": time.time_ns(),
+                        "lease_seconds": lease_seconds,
+                    }
+                    try:
+                        atomic_write_json(lock_path / "owner.json", metadata)
+                    except BaseException:
+                        shutil.rmtree(lock_path, ignore_errors=True)
+                        raise
+            if not acquired:
+                if time.monotonic() >= deadline:
+                    raise RepositoryLockTimeout(f"timed out acquiring repository lock {key!r}")
+                time.sleep(min(poll_interval, max(0.0, deadline - time.monotonic())))
+                continue
+            return RepositoryLease(lock_path, token, owner_name, lease_seconds)
+
+    @staticmethod
+    def _recover_if_stale(lock_path: Path, lease_seconds: float) -> bool:
+        try:
+            metadata = _read_metadata(lock_path / "owner.json")
+            heartbeat_value = metadata["heartbeat_ns"]
+            if not isinstance(heartbeat_value, int):
+                raise TypeError("heartbeat_ns is not an integer")
+            heartbeat_ns = heartbeat_value
+            token = str(metadata["token"])
+            owner_lease = metadata.get("lease_seconds")
+            if (
+                not isinstance(owner_lease, (int, float))
+                or isinstance(owner_lease, bool)
+                or owner_lease <= 0
+            ):
+                raise TypeError("lease_seconds is not positive")
+        except (FileNotFoundError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+            # A newly-created lock may not have metadata yet; its mtime gets one lease.
+            try:
+                stale = time.time() - lock_path.stat().st_mtime > lease_seconds
+            except FileNotFoundError:
+                return True
+            token = "incomplete"
+        else:
+            stale = time.time_ns() - heartbeat_ns > int(owner_lease * 1_000_000_000)
+        if not stale:
+            return False
+        tombstone = lock_path.with_name(f".stale-{token}-{secrets.token_hex(4)}")
+        try:
+            lock_path.rename(tombstone)
+        except FileNotFoundError:
+            return True
+        shutil.rmtree(tombstone, ignore_errors=True)
+        return True
+
+
+def _read_metadata(path: Path) -> dict[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("lock metadata is not an object")
+    return data
+
+
+@contextmanager
+def _guard(lock_path: Path) -> Iterator[None]:
+    """Serialize generation transitions without making the guard itself ownership."""
+    guard_path = lock_path.with_suffix(lock_path.suffix + ".guard")
+    guard_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    fd = os.open(guard_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        _lock_fd(fd)
+        yield
+    finally:
+        _unlock_fd(fd)
+        os.close(fd)
+
+
+def _lock_fd(fd: int) -> None:
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        return
+    if msvcrt is None:  # pragma: no cover - supported Python platforms provide one
+        raise RuntimeError("no cross-process file locking implementation is available")
+    if os.fstat(fd).st_size == 0:
+        os.write(fd, b"\0")
+    os.lseek(fd, 0, os.SEEK_SET)
+    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+
+
+def _unlock_fd(fd: int) -> None:
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return
+    if msvcrt is None:  # pragma: no cover
+        return
+    os.lseek(fd, 0, os.SEEK_SET)
+    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+
+
+__all__ = ["RepositoryLease", "RepositoryLockManager"]

--- a/src/sovereign_agent/repository/manager.py
+++ b/src/sovereign_agent/repository/manager.py
@@ -1,0 +1,523 @@
+"""Native, argv-only Git repository execution."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+from sovereign_agent.contracts import ExecutionId, RepositoryId
+from sovereign_agent.contracts.redaction import REDACTED, redact_text
+from sovereign_agent.runtime import RuntimeRoot
+
+from .errors import (
+    RepositoryCommandError,
+    RepositoryConfigurationError,
+    RepositoryDirtyError,
+    RepositoryValidationError,
+)
+from .locking import RepositoryLease, RepositoryLockManager
+from .models import (
+    DeliveryFailureReason,
+    DeliveryResult,
+    DeliveryState,
+    DirtyWorktreePolicy,
+    GitEvidence,
+    RepositoryConfig,
+    RepositoryExecution,
+    RepositoryIdentity,
+)
+
+_SAFE_GIT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$")
+_SAFE_REMOTE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$")
+_FORBIDDEN_REF_PARTS = ("..", "@{", "//", "\\")
+_URL_USERINFO = re.compile(r"(?i)([a-z][a-z0-9+.-]*://)[^/@\s]+@")
+
+
+class RepositoryManager:
+    """Resolve governed repositories and isolate executions in Git worktrees."""
+
+    def __init__(self, runtime: RuntimeRoot, repositories: tuple[RepositoryConfig, ...]) -> None:
+        self.runtime = runtime.initialize()
+        self._repositories = {item.repository_id: item for item in repositories}
+        if len(self._repositories) != len(repositories):
+            raise RepositoryConfigurationError("duplicate repository_id")
+        self._locks = RepositoryLockManager(self.runtime.locks_dir / "repositories")
+
+    def resolve(self, repository_id: RepositoryId) -> RepositoryConfig:
+        try:
+            config = self._repositories[repository_id]
+        except KeyError as exc:
+            raise RepositoryConfigurationError(
+                f"repository is not governed: {repository_id}"
+            ) from exc
+        checkout = config.checkout
+        if checkout.is_symlink():
+            raise RepositoryValidationError("configured checkout must not be a symlink")
+        try:
+            resolved = checkout.resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise RepositoryConfigurationError("configured checkout does not exist") from exc
+        if not resolved.is_dir():
+            raise RepositoryConfigurationError("configured checkout is not a directory")
+        result = _git(
+            resolved, "rev-parse", "--is-inside-work-tree", operation="validate repository"
+        )
+        if result.stdout.strip() != b"true":
+            raise RepositoryValidationError("configured checkout is not a Git worktree")
+        return RepositoryConfig(
+            repository_id=config.repository_id,
+            checkout=resolved,
+            default_remote=config.default_remote,
+            protected_branches=config.protected_branches,
+        )
+
+    def prepare(
+        self,
+        repository_id: RepositoryId,
+        execution_id: ExecutionId,
+        *,
+        base_ref: str = "HEAD",
+        dirty_policy: DirtyWorktreePolicy = DirtyWorktreePolicy.FAIL,
+        lock_timeout: float = 30.0,
+        lease_seconds: float = 60.0,
+    ) -> RepositoryExecution:
+        config = self.resolve(repository_id)
+        _validate_ref(base_ref, "base_ref")
+        _validate_remote(config.default_remote)
+        lock_key = hashlib.sha256(str(repository_id).encode()).hexdigest()
+        lease = self._locks.acquire(
+            lock_key,
+            timeout=lock_timeout,
+            lease_seconds=lease_seconds,
+            owner=str(execution_id),
+        )
+        try:
+            status = _git(
+                config.checkout,
+                "status",
+                "--porcelain=v1",
+                "-z",
+                operation="inspect operator checkout",
+            ).stdout
+            if status and dirty_policy is DirtyWorktreePolicy.FAIL:
+                raise RepositoryDirtyError("operator checkout is dirty (policy=fail)")
+
+            base_sha = (
+                _git(
+                    config.checkout,
+                    "rev-parse",
+                    "--verify",
+                    "--end-of-options",
+                    f"{base_ref}^{{commit}}",
+                    operation="resolve base ref",
+                )
+                .stdout.decode("ascii")
+                .strip()
+            )
+            branch = _execution_branch(repository_id, execution_id, base_sha)
+            relative = (
+                Path("repository-worktrees")
+                / hashlib.sha256(f"{repository_id}\0{execution_id}".encode()).hexdigest()[:24]
+            )
+            worktree = self.runtime.executions_dir / relative
+            _assert_beneath(worktree, self.runtime.executions_dir)
+            worktree.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+            if worktree.exists():
+                existing_sha = (
+                    _git(worktree, "rev-parse", "HEAD", operation="inspect existing worktree")
+                    .stdout.decode("ascii")
+                    .strip()
+                )
+                existing_branch = (
+                    _git(
+                        worktree,
+                        "symbolic-ref",
+                        "--short",
+                        "HEAD",
+                        operation="inspect existing branch",
+                    )
+                    .stdout.decode()
+                    .strip()
+                )
+                if existing_sha != base_sha or existing_branch != branch:
+                    raise RepositoryValidationError("execution worktree collision")
+            else:
+                branch_exists = (
+                    _git_optional(
+                        config.checkout,
+                        "show-ref",
+                        "--verify",
+                        "--quiet",
+                        f"refs/heads/{branch}",
+                    ).returncode
+                    == 0
+                )
+                args = (
+                    ("worktree", "add", str(worktree), branch)
+                    if branch_exists
+                    else ("worktree", "add", "-b", branch, str(worktree), base_sha)
+                )
+                _git(config.checkout, *args, operation="create execution worktree")
+            return RepositoryExecution(
+                repository_id=repository_id,
+                execution_id=execution_id,
+                source_checkout=config.checkout,
+                worktree_path=worktree,
+                base_ref=base_ref,
+                base_sha=base_sha,
+                branch=branch,
+                lock_token=lease.token,
+            )
+        except BaseException:
+            lease.release()
+            raise
+
+    def heartbeat(self, execution: RepositoryExecution) -> None:
+        self._lease(execution).heartbeat()
+
+    def resolve_relative_path(
+        self, execution: RepositoryExecution, relative_path: str | Path
+    ) -> Path:
+        rel = Path(relative_path)
+        if rel.is_absolute() or any(part in {"", ".", ".."} for part in rel.parts):
+            raise RepositoryValidationError("path must be a normalized relative path")
+        current = execution.worktree_path
+        for part in rel.parts:
+            current = current / part
+            if current.is_symlink():
+                raise RepositoryValidationError("repository path traverses a symlink")
+        _assert_beneath(current, execution.worktree_path)
+        return current
+
+    def capture_evidence(
+        self,
+        execution: RepositoryExecution,
+        *,
+        artifact_references: tuple[str, ...] = (),
+    ) -> GitEvidence:
+        self.heartbeat(execution)
+        config = self.resolve(execution.repository_id)
+        head = (
+            _git(execution.worktree_path, "rev-parse", "HEAD", operation="capture HEAD")
+            .stdout.decode("ascii")
+            .strip()
+        )
+        status = _git(
+            execution.worktree_path,
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            operation="capture status",
+        ).stdout
+        committed_paths = _nul_paths(
+            _git(
+                execution.worktree_path,
+                "diff",
+                "--name-only",
+                "-z",
+                f"{execution.base_sha}..HEAD",
+                operation="capture committed paths",
+            ).stdout
+        )
+        local_paths = _nul_paths(
+            _git(
+                execution.worktree_path,
+                "diff",
+                "--name-only",
+                "-z",
+                "HEAD",
+                operation="capture local paths",
+            ).stdout
+        )
+        untracked_paths = _nul_paths(
+            _git(
+                execution.worktree_path,
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+                "-z",
+                operation="capture untracked paths",
+            ).stdout
+        )
+        changed_paths = tuple(sorted(set(committed_paths + local_paths + untracked_paths)))
+        patch = _git(
+            execution.worktree_path,
+            "diff",
+            "--binary",
+            "--no-ext-diff",
+            execution.base_sha,
+            operation="capture patch",
+        ).stdout
+        digest = hashlib.sha256()
+        digest.update(patch)
+        for path_text in sorted(untracked_paths):
+            path = self.resolve_relative_path(execution, path_text)
+            digest.update(b"\0untracked\0")
+            digest.update(os.fsencode(path_text))
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+        diff_stat = _git(
+            execution.worktree_path,
+            "diff",
+            "--stat",
+            "--no-color",
+            execution.base_sha,
+            operation="capture diff stat",
+        ).stdout
+        commits_raw = _git(
+            execution.worktree_path,
+            "log",
+            "--format=%H",
+            f"{execution.base_sha}..HEAD",
+            operation="capture commits",
+        ).stdout
+        remote_url = _git_optional(config.checkout, "remote", "get-url", config.default_remote)
+        return GitEvidence(
+            identity=RepositoryIdentity(
+                repository_id=execution.repository_id,
+                checkout=str(config.checkout),
+                remote_name=config.default_remote if remote_url.returncode == 0 else None,
+                remote_url=(
+                    _redact_remote(remote_url.stdout.decode(errors="replace").strip())
+                    if remote_url.returncode == 0
+                    else None
+                ),
+            ),
+            base_ref=execution.base_ref,
+            base_sha=execution.base_sha,
+            execution_branch=execution.branch,
+            head_sha=head,
+            status_porcelain=status,
+            changed_paths=changed_paths,
+            diff_stat=diff_stat,
+            patch_sha256=digest.hexdigest(),
+            commits=tuple(line for line in commits_raw.decode("ascii").splitlines() if line),
+            worktree_path=str(execution.worktree_path),
+            artifact_references=tuple(artifact_references),
+        )
+
+    def deliver(
+        self,
+        execution: RepositoryExecution,
+        *,
+        enabled: bool = False,
+        remote: str | None = None,
+        remote_branch: str | None = None,
+    ) -> DeliveryResult:
+        self.heartbeat(execution)
+        head = (
+            _git(execution.worktree_path, "rev-parse", "HEAD", operation="resolve delivery SHA")
+            .stdout.decode("ascii")
+            .strip()
+        )
+        if not enabled:
+            return DeliveryResult(True, DeliveryState.NOT_REQUESTED, head)
+        config = self.resolve(execution.repository_id)
+        selected_remote = remote or config.default_remote
+        selected_branch = remote_branch or execution.branch
+        try:
+            _validate_remote(selected_remote)
+            _validate_ref(selected_branch, "remote_branch")
+        except RepositoryValidationError as exc:
+            return DeliveryResult(
+                True,
+                DeliveryState.FAILED,
+                head,
+                selected_remote,
+                failure_reason=DeliveryFailureReason.INVALID_REMOTE,
+                detail=str(exc),
+            )
+        protected = set(config.protected_branches)
+        if selected_branch in protected or selected_branch != execution.branch:
+            return DeliveryResult(
+                True,
+                DeliveryState.FAILED,
+                head,
+                selected_remote,
+                f"refs/heads/{selected_branch}",
+                failure_reason=DeliveryFailureReason.PROTECTED_BRANCH,
+            )
+        remote_ref = f"refs/heads/{selected_branch}"
+        push = _git_optional(
+            execution.worktree_path,
+            "push",
+            "--porcelain",
+            selected_remote,
+            f"refs/heads/{execution.branch}:{remote_ref}",
+        )
+        if push.returncode != 0:
+            return DeliveryResult(
+                True,
+                DeliveryState.FAILED,
+                head,
+                selected_remote,
+                remote_ref,
+                failure_reason=DeliveryFailureReason.PUSH_REJECTED,
+                detail=_redact_diagnostic(push.stderr.decode(errors="replace").strip()),
+            )
+        verify = _git_optional(
+            execution.worktree_path,
+            "ls-remote",
+            "--refs",
+            selected_remote,
+            remote_ref,
+        )
+        records = verify.stdout.decode("ascii", errors="replace").splitlines()
+        remote_sha = next(
+            (
+                line.split()[0]
+                for line in records
+                if len(line.split()) == 2 and line.split()[1] == remote_ref
+            ),
+            None,
+        )
+        if remote_sha is None:
+            reason = DeliveryFailureReason.REMOTE_REF_MISSING
+        elif remote_sha != head:
+            reason = DeliveryFailureReason.REMOTE_SHA_MISMATCH
+        else:
+            return DeliveryResult(
+                True,
+                DeliveryState.VERIFIED,
+                head,
+                selected_remote,
+                remote_ref,
+                remote_sha,
+            )
+        return DeliveryResult(
+            True,
+            DeliveryState.FAILED,
+            head,
+            selected_remote,
+            remote_ref,
+            remote_sha,
+            reason,
+        )
+
+    def cleanup(self, execution: RepositoryExecution, *, delete_branch: bool = True) -> bool:
+        lease = self._lease(execution)
+        if not execution.worktree_path.exists() and not lease.metadata_path.exists():
+            return False
+        lease.heartbeat()
+        removed = False
+        try:
+            if execution.worktree_path.exists():
+                result = _git_optional(
+                    execution.source_checkout,
+                    "worktree",
+                    "remove",
+                    "--force",
+                    str(execution.worktree_path),
+                )
+                if result.returncode != 0:
+                    raise RepositoryCommandError(
+                        "remove execution worktree",
+                        result.stderr.decode(errors="replace").strip(),
+                        result.returncode,
+                    )
+                removed = True
+            _git_optional(execution.source_checkout, "worktree", "prune")
+            if delete_branch:
+                _git_optional(
+                    execution.source_checkout,
+                    "branch",
+                    "-D",
+                    "--",
+                    execution.branch,
+                )
+            return removed
+        finally:
+            lease.release()
+
+    def _lease(self, execution: RepositoryExecution) -> RepositoryLease:
+        key = hashlib.sha256(str(execution.repository_id).encode()).hexdigest()
+        return RepositoryLease(
+            self.runtime.locks_dir / "repositories" / key,
+            execution.lock_token,
+            str(execution.execution_id),
+            60.0,
+        )
+
+
+def _git(cwd: Path, *args: str, operation: str) -> subprocess.CompletedProcess[bytes]:
+    result = _git_optional(cwd, *args)
+    if result.returncode:
+        raise RepositoryCommandError(
+            operation,
+            _redact_diagnostic(result.stderr.decode(errors="replace").strip()),
+            result.returncode,
+        )
+    return result
+
+
+def _git_optional(cwd: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ("git", "-C", os.fspath(cwd), *args),
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        check=False,
+        shell=False,
+        env={**os.environ, "GIT_TERMINAL_PROMPT": "0", "LC_ALL": "C"},
+    )
+
+
+def _validate_ref(value: str, label: str) -> None:
+    if (
+        not value
+        or value.startswith("-")
+        or value.startswith("/")
+        or value.endswith(("/", "."))
+        or not _SAFE_GIT_NAME.fullmatch(value)
+        or any(part in value for part in _FORBIDDEN_REF_PARTS)
+        or any(char in value for char in " ~^:?*[")
+    ):
+        raise RepositoryValidationError(f"unsafe {label}: {value!r}")
+
+
+def _validate_remote(value: str) -> None:
+    if not _SAFE_REMOTE.fullmatch(value) or value in {".", ".."}:
+        raise RepositoryValidationError(f"unsafe remote name: {value!r}")
+
+
+def _execution_branch(repository_id: RepositoryId, execution_id: ExecutionId, base_sha: str) -> str:
+    digest = hashlib.sha256(f"{repository_id}\0{execution_id}\0{base_sha}".encode()).hexdigest()[
+        :16
+    ]
+    return f"sovereign-agent/{digest}"
+
+
+def _assert_beneath(candidate: Path, root: Path) -> None:
+    root_resolved = root.resolve()
+    try:
+        candidate.resolve(strict=False).relative_to(root_resolved)
+    except ValueError as exc:
+        raise RepositoryValidationError("path escapes governed root") from exc
+
+
+def _nul_paths(value: bytes) -> tuple[str, ...]:
+    return tuple(os.fsdecode(part) for part in value.split(b"\0") if part)
+
+
+def _redact_remote(remote: str) -> str:
+    parsed = urlsplit(remote)
+    if parsed.scheme and parsed.netloc:
+        hostname = parsed.hostname or ""
+        if parsed.port is not None:
+            hostname = f"{hostname}:{parsed.port}"
+        return urlunsplit((parsed.scheme, hostname, parsed.path, "", ""))
+    if "@" in remote and ":" in remote.split("@", 1)[1]:
+        return remote.split("@", 1)[1]
+    return remote
+
+
+def _redact_diagnostic(value: str) -> str:
+    return redact_text(_URL_USERINFO.sub(lambda match: f"{match.group(1)}{REDACTED}@", value))
+
+
+__all__ = ["RepositoryManager"]

--- a/src/sovereign_agent/repository/models.py
+++ b/src/sovereign_agent/repository/models.py
@@ -1,0 +1,110 @@
+"""Immutable contracts for governed repository execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from sovereign_agent.contracts import ExecutionId, RepositoryId
+
+
+class DirtyWorktreePolicy(StrEnum):
+    """Policy for an operator checkout that contains local changes."""
+
+    FAIL = "fail"
+    ALLOW = "allow"
+
+
+class DeliveryState(StrEnum):
+    """Delivery is deliberately separate from local completion."""
+
+    NOT_REQUESTED = "not_requested"
+    VERIFIED = "verified"
+    FAILED = "failed"
+
+
+class DeliveryFailureReason(StrEnum):
+    """Stable failure reasons suitable for receipts."""
+
+    PUSH_REJECTED = "push_rejected"
+    REMOTE_REF_MISSING = "remote_ref_missing"
+    REMOTE_SHA_MISMATCH = "remote_sha_mismatch"
+    PROTECTED_BRANCH = "protected_branch"
+    INVALID_REMOTE = "invalid_remote"
+
+
+@dataclass(frozen=True)
+class RepositoryConfig:
+    """Governance mapping from an opaque ID to one local checkout."""
+
+    repository_id: RepositoryId
+    checkout: Path
+    default_remote: str = "origin"
+    protected_branches: tuple[str, ...] = ("main", "master")
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "checkout", Path(self.checkout))
+        object.__setattr__(self, "protected_branches", tuple(self.protected_branches))
+
+
+@dataclass(frozen=True)
+class RepositoryIdentity:
+    repository_id: RepositoryId
+    checkout: str
+    remote_name: str | None
+    remote_url: str | None
+
+
+@dataclass(frozen=True)
+class GitEvidence:
+    """Byte-stable evidence captured at a repository boundary."""
+
+    identity: RepositoryIdentity
+    base_ref: str
+    base_sha: str
+    execution_branch: str
+    head_sha: str
+    status_porcelain: bytes
+    changed_paths: tuple[str, ...]
+    diff_stat: bytes
+    patch_sha256: str
+    commits: tuple[str, ...]
+    worktree_path: str
+    artifact_references: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RepositoryExecution:
+    repository_id: RepositoryId
+    execution_id: ExecutionId
+    source_checkout: Path
+    worktree_path: Path
+    base_ref: str
+    base_sha: str
+    branch: str
+    lock_token: str
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    local_complete: bool
+    state: DeliveryState
+    local_sha: str
+    remote: str | None = None
+    remote_ref: str | None = None
+    verified_sha: str | None = None
+    failure_reason: DeliveryFailureReason | None = None
+    detail: str | None = None
+
+
+__all__ = [
+    "DeliveryFailureReason",
+    "DeliveryResult",
+    "DeliveryState",
+    "DirtyWorktreePolicy",
+    "GitEvidence",
+    "RepositoryConfig",
+    "RepositoryExecution",
+    "RepositoryIdentity",
+]

--- a/tests/repository/test_repository_manager.py
+++ b/tests/repository/test_repository_manager.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from sovereign_agent.contracts import ExecutionId, RepositoryId
+from sovereign_agent.repository import (
+    DeliveryFailureReason,
+    DeliveryState,
+    DirtyWorktreePolicy,
+    RepositoryConfig,
+    RepositoryDirtyError,
+    RepositoryLockManager,
+    RepositoryLockTimeout,
+    RepositoryManager,
+    RepositoryValidationError,
+)
+from sovereign_agent.runtime import RuntimeRoot
+
+
+def git(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", "-C", str(path), *args),
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.invalid",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.invalid",
+            "LC_ALL": "C",
+        },
+    )
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> tuple[Path, Path]:
+    bare = tmp_path / "remote.git"
+    subprocess.run(("git", "init", "--bare", str(bare)), check=True, capture_output=True)
+    checkout = tmp_path / "checkout"
+    subprocess.run(("git", "init", "-b", "main", str(checkout)), check=True, capture_output=True)
+    (checkout / "tracked.txt").write_text("base\n")
+    git(checkout, "add", "tracked.txt")
+    git(checkout, "commit", "-m", "base")
+    git(checkout, "remote", "add", "origin", str(bare))
+    git(checkout, "push", "-u", "origin", "main")
+    return checkout, bare
+
+
+def manager(tmp_path: Path, checkout: Path) -> RepositoryManager:
+    return RepositoryManager(
+        RuntimeRoot(tmp_path / "runtime"),
+        (RepositoryConfig(RepositoryId("repo"), checkout),),
+    )
+
+
+def test_clean_prepare_isolated_and_cleanup_idempotent(
+    tmp_path: Path, repository: tuple[Path, Path]
+) -> None:
+    checkout, _ = repository
+    subject = manager(tmp_path, checkout)
+    execution = subject.prepare(RepositoryId("repo"), ExecutionId("exec-1"))
+    assert execution.worktree_path != checkout
+    assert execution.worktree_path.is_dir()
+    assert git(checkout, "branch", "--show-current").stdout.strip() == "main"
+    (execution.worktree_path / "tracked.txt").write_text("changed\n")
+    assert (checkout / "tracked.txt").read_text() == "base\n"
+    assert subject.cleanup(execution)
+    assert not subject.cleanup(execution)
+
+
+def test_dirty_checkout_fails_closed_but_can_be_explicitly_allowed(
+    tmp_path: Path, repository: tuple[Path, Path]
+) -> None:
+    checkout, _ = repository
+    (checkout / "tracked.txt").write_text("operator change\n")
+    subject = manager(tmp_path, checkout)
+    with pytest.raises(RepositoryDirtyError):
+        subject.prepare(RepositoryId("repo"), ExecutionId("fail"))
+    execution = subject.prepare(
+        RepositoryId("repo"),
+        ExecutionId("allow"),
+        dirty_policy=DirtyWorktreePolicy.ALLOW,
+    )
+    assert (execution.worktree_path / "tracked.txt").read_text() == "base\n"
+    subject.cleanup(execution)
+
+
+@pytest.mark.parametrize(
+    "bad_ref", ["--upload-pack=evil", "../main", "main..evil", "x@{0}", "x y", "/main"]
+)
+def test_malicious_refs_are_rejected(
+    tmp_path: Path, repository: tuple[Path, Path], bad_ref: str
+) -> None:
+    checkout, _ = repository
+    with pytest.raises(RepositoryValidationError):
+        manager(tmp_path, checkout).prepare(
+            RepositoryId("repo"), ExecutionId("bad"), base_ref=bad_ref
+        )
+
+
+def test_path_traversal_and_symlink_escape_rejected(
+    tmp_path: Path, repository: tuple[Path, Path]
+) -> None:
+    checkout, _ = repository
+    subject = manager(tmp_path, checkout)
+    execution = subject.prepare(RepositoryId("repo"), ExecutionId("paths"))
+    with pytest.raises(RepositoryValidationError):
+        subject.resolve_relative_path(execution, "../outside")
+    (execution.worktree_path / "escape").symlink_to(tmp_path)
+    with pytest.raises(RepositoryValidationError):
+        subject.resolve_relative_path(execution, "escape/file")
+    subject.cleanup(execution)
+
+
+def test_lock_wait_is_bounded_and_release_explicit(tmp_path: Path) -> None:
+    locks = RepositoryLockManager(tmp_path / "locks")
+    first = locks.acquire("repo", timeout=0.1)
+    with pytest.raises(RepositoryLockTimeout):
+        locks.acquire("repo", timeout=0.05, poll_interval=0.01)
+    assert first.release()
+    assert not first.release()
+    assert locks.acquire("repo", timeout=0.1).release()
+
+
+def test_stale_takeover_is_fenced_from_old_release(tmp_path: Path) -> None:
+    locks = RepositoryLockManager(tmp_path / "locks")
+    old = locks.acquire("repo", lease_seconds=0.01)
+    metadata = json.loads(old.metadata_path.read_text())
+    metadata["heartbeat_ns"] = time.time_ns() - 10_000_000_000
+    old.metadata_path.write_text(json.dumps(metadata))
+    new = locks.acquire("repo", timeout=0.2, lease_seconds=0.01)
+    assert old.release() is False
+    new.heartbeat()
+    assert new.release()
+
+
+def test_contender_cannot_shorten_current_owners_lease(tmp_path: Path) -> None:
+    locks = RepositoryLockManager(tmp_path / "locks")
+    owner = locks.acquire("repo", lease_seconds=1.0)
+    metadata = json.loads(owner.metadata_path.read_text())
+    metadata["heartbeat_ns"] = time.time_ns() - 50_000_000
+    owner.metadata_path.write_text(json.dumps(metadata))
+    with pytest.raises(RepositoryLockTimeout):
+        locks.acquire(
+            "repo",
+            timeout=0.03,
+            lease_seconds=0.01,
+            poll_interval=0.005,
+        )
+    assert owner.release()
+
+
+def test_evidence_is_deterministic_and_redacts_remote_credentials(
+    tmp_path: Path, repository: tuple[Path, Path]
+) -> None:
+    checkout, _ = repository
+    git(checkout, "remote", "set-url", "origin", "https://user:secret@example.invalid/repo.git")
+    subject = manager(tmp_path, checkout)
+    execution = subject.prepare(RepositoryId("repo"), ExecutionId("evidence"))
+    (execution.worktree_path / "new.txt").write_bytes(b"stable\n")
+    first = subject.capture_evidence(execution)
+    second = subject.capture_evidence(execution)
+    assert first == second
+    assert first.changed_paths == ("new.txt",)
+    assert first.patch_sha256 == second.patch_sha256
+    assert first.identity.remote_url == "https://example.invalid/repo.git"
+    subject.cleanup(execution)
+
+
+def test_push_verifies_exact_execution_ref(tmp_path: Path, repository: tuple[Path, Path]) -> None:
+    checkout, bare = repository
+    subject = manager(tmp_path, checkout)
+    execution = subject.prepare(RepositoryId("repo"), ExecutionId("push"))
+    (execution.worktree_path / "tracked.txt").write_text("delivery\n")
+    git(execution.worktree_path, "add", "tracked.txt")
+    git(execution.worktree_path, "commit", "-m", "delivery")
+    result = subject.deliver(execution, enabled=True)
+    assert result.state is DeliveryState.VERIFIED
+    assert result.verified_sha == result.local_sha
+    assert (
+        git(bare, "rev-parse", f"refs/heads/{execution.branch}").stdout.strip() == result.local_sha
+    )
+    subject.cleanup(execution)
+
+
+@pytest.mark.parametrize(
+    ("hook_body", "reason"),
+    [
+        (
+            'while read -r old new ref; do git update-ref "$ref" "$(git rev-parse refs/heads/main)"; done\n',
+            DeliveryFailureReason.REMOTE_SHA_MISMATCH,
+        ),
+        (
+            'while read -r old new ref; do git update-ref -d "$ref"; done\n',
+            DeliveryFailureReason.REMOTE_REF_MISSING,
+        ),
+    ],
+)
+def test_delivery_detects_wrong_or_missing_remote_ref(
+    tmp_path: Path,
+    repository: tuple[Path, Path],
+    hook_body: str,
+    reason: DeliveryFailureReason,
+) -> None:
+    checkout, bare = repository
+    hook = bare / "hooks" / "post-receive"
+    hook.write_text("#!/bin/sh\n" + hook_body)
+    hook.chmod(0o700)
+    subject = manager(tmp_path, checkout)
+    execution = subject.prepare(RepositoryId("repo"), ExecutionId(f"verify-{reason}"))
+    (execution.worktree_path / "tracked.txt").write_text("delivery\n")
+    git(execution.worktree_path, "add", "tracked.txt")
+    git(execution.worktree_path, "commit", "-m", "delivery")
+    assert subject.deliver(execution, enabled=True).failure_reason is reason
+    subject.cleanup(execution)
+
+
+def test_delivery_defaults_off_and_refuses_protected_branch(
+    tmp_path: Path, repository: tuple[Path, Path]
+) -> None:
+    checkout, _ = repository
+    subject = manager(tmp_path, checkout)
+    execution = subject.prepare(RepositoryId("repo"), ExecutionId("protected"))
+    assert subject.deliver(execution).state is DeliveryState.NOT_REQUESTED
+    refused = subject.deliver(execution, enabled=True, remote_branch="main")
+    assert refused.failure_reason is DeliveryFailureReason.PROTECTED_BRANCH
+    subject.cleanup(execution)
+
+
+def test_non_fast_forward_push_is_refused_without_force(
+    tmp_path: Path, repository: tuple[Path, Path]
+) -> None:
+    checkout, bare = repository
+    subject = manager(tmp_path, checkout)
+    execution = subject.prepare(RepositoryId("repo"), ExecutionId("nff"))
+    git(execution.worktree_path, "push", "origin", f"HEAD:refs/heads/{execution.branch}")
+    other = tmp_path / "other"
+    subprocess.run(("git", "clone", str(bare), str(other)), check=True, capture_output=True)
+    git(other, "checkout", execution.branch)
+    (other / "other.txt").write_text("remote\n")
+    git(other, "add", "other.txt")
+    git(other, "commit", "-m", "remote advance")
+    git(other, "push", "origin", execution.branch)
+    (execution.worktree_path / "local.txt").write_text("local\n")
+    git(execution.worktree_path, "add", "local.txt")
+    git(execution.worktree_path, "commit", "-m", "local divergence")
+    result = subject.deliver(execution, enabled=True)
+    assert result.failure_reason is DeliveryFailureReason.PUSH_REJECTED
+    assert git(bare, "show", f"{execution.branch}:other.txt").stdout == "remote\n"
+    subject.cleanup(execution)


### PR DESCRIPTION
## Summary
- resolve governed repositories into execution-owned branches and worktrees with fail-closed input and dirty-state policies
- serialize repository ownership with heartbeat leases and fenced stale recovery
- capture deterministic redacted Git evidence and verify opt-in non-force delivery at the exact remote SHA

## Test plan
- [x] `make ci` (445 passed, 1 skipped)
- [x] 18 local-only repository tests
- [x] current Ruff format/lint over source, tests, examples, scripts, and tools
- [x] mypy over 60 enforced runtime modules
- [x] public export count and documentation agree at 119

Stacked on #7.

Made with [Cursor](https://cursor.com)