### PR TITLE
feat(execution): compose governed end-to-end flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,16 +40,23 @@ a feature-branch tip rather than the pre-v0.3 state of `main`.
   opt-in non-force delivery with exact remote-SHA verification. See
   `docs/v0.3-unit5-repository.md`.
 - Unit 6 persistent seat registry and durable local relay: immutable
-  registration identity, atomic heartbeats, liveness inspection, validated
-  local addressing, idempotent envelopes, ordered fenced claims, ack/nack,
-  bounded backoff, lease recovery, dead letters, acknowledgement records and
-  explicit corruption quarantine. See `docs/v0.3-unit6-registry-relay.md`.
+  registration identity (including sovereign-session and provider-session
+  bindings), atomic heartbeats, liveness inspection, validated local
+  addressing, conversation/reply envelopes, artifact references, expiry,
+  idempotent enqueue, ordered fenced claims, ack/nack, bounded backoff,
+  lease recovery, dead letters, acknowledgement records and explicit
+  corruption quarantine. See `docs/v0.3-unit6-registry-relay.md`.
+- Unit 7 governed execution handshake: typed `GovernedExecutionRequest` /
+  `ExecutionReceipt` fields, admission that refuses before invocation,
+  repository execution under lock, provider/worker composition, and CLI
+  `seat`/`execute`/`execution`/`receipt`/`relay` commands (with `governed`
+  aliases). See `docs/v0.3-unit7-governed-execution.md`.
 - `LivenessMonitor` — stalled-session detection and heartbeat. Importable but not
   in `__all__`.
 - Move to `src/` layout.
 
-`sovereign_agent.__all__` now has 143 symbols, up from the 67 that shipped in
-0.2.0. The 76 additions carry no stability promise until 0.3.0 is tagged.
+`sovereign_agent.__all__` now has 152 symbols, up from the 67 that shipped in
+0.2.0. The 85 additions carry no stability promise until 0.3.0 is tagged.
 
 ### Documentation and truth repair
 
@@ -57,9 +64,9 @@ a feature-branch tip rather than the pre-v0.3 state of `main`.
   `pyproject.toml` URLs, `mkdocs.yml`, and the docs tree. Old
   `sovereignagents/...` links still resolve by GitHub redirect but are no longer
   canonical.
-- Corrected test-count claims: the suite collects **457** tests (456 pass, 1
+- Corrected test-count claims: the suite collects **477** tests (476 pass, 1
   skipped). Previous docs claimed 267, 220, and 120 in different places.
-- Corrected public-API claims: **143** symbols in `__all__`, of which 67 are the
+- Corrected public-API claims: **152** symbols in `__all__`, of which 67 are the
   stable 0.2.0 surface. `docs/API.md` now lists both sets separately, and names
   the v0.3 symbols that are importable but not in `__all__`.
 - Removed links to files that do not exist: `docs/class-slides.md`,

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #
 # Quick start:
 #   make first-run           # install uv project + dev tools + run preflight
-#   make test                # 457 tests
+#   make test                # 477 tests
 #   make demo-ch5            # full working agent end-to-end
 #   make example-research    # research-assistant example end-to-end
 #   make bundle              # tar the repo for sharing
@@ -488,6 +488,7 @@ typecheck: ## Enforce mypy on currently clean public runtime modules
 		$(PKG_DIR)/contracts \
 		$(PKG_DIR)/discovery.py \
 		$(PKG_DIR)/errors.py \
+		$(PKG_DIR)/execution \
 		$(PKG_DIR)/executor \
 		$(PKG_DIR)/halves \
 		$(PKG_DIR)/handoff \

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ sovereign-agent/
 ├── chapters/             # 5 tutorial chapters (minitorch-style, fill in the TODOs)
 ├── examples/             # 8 reference scenarios (research, code review, HITL, etc.)
 ├── docs/                 # architecture, API stability, deployment
-└── tests/                # 457 collected tests — library + chapters + examples
+└── tests/                # 477 collected tests — library + chapters + examples
 ```
 
 - **If you want to ship an agent today** → read `src/sovereign_agent/` and pick scenarios from `examples/`
@@ -320,7 +320,7 @@ The Makefile is also the documentation for the release workflow:
 ```
 make doctor           # tabular status — Python, uv, .env, deps, imports, CI
 make preflight        # lint + drift + pytest collection + demo importability
-make test             # full suite (457 collected: 456 pass, 1 skip)
+make test             # full suite (477 collected: 476 pass, 1 skip)
 make ci-real-estimate # cost preview for a full ci-real run (no API calls)
 make ci-real          # run every -real scenario against a live LLM
 make pre-publish      # audit for secrets, PII, forbidden files before public push
@@ -350,13 +350,13 @@ Override via `SOVEREIGN_AGENT_DATA_DIR=<path>`.
 
 **v0.2.0 alpha, with unreleased v0.3 work on `main`.** PyPI has one release
 (`0.2.0`); `pyproject.toml` still declares `0.2.0`. The published 0.2.0 semver
-surface was 67 symbols. The working tree now exports **143** symbols in
-`sovereign_agent.__all__` — the 76 additions are unreleased v0.3 work and are not
+surface was 67 symbols. The working tree now exports **152** symbols in
+`sovereign_agent.__all__` — the 85 additions are unreleased v0.3 work and are not
 covered by the 0.2.x stability promise. See [`docs/API.md`](docs/API.md) for the
 full contract and the symbol-by-symbol breakdown.
 
 - ✅ Framework: sessions, tickets, IPC, parallelism, isolation, resume, verifiers, HITL
-- ✅ 457 tests collected — 456 pass, 1 skipped (library + chapters + integration)
+- ✅ 477 tests collected — 476 pass, 1 skipped (library + chapters + integration)
 - ✅ 8 reference scenarios, all with dataflow integrity checks
 - ✅ 5 tutorial chapters, drift-checked against production code in CI
 - 🚧 Voice pipeline, observability backends (Evidently/OTel) — skeletons, not implementations

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
 
 !!! warning "The tree is ahead of the last release"
     The only published release is **0.2.0**, whose semver surface was **67**
-    symbols. The working tree exports **143**. The 76 extra symbols are unreleased
+    symbols. The working tree exports **152**. The 85 extra symbols are unreleased
     v0.3 work and carry **no** stability promise until v0.3.0 is tagged. Both
     sets are listed below, separately, so you can tell which is which.
 
@@ -98,7 +98,7 @@ Category | Symbols
 
 ---
 
-## The 76 unreleased additions (in-tree, not covered)
+## The 85 unreleased additions (in-tree, not covered)
 
 These are in `sovereign_agent.__all__` on `main` but were not in the published
 0.2.0 surface. They may be renamed, resignatured, or removed before v0.3.0 is
@@ -112,6 +112,7 @@ Category | Symbols
 **Agent providers** (v0.3 Units 2 and 4) | `AgentProvider`, `InvocationRequest`, `InvocationResult`, `NativeProvider`, `ProviderCapabilities`, `ProviderEvent`, `ProviderRegistry`, `PROVIDER_REGISTRY`, `CliProvider`, `CodexCliProvider`, `ClaudeCodeProvider`, `ProbeEvidence`, `ProviderUnavailable`
 **Repository execution** (v0.3 Unit 5) | `RepositoryManager`, `RepositoryConfig`, `RepositoryExecution`, `RepositoryIdentity`, `GitEvidence`, `DirtyWorktreePolicy`, `DeliveryState`, `DeliveryResult`, `DeliveryFailureReason`, `RepositoryLease`, `RepositoryLockManager`, `RepositoryError`, `RepositoryConfigurationError`, `RepositoryValidationError`, `RepositoryDirtyError`, `RepositoryCommandError`, `RepositoryLockTimeout`, `RepositoryLockLost`, `RepositoryDeliveryError`
 **Seat registry and relay** (v0.3 Unit 6) | `Seat`, `SeatInstance`, `SeatLifecycle`, `SeatRegistry`, `RuntimeAddress`, `RegistrationConflict`, `RegistryError`, `RegistryValidationError`, `RegistryCorruptionError`, `SeatInstanceNotFound`, `RelayMessage`, `DeliveryRecord`, `DeliveryStatus`, `ClaimedMessage`, `Acknowledgement`, `DurableRelay`, `Relay`, `RelayError`, `RelayValidationError`, `RelayAuthenticationError`, `RelayCorruptionError`, `DuplicateMessageConflict`, `MessageNotFound`, `LeaseLost`
+**Governed execution** (v0.3 Unit 7) | `AdmissionRejected`, `ExecutionNotFound`, `ExecutionStatus`, `GovernedExecutionEngine`, `GovernedExecutionRequest`, `ExecutionConstraints`, `ExecutionReceipt`, `ReceiptStatus`, `ReceiptTermination`
 
 `DockerWorker` is an unavailable placeholder. It remains discoverable, but
 refuses during lifecycle preparation and its legacy `run_session()` raises

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -175,6 +175,26 @@ from sovereign_agent import (
 
 Use `"subprocess"` where you would have reached for `"docker"`.
 
+## Governed execution (unreleased v0.3 Unit 7)
+
+```python
+from sovereign_agent import (
+    AdmissionRejected,
+    ExecutionReceipt,
+    ExecutionStatus,
+    GovernedExecutionEngine,
+    GovernedExecutionRequest,
+    ReceiptStatus,
+)
+```
+
+`GovernedExecutionEngine.run(request)` admits and executes one versioned request.
+Admission refusals and every later terminal class produce a finalized receipt.
+Zero Employee, not this engine, decides whether the receipt satisfies a governed
+obligation. `status`, `cancel`, and `receipt` expose durable execution control.
+An execution ID is an idempotency key: finalized retries return the existing
+immutable receipt.
+
 ## Plugin registries (unreleased v0.3)
 
 ```python

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,12 @@ branch in a work repo is invisible to everyone who is not already on that branch
 which is exactly the failure mode the split exists to prevent. So: no `SOW.md` in
 this tree, and no path in this tree that claims to be one.
 
+The governed handshake is the same split in runtime form. This repository
+validates request shape, capabilities, and technical evidence, then returns an
+immutable `ExecutionReceipt`. Zero Employee validates that receipt against
+doctrine (conformance / acceptance). Sovereign Agent does not set that bit.
+
+
 For the current release-readiness picture, read
 [CHANGELOG.md](https://github.com/zeroemployeeorg/sovereign-agent/blob/main/CHANGELOG.md)
 and [v0.3 non-goals](v0.3-non-goals.md). Those are maintained; a checklist buried

--- a/docs/v0.3-unit6-registry-relay.md
+++ b/docs/v0.3-unit6-registry-relay.md
@@ -4,20 +4,27 @@ Unit 6 adds two local, filesystem-backed primitives under the Unit 1
 `RuntimeRoot`.
 
 `SeatRegistry` keeps logical `Seat` identity separate from `SeatInstance`.
-Registration identity (seat, instance, provider, backend, capabilities and
-`local://` runtime address) is immutable. Heartbeats atomically replace only
-lifecycle, status and heartbeat timestamps. IDs are validated typed contracts;
-record filenames are SHA-256 derivations, so IDs never become paths. Registry
-updates use process-wide file locks and atomic replacement. Stale inspection
-never deletes registration identity.
+Registration identity (seat, instance, provider, backend, capabilities,
+`local://` runtime address, optional sovereign-session binding, optional
+provider-session binding, and optional capability-manifest artifact reference)
+is immutable. Heartbeats atomically replace only lifecycle, status and heartbeat
+timestamps. A provider session identifier is never treated as a seat-instance
+identity or runtime address. Two instances of the same seat type remain
+separately addressable. IDs are validated typed contracts; record filenames
+are SHA-256 derivations, so IDs never become paths. Registry updates use
+process-wide file locks and atomic replacement. Stale inspection never deletes
+registration identity.
 
-`DurableRelay` persists immutable JSON `RelayMessage` envelopes. Enqueue is
-idempotent by message ID and rejects conflicting reuse. Claims are ordered per
-recipient and carry random lease tokens as fencing generations. Ack and nack
-require the current owner and token. Expired leases recover for redelivery;
-nacks use bounded exponential backoff; exhausted messages become inspectable
-dead letters. Corrupt queue records are moved to an explicit quarantine and the
-operation fails closed.
+`DurableRelay` persists immutable JSON `RelayMessage` envelopes addressed to
+registered `local://` instances. Enqueue is idempotent by message ID and
+rejects conflicting reuse. Envelopes carry conversation and reply chains,
+acknowledgement requirement, artifact *references* (never copied bytes), and
+an optional expiry. Claims are ordered per recipient and carry random lease
+tokens as fencing generations. Ack and nack require the current owner and
+token. Expired leases recover for redelivery; message-level expiry and
+exhausted retries become inspectable dead letters that retain failure ground.
+Corrupt queue records are moved to an explicit quarantine and the operation
+fails closed. Restart reconstructs registrations and queues from disk.
 
 Sender and recipient checks prove only that the exact local runtime addresses
 are currently registered. This is not network authentication. Notification is

--- a/docs/v0.3-unit7-governed-execution.md
+++ b/docs/v0.3-unit7-governed-execution.md
@@ -1,0 +1,27 @@
+# v0.3 Unit 7 — governed execution handshake
+
+Unit 7 composes Units 1–6 into one admission-to-receipt path. Zero Employee
+sends a versioned `GovernedExecutionRequest`. Sovereign Agent returns a
+finalized `ExecutionReceipt`. Organizational acceptance (whether the receipt
+closes a governed obligation) is decided outside this repository.
+
+Admission validates shape, seat-instance registration and session binding,
+provider/worker capability evidence, repository preconditions, and lock
+ownership. Requested isolation that cannot be enforced is refused before
+`AgentProvider.invoke`. Docker remains unavailable.
+
+Every admitted attempt, including admission refusal, produces one append-only
+receipt. `termination` is independent of coarse `status`. Predicate flags
+record completion-signal, structured-result, technical-verification, and
+dataflow checks. There is no ZEO conformance bit. A local commit is produced;
+delivery is claimed only after remote containment when required.
+
+CLI names:
+
+- `sovereign-agent seat register`
+- `sovereign-agent execute --request`
+- `sovereign-agent execution status`
+- `sovereign-agent receipt show`
+- `sovereign-agent relay send|receive`
+
+`sovereign-agent governed …` remains an alias for the same engine.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,5 +49,6 @@ nav:
       - Overview: chapters/index.md
   - Deployment: deployment.md
   - Project:
+      - v0.3 Unit 7 Governed Execution: v0.3-unit7-governed-execution.md
       - v0.3 Non-Goals: v0.3-non-goals.md
       - Branch Consolidation (2026-08-22): branch-consolidation-2026-08-22.md

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -49,6 +49,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/contracts",
     "src/sovereign_agent/discovery.py",
     "src/sovereign_agent/errors.py",
+    "src/sovereign_agent/execution",
     "src/sovereign_agent/executor",
     "src/sovereign_agent/halves",
     "src/sovereign_agent/handoff",

--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -49,6 +49,7 @@ PUBLIC_RUNTIME_PATHS = [
     "src/sovereign_agent/contracts",
     "src/sovereign_agent/discovery.py",
     "src/sovereign_agent/errors.py",
+    "src/sovereign_agent/execution",
     "src/sovereign_agent/executor",
     "src/sovereign_agent/halves",
     "src/sovereign_agent/handoff",

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -4,8 +4,8 @@ Alpha. The declared version is 0.2.0 and that is the only release on PyPI,
 but this tree also carries unreleased v0.3 work (channels, plugin
 registries, worker-backend dispatch, liveness monitor).
 
-The 143 names in __all__ are the public API surface. Of those, 67 shipped in
-0.2.0 and are stable across 0.2.x; the 76 v0.3 additions carry no stability
+The 152 names in __all__ are the public API surface. Of those, 67 shipped in
+0.2.0 and are stable across 0.2.x; the 85 v0.3 additions carry no stability
 promise until 0.3.0 is tagged. Anything not in __all__ is internal and may
 change between any two releases -- including names that happen to be
 importable from this module, such as the channel adapter types and
@@ -34,6 +34,13 @@ from sovereign_agent.channels import OutboundMessage as OutboundMessage
 
 # Config
 from sovereign_agent.config import Config
+from sovereign_agent.contracts import (
+    ExecutionConstraints,
+    ExecutionReceipt,
+    GovernedExecutionRequest,
+    ReceiptStatus,
+    ReceiptTermination,
+)
 
 # Discovery (Pattern A)
 from sovereign_agent.discovery import Discoverable, DiscoverySchema, discoverable
@@ -47,6 +54,14 @@ from sovereign_agent.errors import (
     SystemError,
     ToolError,
     ValidationError,
+)
+
+# Governed end-to-end execution (v0.3 Unit 7)
+from sovereign_agent.execution import (
+    AdmissionRejected,
+    ExecutionNotFound,
+    ExecutionStatus,
+    GovernedExecutionEngine,
 )
 from sovereign_agent.executor import DefaultExecutor, Executor, ExecutorResult
 
@@ -304,6 +319,16 @@ __all__ = [
     "ProviderUnavailable",
     "ProbeEvidence",
     "PROVIDER_REGISTRY",
+    # governed execution (v0.3 Unit 7)
+    "AdmissionRejected",
+    "ExecutionNotFound",
+    "ExecutionStatus",
+    "GovernedExecutionEngine",
+    "GovernedExecutionRequest",
+    "ExecutionConstraints",
+    "ExecutionReceipt",
+    "ReceiptStatus",
+    "ReceiptTermination",
     # repository execution (v0.3 Unit 5)
     "DeliveryFailureReason",
     "DeliveryResult",

--- a/src/sovereign_agent/cli/__init__.py
+++ b/src/sovereign_agent/cli/__init__.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import typer
 
 from sovereign_agent.config import Config
+from sovereign_agent.execution.cli import register_execution_commands
 from sovereign_agent.observability.report import generate_session_report
 from sovereign_agent.orchestrator import Orchestrator, run_task
 from sovereign_agent.session.directory import (
@@ -33,6 +34,8 @@ app = typer.Typer(
 )
 sessions_app = typer.Typer(name="sessions", help="Session management subcommands.")
 app.add_typer(sessions_app, name="sessions")
+
+register_execution_commands(app)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sovereign_agent/contracts/__init__.py
+++ b/src/sovereign_agent/contracts/__init__.py
@@ -3,7 +3,13 @@
 from ._core import ContractValidationError, FrozenDict
 from .canonical import canonical_json_bytes
 from .capabilities import Capability, CapabilityManifest, EvidenceLevel
-from .execution import GovernedExecutionRequest
+from .execution import (
+    ExecutionConstraints,
+    GovernedExecutionRequest,
+    MutationPolicy,
+    NetworkPolicy,
+    SandboxMinimum,
+)
 from .ids import (
     ExecutionId,
     InvocationId,
@@ -16,8 +22,13 @@ from .ids import (
     WorkerHandleId,
 )
 from .receipts import (
+    CommitEvidence,
     ExecutionReceipt,
     ReceiptStatus,
+    ReceiptTermination,
+    RepositoryReceipt,
+    UsageRecord,
+    VerificationCommand,
     evidence_verified,
     lifecycle_complete,
 )
@@ -26,21 +37,30 @@ from .redaction import REDACTED, redact_json, redact_mapping, redact_text
 __all__ = [
     "Capability",
     "CapabilityManifest",
+    "CommitEvidence",
     "ContractValidationError",
     "EvidenceLevel",
+    "ExecutionConstraints",
     "ExecutionId",
     "ExecutionReceipt",
     "FrozenDict",
     "GovernedExecutionRequest",
     "InvocationId",
+    "MutationPolicy",
+    "NetworkPolicy",
     "ProviderSessionId",
     "RelayMessageId",
     "REDACTED",
     "ReceiptStatus",
+    "ReceiptTermination",
     "RepositoryId",
+    "RepositoryReceipt",
+    "SandboxMinimum",
     "SeatId",
     "SeatInstanceId",
     "SovereignSessionId",
+    "UsageRecord",
+    "VerificationCommand",
     "WorkerHandleId",
     "canonical_json_bytes",
     "evidence_verified",

--- a/src/sovereign_agent/contracts/execution.py
+++ b/src/sovereign_agent/contracts/execution.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import StrEnum
 from typing import Any, ClassVar
 
 from ._core import (
@@ -24,10 +26,188 @@ from .ids import (
     InvocationId,
     ProviderSessionId,
     RepositoryId,
+    SeatId,
     SeatInstanceId,
     SovereignSessionId,
     WorkerHandleId,
 )
+
+_PROTECTED_TRUNK = frozenset({"main", "master", "HEAD", "origin/main", "origin/master"})
+_SUPPORTED_EVIDENCE = frozenset(
+    {
+        "structured_result",
+        "verification_commands",
+        "commit_sha",
+        "remote_containment",
+    }
+)
+
+
+class MutationPolicy(StrEnum):
+    FORBIDDEN = "forbidden"
+    ALLOWED = "allowed"
+
+
+class SandboxMinimum(StrEnum):
+    NONE = "none"
+    BARE = "bare"
+    PROCESS = "process"
+    FILESYSTEM_ISOLATED = "filesystem-isolated"
+    NETWORK_RESTRICTED = "network-restricted"
+
+
+class NetworkPolicy(StrEnum):
+    UNKNOWN = "unknown"
+    UNRESTRICTED = "unrestricted"
+    RESTRICTED = "restricted"
+    DENIED = "denied"
+
+
+def _string_tuple(value: object, name: str) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise ContractValidationError(f"{name} must be an array of strings")
+    items = tuple(require_string(item, f"{name}[{index}]") for index, item in enumerate(value))
+    return items
+
+
+@dataclass(frozen=True)
+class ExecutionConstraints:
+    """Typed enforcement requested of Sovereign Agent, not organizational wisdom."""
+
+    trunk_mutation: MutationPolicy = MutationPolicy.FORBIDDEN
+    self_merge: MutationPolicy = MutationPolicy.FORBIDDEN
+    sandbox_minimum: SandboxMinimum = SandboxMinimum.NONE
+    network: NetworkPolicy = NetworkPolicy.UNKNOWN
+    max_invocations: int = 1
+    idle_timeout_seconds: int | None = None
+    dirty_worktree: str = "fail"
+    filesystem_isolation: bool = False
+    network_isolation: bool = False
+    preserve_on_failure: bool = True
+    structured_output: Any = False
+    timeouts: FrozenDict = field(default_factory=FrozenDict)
+    delivery_enabled: bool = False
+    delivery_remote: str | None = None
+    delivery_branch: str | None = None
+    unknown_fields: FrozenDict = field(default_factory=FrozenDict, repr=False)
+
+    _KNOWN: ClassVar[frozenset[str]] = frozenset(
+        {
+            "trunk_mutation",
+            "self_merge",
+            "sandbox_minimum",
+            "network",
+            "max_invocations",
+            "idle_timeout_seconds",
+            "dirty_worktree",
+            "filesystem_isolation",
+            "network_isolation",
+            "preserve_on_failure",
+            "structured_output",
+            "timeouts",
+            "delivery_enabled",
+            "delivery_remote",
+            "delivery_branch",
+        }
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "trunk_mutation", MutationPolicy(self.trunk_mutation))
+        object.__setattr__(self, "self_merge", MutationPolicy(self.self_merge))
+        object.__setattr__(self, "sandbox_minimum", SandboxMinimum(self.sandbox_minimum))
+        object.__setattr__(self, "network", NetworkPolicy(self.network))
+        if not isinstance(self.max_invocations, int) or isinstance(self.max_invocations, bool):
+            raise ContractValidationError("max_invocations must be an integer")
+        if self.max_invocations < 1:
+            raise ContractValidationError("max_invocations must be at least 1")
+        if self.idle_timeout_seconds is not None:
+            if not isinstance(self.idle_timeout_seconds, int) or isinstance(
+                self.idle_timeout_seconds, bool
+            ):
+                raise ContractValidationError("idle_timeout_seconds must be an integer")
+            if self.idle_timeout_seconds <= 0:
+                raise ContractValidationError("idle_timeout_seconds must be positive")
+        if self.dirty_worktree not in {"fail", "allow"}:
+            raise ContractValidationError("dirty_worktree must be 'fail' or 'allow'")
+        for name in (
+            "filesystem_isolation",
+            "network_isolation",
+            "preserve_on_failure",
+            "delivery_enabled",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise ContractValidationError(f"{name} must be a boolean")
+        object.__setattr__(
+            self,
+            "timeouts",
+            freeze_json(require_object(self.timeouts, "timeouts"), path="timeouts"),
+        )
+        object.__setattr__(self, "structured_output", freeze_json(self.structured_output))
+        for name in ("delivery_remote", "delivery_branch"):
+            value = getattr(self, name)
+            if value is not None:
+                require_string(value, name)
+        if (
+            self.trunk_mutation is MutationPolicy.ALLOWED
+            and self.sandbox_minimum is SandboxMinimum.FILESYSTEM_ISOLATED
+        ):
+            raise ContractValidationError(
+                "trunk mutation cannot be allowed under filesystem-isolated governed execution"
+            )
+        object.__setattr__(
+            self,
+            "unknown_fields",
+            freeze_json(require_object(self.unknown_fields, "unknown_fields")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        known: dict[str, Any] = {
+            "trunk_mutation": self.trunk_mutation.value,
+            "self_merge": self.self_merge.value,
+            "sandbox_minimum": self.sandbox_minimum.value,
+            "network": self.network.value,
+            "max_invocations": self.max_invocations,
+            "idle_timeout_seconds": self.idle_timeout_seconds,
+            "dirty_worktree": self.dirty_worktree,
+            "filesystem_isolation": self.filesystem_isolation,
+            "network_isolation": self.network_isolation,
+            "preserve_on_failure": self.preserve_on_failure,
+            "structured_output": thaw_json(self.structured_output),
+            "timeouts": thaw_json(self.timeouts),
+            "delivery_enabled": self.delivery_enabled,
+            "delivery_remote": self.delivery_remote,
+            "delivery_branch": self.delivery_branch,
+        }
+        return merge_unknown(known, self.unknown_fields)
+
+    @classmethod
+    def from_dict(cls, value: object) -> ExecutionConstraints:
+        data = require_object(value, "constraints")
+        known, unknown = split_known(data, cls._KNOWN)
+        return cls(
+            trunk_mutation=MutationPolicy(
+                require_string(known.get("trunk_mutation", "forbidden"), "trunk_mutation")
+            ),
+            self_merge=MutationPolicy(
+                require_string(known.get("self_merge", "forbidden"), "self_merge")
+            ),
+            sandbox_minimum=SandboxMinimum(
+                require_string(known.get("sandbox_minimum", "none"), "sandbox_minimum")
+            ),
+            network=NetworkPolicy(require_string(known.get("network", "unknown"), "network")),
+            max_invocations=int(known.get("max_invocations", 1)),
+            idle_timeout_seconds=known.get("idle_timeout_seconds"),
+            dirty_worktree=str(known.get("dirty_worktree", "fail")),
+            filesystem_isolation=bool(known.get("filesystem_isolation", False)),
+            network_isolation=bool(known.get("network_isolation", False)),
+            preserve_on_failure=bool(known.get("preserve_on_failure", True)),
+            structured_output=known.get("structured_output", False),
+            timeouts=freeze_json(require_object(known.get("timeouts", {}), "timeouts")),
+            delivery_enabled=bool(known.get("delivery_enabled", False)),
+            delivery_remote=known.get("delivery_remote"),
+            delivery_branch=known.get("delivery_branch"),
+            unknown_fields=unknown,
+        )
 
 
 @dataclass(frozen=True)
@@ -43,11 +223,22 @@ class GovernedExecutionRequest:
     repository_id: RepositoryId
     operation: str
     input: FrozenDict
-    governance: FrozenDict
     capability_manifest: CapabilityManifest
     requested_at: datetime
+    conversation_id: str
+    seat_type: SeatId
+    requested_by: str
+    authority_refs: tuple[str, ...]
+    work_artifact_refs: tuple[str, ...]
+    base_ref: str
+    branch: str
+    constraints: ExecutionConstraints = field(default_factory=ExecutionConstraints)
+    required_evidence: tuple[str, ...] = ()
+    acceptance_commands: tuple[tuple[str, ...], ...] = ()
+    predecessor_execution_id: ExecutionId | None = None
     provider_session_id: ProviderSessionId | None = None
     worker_handle_id: WorkerHandleId | None = None
+    governance: FrozenDict = field(default_factory=FrozenDict)
     schema_version: str = SCHEMA_VERSION
     unknown_fields: FrozenDict = field(default_factory=FrozenDict, repr=False)
 
@@ -66,6 +257,17 @@ class GovernedExecutionRequest:
             "governance",
             "capability_manifest",
             "requested_at",
+            "conversation_id",
+            "seat_type",
+            "requested_by",
+            "authority_refs",
+            "work_artifact_refs",
+            "base_ref",
+            "branch",
+            "constraints",
+            "required_evidence",
+            "acceptance_commands",
+            "predecessor_execution_id",
         }
     )
 
@@ -76,6 +278,7 @@ class GovernedExecutionRequest:
             ("execution_id", self.execution_id, ExecutionId),
             ("invocation_id", self.invocation_id, InvocationId),
             ("repository_id", self.repository_id, RepositoryId),
+            ("seat_type", self.seat_type, SeatId),
         )
         for name, value, expected in id_types:
             if not isinstance(value, expected):
@@ -88,7 +291,37 @@ class GovernedExecutionRequest:
             self.worker_handle_id, WorkerHandleId
         ):
             raise ContractValidationError("worker_handle_id must be WorkerHandleId or null")
+        if self.predecessor_execution_id is not None:
+            if not isinstance(self.predecessor_execution_id, ExecutionId):
+                raise ContractValidationError(
+                    "predecessor_execution_id must be ExecutionId or null"
+                )
+            if self.predecessor_execution_id == self.execution_id:
+                raise ContractValidationError("predecessor_execution_id cannot equal execution_id")
         require_string(self.operation, "operation")
+        require_string(self.conversation_id, "conversation_id")
+        require_string(self.requested_by, "requested_by")
+        require_string(self.base_ref, "base_ref")
+        require_string(self.branch, "branch")
+        object.__setattr__(
+            self, "authority_refs", _string_tuple(self.authority_refs, "authority_refs")
+        )
+        if not self.authority_refs:
+            raise ContractValidationError("authority_refs must not be empty")
+        object.__setattr__(
+            self, "work_artifact_refs", _string_tuple(self.work_artifact_refs, "work_artifact_refs")
+        )
+        object.__setattr__(
+            self, "required_evidence", _string_tuple(self.required_evidence, "required_evidence")
+        )
+        unknown_evidence = sorted(set(self.required_evidence) - _SUPPORTED_EVIDENCE)
+        if unknown_evidence:
+            raise ContractValidationError(
+                f"unsupported required_evidence: {', '.join(unknown_evidence)}"
+            )
+        object.__setattr__(self, "acceptance_commands", _command_tuple(self.acceptance_commands))
+        if not isinstance(self.constraints, ExecutionConstraints):
+            raise ContractValidationError("constraints must be ExecutionConstraints")
         if self.schema_version != self.SCHEMA_VERSION:
             raise ContractValidationError(
                 f"schema_version must be {self.SCHEMA_VERSION!r}, got {self.schema_version!r}"
@@ -107,6 +340,16 @@ class GovernedExecutionRequest:
                 require_object(self.unknown_fields, "unknown_fields"), path="unknown_fields"
             ),
         )
+        if self.constraints.trunk_mutation is MutationPolicy.FORBIDDEN:
+            if _is_protected_trunk(self.branch):
+                raise ContractValidationError("direct governed trunk mutation is forbidden")
+            if _is_protected_trunk(self.base_ref) and self.branch in _PROTECTED_TRUNK:
+                raise ContractValidationError("direct governed trunk mutation is forbidden")
+        if self.constraints.self_merge is MutationPolicy.ALLOWED:
+            if self.constraints.trunk_mutation is MutationPolicy.FORBIDDEN:
+                raise ContractValidationError(
+                    "self_merge cannot be allowed while trunk mutation is forbidden"
+                )
 
     def to_dict(self) -> dict[str, Any]:
         known: dict[str, Any] = {
@@ -121,12 +364,27 @@ class GovernedExecutionRequest:
             "worker_handle_id": (
                 str(self.worker_handle_id) if self.worker_handle_id is not None else None
             ),
+            "predecessor_execution_id": (
+                None
+                if self.predecessor_execution_id is None
+                else str(self.predecessor_execution_id)
+            ),
             "repository_id": str(self.repository_id),
             "operation": self.operation,
             "input": thaw_json(self.input),
             "governance": thaw_json(self.governance),
             "capability_manifest": self.capability_manifest.to_dict(),
             "requested_at": format_datetime(self.requested_at, "requested_at"),
+            "conversation_id": self.conversation_id,
+            "seat_type": str(self.seat_type),
+            "requested_by": self.requested_by,
+            "authority_refs": list(self.authority_refs),
+            "work_artifact_refs": list(self.work_artifact_refs),
+            "base_ref": self.base_ref,
+            "branch": self.branch,
+            "constraints": self.constraints.to_dict(),
+            "required_evidence": list(self.required_evidence),
+            "acceptance_commands": [list(command) for command in self.acceptance_commands],
         }
         return merge_unknown(known, self.unknown_fields)
 
@@ -134,13 +392,23 @@ class GovernedExecutionRequest:
     def from_dict(cls, value: object) -> GovernedExecutionRequest:
         data = require_object(value, "governed_execution_request")
         known, unknown = split_known(data, cls._KNOWN)
-        required = cls._KNOWN - {"provider_session_id", "worker_handle_id"}
+        required = cls._KNOWN - {
+            "provider_session_id",
+            "worker_handle_id",
+            "predecessor_execution_id",
+            "governance",
+            "required_evidence",
+            "acceptance_commands",
+            "constraints",
+        }
         missing = sorted(required - known.keys())
         if missing:
             raise ContractValidationError(f"missing required fields: {', '.join(missing)}")
 
         provider = known.get("provider_session_id")
         worker = known.get("worker_handle_id")
+        predecessor = known.get("predecessor_execution_id")
+        constraints_raw = known.get("constraints", {})
         return cls(
             schema_version=require_string(known["schema_version"], "schema_version"),
             seat_instance_id=SeatInstanceId(
@@ -161,14 +429,56 @@ class GovernedExecutionRequest:
                 if worker is not None
                 else None
             ),
+            predecessor_execution_id=(
+                ExecutionId(require_string(predecessor, "predecessor_execution_id"))
+                if predecessor is not None
+                else None
+            ),
             repository_id=RepositoryId(require_string(known["repository_id"], "repository_id")),
             operation=require_string(known["operation"], "operation"),
             input=freeze_json(require_object(known["input"], "input")),
-            governance=freeze_json(require_object(known["governance"], "governance")),
+            governance=freeze_json(require_object(known.get("governance", {}), "governance")),
             capability_manifest=CapabilityManifest.from_dict(known["capability_manifest"]),
             requested_at=parse_datetime(known["requested_at"], "requested_at"),
+            conversation_id=require_string(known["conversation_id"], "conversation_id"),
+            seat_type=SeatId(require_string(known["seat_type"], "seat_type")),
+            requested_by=require_string(known["requested_by"], "requested_by"),
+            authority_refs=_string_tuple(known["authority_refs"], "authority_refs"),
+            work_artifact_refs=_string_tuple(known["work_artifact_refs"], "work_artifact_refs"),
+            base_ref=require_string(known["base_ref"], "base_ref"),
+            branch=require_string(known["branch"], "branch"),
+            constraints=ExecutionConstraints.from_dict(constraints_raw),
+            required_evidence=_string_tuple(
+                known.get("required_evidence", ()), "required_evidence"
+            ),
+            acceptance_commands=_command_tuple(known.get("acceptance_commands", ())),
             unknown_fields=unknown,
         )
 
 
-__all__ = ["GovernedExecutionRequest"]
+def _command_tuple(value: object) -> tuple[tuple[str, ...], ...]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise ContractValidationError("acceptance_commands must be an array of argv arrays")
+    commands: list[tuple[str, ...]] = []
+    for index, item in enumerate(value):
+        if isinstance(item, str):
+            commands.append((item,))
+            continue
+        commands.append(_string_tuple(item, f"acceptance_commands[{index}]"))
+        if not commands[-1]:
+            raise ContractValidationError("acceptance_commands entries must not be empty")
+    return tuple(commands)
+
+
+def _is_protected_trunk(value: str) -> bool:
+    name = value.removeprefix("refs/heads/")
+    return name in _PROTECTED_TRUNK or name.rsplit("/", 1)[-1] in {"main", "master"}
+
+
+__all__ = [
+    "ExecutionConstraints",
+    "GovernedExecutionRequest",
+    "MutationPolicy",
+    "NetworkPolicy",
+    "SandboxMinimum",
+]

--- a/src/sovereign_agent/contracts/receipts.py
+++ b/src/sovereign_agent/contracts/receipts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from enum import StrEnum
@@ -23,7 +23,14 @@ from ._core import (
     split_known,
     thaw_json,
 )
-from .ids import ExecutionId, InvocationId
+from .ids import (
+    ExecutionId,
+    InvocationId,
+    ProviderSessionId,
+    SeatId,
+    SeatInstanceId,
+    SovereignSessionId,
+)
 
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
@@ -37,6 +44,168 @@ class ReceiptStatus(StrEnum):
     @property
     def is_terminal(self) -> bool:
         return self is not ReceiptStatus.RUNNING
+
+
+class ReceiptTermination(StrEnum):
+    COMPLETED = "completed"
+    REFUSED = "refused"
+    ABORTED = "aborted"
+    IDLE_TIMEOUT = "idle-timeout"
+    COMPLETION_TIMEOUT = "completion-timeout"
+    WORKER_TIMEOUT = "worker-timeout"
+    PROVIDER_TIMEOUT = "provider-timeout"
+    LIFECYCLE_TIMEOUT = "lifecycle-timeout"
+    PROVIDER_ERROR = "provider-error"
+    WORKER_ERROR = "worker-error"
+    ISOLATION_UNAVAILABLE = "isolation-unavailable"
+    INVALID_STRUCTURED_OUTPUT = "invalid-structured-output"
+    VERIFICATION_FAILED = "verification-failed"
+    DELIVERY_FAILED = "delivery-failed"
+    BUSINESS_VERIFICATION_FAILED = "business-verification-failed"
+    AMBIGUOUS_PROVIDER_INVOCATION = "ambiguous-provider-invocation"
+    AMBIGUOUS_DELIVERY = "ambiguous-delivery"
+    REPOSITORY_DIRTY = "repository-dirty"
+    REPOSITORY_ERROR = "repository-error"
+
+
+_STATUS_FOR_TERMINATION = {
+    ReceiptTermination.COMPLETED: ReceiptStatus.SUCCEEDED,
+    ReceiptTermination.ABORTED: ReceiptStatus.CANCELLED,
+    ReceiptTermination.REFUSED: ReceiptStatus.FAILED,
+}
+
+
+def status_for_termination(
+    termination: ReceiptTermination | None, status: ReceiptStatus
+) -> ReceiptStatus:
+    if termination is None:
+        return status
+    return _STATUS_FOR_TERMINATION.get(termination, ReceiptStatus.FAILED)
+
+
+def default_termination(status: ReceiptStatus) -> ReceiptTermination | None:
+    if status is ReceiptStatus.SUCCEEDED:
+        return ReceiptTermination.COMPLETED
+    if status is ReceiptStatus.CANCELLED:
+        return ReceiptTermination.ABORTED
+    if status is ReceiptStatus.FAILED:
+        return ReceiptTermination.PROVIDER_ERROR
+    return None
+
+
+@dataclass(frozen=True)
+class VerificationCommand:
+    command: tuple[str, ...]
+    exit_code: int | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.command, str) or not isinstance(self.command, Sequence):
+            raise ContractValidationError("verification.command must be an argv array")
+        object.__setattr__(
+            self,
+            "command",
+            tuple(require_string(item, "verification.command") for item in self.command),
+        )
+        if not self.command:
+            raise ContractValidationError("verification.command must not be empty")
+        if self.exit_code is not None and (
+            not isinstance(self.exit_code, int) or isinstance(self.exit_code, bool)
+        ):
+            raise ContractValidationError("verification.exit_code must be an integer")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"command": list(self.command), "exit_code": self.exit_code}
+
+    @classmethod
+    def from_dict(cls, value: object) -> VerificationCommand:
+        data = require_object(value, "verification")
+        command = data.get("command", data.get("argv"))
+        return cls(command=tuple(command or ()), exit_code=data.get("exit_code"))
+
+
+@dataclass(frozen=True)
+class CommitEvidence:
+    sha: str
+    remote_contains: bool | None = None
+
+    def __post_init__(self) -> None:
+        require_string(self.sha, "commit.sha")
+        if self.remote_contains is not None and not isinstance(self.remote_contains, bool):
+            raise ContractValidationError("commit.remote_contains must be boolean or null")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"sha": self.sha, "remote_contains": self.remote_contains}
+
+    @classmethod
+    def from_dict(cls, value: object) -> CommitEvidence:
+        data = require_object(value, "commit")
+        contains = data.get("remote_contains")
+        return cls(sha=require_string(data["sha"], "commit.sha"), remote_contains=contains)
+
+
+@dataclass(frozen=True)
+class RepositoryReceipt:
+    remote: str | None = None
+    branch: str | None = None
+    base_commit: str | None = None
+    commits: tuple[CommitEvidence, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "remote": self.remote,
+            "branch": self.branch,
+            "base_commit": self.base_commit,
+            "commits": [item.to_dict() for item in self.commits],
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> RepositoryReceipt:
+        data = require_object(value, "repository")
+        commits = data.get("commits", ())
+        if isinstance(commits, str) or not isinstance(commits, Sequence):
+            raise ContractValidationError("repository.commits must be an array")
+        return cls(
+            remote=None if data.get("remote") is None else require_string(data["remote"], "remote"),
+            branch=None if data.get("branch") is None else require_string(data["branch"], "branch"),
+            base_commit=(
+                None
+                if data.get("base_commit") is None
+                else require_string(data["base_commit"], "base_commit")
+            ),
+            commits=tuple(CommitEvidence.from_dict(item) for item in commits),
+        )
+
+
+@dataclass(frozen=True)
+class UsageRecord:
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    source: str = "unknown"
+
+    def __post_init__(self) -> None:
+        require_string(self.source, "usage.source")
+        for name in ("input_tokens", "output_tokens"):
+            value = getattr(self, name)
+            if value is not None and (
+                not isinstance(value, int) or isinstance(value, bool) or value < 0
+            ):
+                raise ContractValidationError(f"{name} must be a non-negative integer")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "source": self.source,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> UsageRecord:
+        data = require_object(value, "usage")
+        return cls(
+            input_tokens=data.get("input_tokens"),
+            output_tokens=data.get("output_tokens"),
+            source=str(data.get("source", "unknown")),
+        )
 
 
 @dataclass(frozen=True)
@@ -62,6 +231,24 @@ class ExecutionReceipt:
     evidence_sha256: str | None = None
     supersedes_sha256: str | None = None
     correction_sequence: int = 0
+    termination: ReceiptTermination | None = None
+    predecessor_execution_id: ExecutionId | None = None
+    seat_type: SeatId | None = None
+    seat_instance: SeatInstanceId | None = None
+    sovereign_session: SovereignSessionId | None = None
+    provider: str | None = None
+    provider_session: ProviderSessionId | None = None
+    worker_backend: str | None = None
+    capability_manifest_ref: str | None = None
+    completion_signal_seen: bool | None = None
+    structured_result_valid: bool | None = None
+    technical_verification_valid: bool | None = None
+    dataflow_integrity_valid: bool | None = None
+    repository: RepositoryReceipt | None = None
+    verification: tuple[VerificationCommand, ...] = ()
+    usage: UsageRecord | None = None
+    artifact_refs: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
     schema_version: str = SCHEMA_VERSION
     unknown_fields: FrozenDict = field(default_factory=FrozenDict, repr=False)
 
@@ -79,6 +266,24 @@ class ExecutionReceipt:
             "evidence_sha256",
             "supersedes_sha256",
             "correction_sequence",
+            "termination",
+            "predecessor_execution_id",
+            "seat_type",
+            "seat_instance",
+            "sovereign_session",
+            "provider",
+            "provider_session",
+            "worker_backend",
+            "capability_manifest_ref",
+            "completion_signal_seen",
+            "structured_result_valid",
+            "technical_verification_valid",
+            "dataflow_integrity_valid",
+            "repository",
+            "verification",
+            "usage",
+            "artifact_refs",
+            "warnings",
         }
     )
 
@@ -91,6 +296,25 @@ class ExecutionReceipt:
             raise ContractValidationError("status must be ReceiptStatus")
         if self.schema_version != self.SCHEMA_VERSION:
             raise ContractValidationError(f"schema_version must be {self.SCHEMA_VERSION!r}")
+        termination = self.termination
+        if termination is None:
+            termination = default_termination(self.status)
+            object.__setattr__(self, "termination", termination)
+        elif not isinstance(termination, ReceiptTermination):
+            object.__setattr__(self, "termination", ReceiptTermination(termination))
+            termination = self.termination
+        if termination is not None:
+            projected = status_for_termination(termination, self.status)
+            if self.status is ReceiptStatus.RUNNING:
+                raise ContractValidationError("a running receipt cannot have a termination")
+            if (
+                self.status is ReceiptStatus.SUCCEEDED
+                and termination is not ReceiptTermination.COMPLETED
+            ):
+                raise ContractValidationError("succeeded receipts terminate as completed")
+            if self.status is not projected and self.status is not ReceiptStatus.RUNNING:
+                if termination is ReceiptTermination.COMPLETED:
+                    raise ContractValidationError("completed termination requires succeeded status")
         format_datetime(self.started_at, "started_at")
         if self.completed_at is not None:
             format_datetime(self.completed_at, "completed_at")
@@ -122,6 +346,10 @@ class ExecutionReceipt:
         ):
             if digest is not None and not _SHA256_PATTERN.fullmatch(digest):
                 raise ContractValidationError(f"{name} must be a lowercase SHA-256 hex digest")
+        if self.predecessor_execution_id is not None and not isinstance(
+            self.predecessor_execution_id, ExecutionId
+        ):
+            raise ContractValidationError("predecessor_execution_id must be ExecutionId or null")
         object.__setattr__(self, "result", freeze_json(self.result, path="result"))
         if self.error is not None:
             object.__setattr__(
@@ -132,6 +360,28 @@ class ExecutionReceipt:
             "evidence",
             freeze_json(require_object(self.evidence, "evidence"), path="evidence"),
         )
+        object.__setattr__(self, "verification", tuple(self.verification))
+        if any(not isinstance(item, VerificationCommand) for item in self.verification):
+            raise ContractValidationError("verification entries must be VerificationCommand")
+        object.__setattr__(self, "artifact_refs", tuple(self.artifact_refs))
+        object.__setattr__(self, "warnings", tuple(self.warnings))
+        if any(
+            not isinstance(item, str) or not item for item in (*self.artifact_refs, *self.warnings)
+        ):
+            raise ContractValidationError("artifact_refs and warnings must be non-empty strings")
+        if self.repository is not None and not isinstance(self.repository, RepositoryReceipt):
+            raise ContractValidationError("repository must be RepositoryReceipt or null")
+        if self.usage is not None and not isinstance(self.usage, UsageRecord):
+            raise ContractValidationError("usage must be UsageRecord or null")
+        worker = self.worker_backend
+        if worker is not None:
+            require_string(worker, "worker_backend")
+        if (
+            worker in {"bare", "none"}
+            and "bare" not in self.warnings
+            and "none" not in self.warnings
+        ):
+            object.__setattr__(self, "warnings", (*self.warnings, f"worker_backend={worker}"))
         object.__setattr__(
             self,
             "unknown_fields",
@@ -185,6 +435,7 @@ class ExecutionReceipt:
         result: Any = None,
         error: Mapping[str, Any] | None = None,
         evidence: Mapping[str, Any] | None = None,
+        termination: ReceiptTermination | None = None,
     ) -> ExecutionReceipt:
         """Create and finalize a linked correction; never alter this receipt."""
         if not self.is_finalized:
@@ -200,6 +451,20 @@ class ExecutionReceipt:
             evidence=self.evidence if evidence is None else evidence,
             supersedes_sha256=self.evidence_sha256,
             correction_sequence=self.correction_sequence + 1,
+            termination=termination,
+            predecessor_execution_id=self.predecessor_execution_id,
+            seat_type=self.seat_type,
+            seat_instance=self.seat_instance,
+            sovereign_session=self.sovereign_session,
+            provider=self.provider,
+            provider_session=self.provider_session,
+            worker_backend=self.worker_backend,
+            capability_manifest_ref=self.capability_manifest_ref,
+            repository=self.repository,
+            verification=self.verification,
+            usage=self.usage,
+            artifact_refs=self.artifact_refs,
+            warnings=self.warnings,
             unknown_fields=self.unknown_fields,
         )
         return correction.finalize()
@@ -222,6 +487,32 @@ class ExecutionReceipt:
             "evidence_sha256": self.evidence_sha256,
             "supersedes_sha256": self.supersedes_sha256,
             "correction_sequence": self.correction_sequence,
+            "termination": None if self.termination is None else self.termination.value,
+            "predecessor_execution_id": (
+                None
+                if self.predecessor_execution_id is None
+                else str(self.predecessor_execution_id)
+            ),
+            "seat_type": None if self.seat_type is None else str(self.seat_type),
+            "seat_instance": None if self.seat_instance is None else str(self.seat_instance),
+            "sovereign_session": (
+                None if self.sovereign_session is None else str(self.sovereign_session)
+            ),
+            "provider": self.provider,
+            "provider_session": (
+                None if self.provider_session is None else str(self.provider_session)
+            ),
+            "worker_backend": self.worker_backend,
+            "capability_manifest_ref": self.capability_manifest_ref,
+            "completion_signal_seen": self.completion_signal_seen,
+            "structured_result_valid": self.structured_result_valid,
+            "technical_verification_valid": self.technical_verification_valid,
+            "dataflow_integrity_valid": self.dataflow_integrity_valid,
+            "repository": None if self.repository is None else self.repository.to_dict(),
+            "verification": [item.to_dict() for item in self.verification],
+            "usage": None if self.usage is None else self.usage.to_dict(),
+            "artifact_refs": list(self.artifact_refs),
+            "warnings": list(self.warnings),
         }
         return merge_unknown(known, self.unknown_fields)
 
@@ -229,7 +520,30 @@ class ExecutionReceipt:
     def from_dict(cls, value: object) -> ExecutionReceipt:
         data = require_object(value, "execution_receipt")
         known, unknown = split_known(data, cls._KNOWN)
-        required = cls._KNOWN - {"result", "error", "evidence_sha256", "supersedes_sha256"}
+        required = cls._KNOWN - {
+            "result",
+            "error",
+            "evidence_sha256",
+            "supersedes_sha256",
+            "termination",
+            "predecessor_execution_id",
+            "seat_type",
+            "seat_instance",
+            "sovereign_session",
+            "provider",
+            "provider_session",
+            "worker_backend",
+            "capability_manifest_ref",
+            "completion_signal_seen",
+            "structured_result_valid",
+            "technical_verification_valid",
+            "dataflow_integrity_valid",
+            "repository",
+            "verification",
+            "usage",
+            "artifact_refs",
+            "warnings",
+        }
         missing = sorted(required - known.keys())
         if missing:
             raise ContractValidationError(f"missing required fields: {', '.join(missing)}")
@@ -241,6 +555,12 @@ class ExecutionReceipt:
         sequence = known["correction_sequence"]
         if not isinstance(sequence, int) or isinstance(sequence, bool):
             raise ContractValidationError("correction_sequence must be an integer")
+        termination_raw = known.get("termination")
+        repository_raw = known.get("repository")
+        usage_raw = known.get("usage")
+        verification_raw = known.get("verification", ())
+        if isinstance(verification_raw, str) or not isinstance(verification_raw, Sequence):
+            raise ContractValidationError("verification must be an array")
         return cls(
             schema_version=require_string(known["schema_version"], "schema_version"),
             execution_id=ExecutionId(require_string(known["execution_id"], "execution_id")),
@@ -256,8 +576,42 @@ class ExecutionReceipt:
             evidence_sha256=known.get("evidence_sha256"),
             supersedes_sha256=known.get("supersedes_sha256"),
             correction_sequence=sequence,
+            termination=(
+                None if termination_raw is None else ReceiptTermination(str(termination_raw))
+            ),
+            predecessor_execution_id=_optional_execution_id(known.get("predecessor_execution_id")),
+            seat_type=_optional_id(known.get("seat_type"), SeatId),
+            seat_instance=_optional_id(known.get("seat_instance"), SeatInstanceId),
+            sovereign_session=_optional_id(known.get("sovereign_session"), SovereignSessionId),
+            provider=known.get("provider"),
+            provider_session=_optional_id(known.get("provider_session"), ProviderSessionId),
+            worker_backend=known.get("worker_backend"),
+            capability_manifest_ref=known.get("capability_manifest_ref"),
+            completion_signal_seen=known.get("completion_signal_seen"),
+            structured_result_valid=known.get("structured_result_valid"),
+            technical_verification_valid=known.get("technical_verification_valid"),
+            dataflow_integrity_valid=known.get("dataflow_integrity_valid"),
+            repository=None
+            if repository_raw is None
+            else RepositoryReceipt.from_dict(repository_raw),
+            verification=tuple(VerificationCommand.from_dict(item) for item in verification_raw),
+            usage=None if usage_raw is None else UsageRecord.from_dict(usage_raw),
+            artifact_refs=tuple(known.get("artifact_refs") or ()),
+            warnings=tuple(known.get("warnings") or ()),
             unknown_fields=unknown,
         )
+
+
+def _optional_execution_id(value: object) -> ExecutionId | None:
+    if value is None:
+        return None
+    return ExecutionId(require_string(value, "predecessor_execution_id"))
+
+
+def _optional_id(value: object, cls: type[Any]) -> Any:
+    if value is None:
+        return None
+    return cls(require_string(value, cls.__name__))
 
 
 def lifecycle_complete(receipt: ExecutionReceipt) -> bool:
@@ -271,8 +625,13 @@ def evidence_verified(receipt: ExecutionReceipt) -> bool:
 
 
 __all__ = [
+    "CommitEvidence",
     "ExecutionReceipt",
     "ReceiptStatus",
+    "ReceiptTermination",
+    "RepositoryReceipt",
+    "UsageRecord",
+    "VerificationCommand",
     "evidence_verified",
     "lifecycle_complete",
 ]

--- a/src/sovereign_agent/contracts/schemas/execution-receipt.schema.json
+++ b/src/sovereign_agent/contracts/schemas/execution-receipt.schema.json
@@ -35,7 +35,27 @@
       "type": ["string", "null"],
       "pattern": "^[0-9a-f]{64}$"
     },
-    "correction_sequence": {"type": "integer", "minimum": 0}
+    "correction_sequence": {"type": "integer", "minimum": 0},
+    "termination": {"type": ["string", "null"]},
+    "predecessor_execution_id": {
+      "oneOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]
+    },
+    "seat_type": {"oneOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]},
+    "seat_instance": {"oneOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]},
+    "sovereign_session": {"oneOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]},
+    "provider": {"type": ["string", "null"]},
+    "provider_session": {"oneOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]},
+    "worker_backend": {"type": ["string", "null"]},
+    "capability_manifest_ref": {"type": ["string", "null"]},
+    "completion_signal_seen": {"type": ["boolean", "null"]},
+    "structured_result_valid": {"type": ["boolean", "null"]},
+    "technical_verification_valid": {"type": ["boolean", "null"]},
+    "dataflow_integrity_valid": {"type": ["boolean", "null"]},
+    "repository": {"type": ["object", "null"]},
+    "verification": {"type": "array"},
+    "usage": {"type": ["object", "null"]},
+    "artifact_refs": {"type": "array", "items": {"type": "string"}},
+    "warnings": {"type": "array", "items": {"type": "string"}}
   },
   "allOf": [
     {

--- a/src/sovereign_agent/contracts/schemas/governed-execution-request.schema.json
+++ b/src/sovereign_agent/contracts/schemas/governed-execution-request.schema.json
@@ -14,7 +14,14 @@
     "input",
     "governance",
     "capability_manifest",
-    "requested_at"
+    "requested_at",
+    "conversation_id",
+    "seat_type",
+    "requested_by",
+    "authority_refs",
+    "work_artifact_refs",
+    "base_ref",
+    "branch"
   ],
   "properties": {
     "schema_version": {"const": "1.0"},
@@ -35,7 +42,23 @@
     "capability_manifest": {
       "$ref": "capability-manifest.schema.json"
     },
-    "requested_at": {"type": "string", "format": "date-time"}
+    "requested_at": {"type": "string", "format": "date-time"},
+    "conversation_id": {"type": "string", "minLength": 1},
+    "seat_type": {"$ref": "#/$defs/id"},
+    "requested_by": {"type": "string", "minLength": 1},
+    "authority_refs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "work_artifact_refs": {"type": "array", "items": {"type": "string"}},
+    "base_ref": {"type": "string", "minLength": 1},
+    "branch": {"type": "string", "minLength": 1},
+    "constraints": {"type": "object"},
+    "required_evidence": {"type": "array", "items": {"type": "string"}},
+    "acceptance_commands": {
+      "type": "array",
+      "items": {"type": "array", "items": {"type": "string"}}
+    },
+    "predecessor_execution_id": {
+      "oneOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]
+    }
   },
   "$defs": {
     "id": {

--- a/src/sovereign_agent/execution/__init__.py
+++ b/src/sovereign_agent/execution/__init__.py
@@ -1,0 +1,15 @@
+"""Public governed execution service."""
+
+from .engine import (
+    AdmissionRejected,
+    ExecutionNotFound,
+    ExecutionStatus,
+    GovernedExecutionEngine,
+)
+
+__all__ = [
+    "AdmissionRejected",
+    "ExecutionNotFound",
+    "ExecutionStatus",
+    "GovernedExecutionEngine",
+]

--- a/src/sovereign_agent/execution/cli.py
+++ b/src/sovereign_agent/execution/cli.py
@@ -1,0 +1,376 @@
+"""Offline JSON CLI wiring for governed execution."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from sovereign_agent.contracts import (
+    EvidenceLevel,
+    FrozenDict,
+    GovernedExecutionRequest,
+    RelayMessageId,
+    RepositoryId,
+    SeatId,
+    SeatInstanceId,
+)
+from sovereign_agent.orchestrator import (
+    BareWorker,
+    DockerWorker,
+    OSIsolatedWorker,
+    SubprocessWorker,
+    WorkerOutcome,
+)
+from sovereign_agent.providers import (
+    AgentProvider,
+    ClaudeCodeProvider,
+    CodexCliProvider,
+    ProviderCapabilities,
+)
+from sovereign_agent.registry import RuntimeAddress, SeatRegistry
+from sovereign_agent.relay import DurableRelay, RelayMessage
+from sovereign_agent.repository import RepositoryConfig, RepositoryManager
+from sovereign_agent.runtime import RuntimeRoot
+
+from .engine import AdmissionRejected, ExecutionNotFound, GovernedExecutionEngine
+
+governed_app = typer.Typer(
+    name="governed",
+    help="Run and inspect governed v0.3 executions using JSON.",
+    no_args_is_help=True,
+)
+seat_app = typer.Typer(
+    name="seat", help="Register persistent seat instances.", no_args_is_help=True
+)
+execution_app = typer.Typer(
+    name="execution", help="Inspect execution status.", no_args_is_help=True
+)
+receipt_app = typer.Typer(
+    name="receipt", help="Show finalized execution receipts.", no_args_is_help=True
+)
+relay_app = typer.Typer(
+    name="relay", help="Send and receive durable relay messages.", no_args_is_help=True
+)
+
+EXIT_OK = 0
+EXIT_INPUT = 2
+EXIT_FAILED = 3
+EXIT_NOT_FOUND = 4
+
+
+@governed_app.command("run")
+def run_command(
+    request_file: Path = typer.Argument(..., exists=True, dir_okay=False),
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+) -> None:
+    """Admit and run a request, printing exactly one JSON result."""
+    _execute_request(request_file, config_file)
+
+
+@governed_app.command("submit")
+def submit_command(
+    request_file: Path = typer.Argument(..., exists=True, dir_okay=False),
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+) -> None:
+    """Offline submit-and-run alias; execution IDs make retries idempotent."""
+    run_command(request_file, config_file)
+
+
+@governed_app.command("status")
+def governed_status_command(
+    execution_id: str,
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+) -> None:
+    """Print durable execution status as JSON."""
+    _status(execution_id, config_file)
+
+
+@governed_app.command("cancel")
+def cancel_command(
+    execution_id: str,
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+) -> None:
+    """Persist cancellation and signal an execution-local Unit 3 token."""
+    cancelled = _engine(config_file).cancel(execution_id)
+    _json({"execution_id": execution_id, "cancellation_requested": cancelled})
+    if not cancelled:
+        raise typer.Exit(EXIT_NOT_FOUND)
+
+
+@governed_app.command("receipt")
+def governed_receipt_command(
+    execution_id: str,
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+) -> None:
+    """Print a finalized immutable receipt as JSON."""
+    _show_receipt(execution_id, config_file)
+
+
+def execute_command(
+    request: Path = typer.Option(..., "--request", exists=True, dir_okay=False),
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+) -> None:
+    """Admit and run a governed request file (JSON or YAML)."""
+    _execute_request(request, config_file)
+
+
+@execution_app.command("status")
+def execution_status_command(
+    execution_id: str,
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+) -> None:
+    _status(execution_id, config_file)
+
+
+@receipt_app.command("show")
+def receipt_show_command(
+    execution_id: str,
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+) -> None:
+    _show_receipt(execution_id, config_file)
+
+
+@seat_app.command("register")
+def seat_register_command(
+    instance: str = typer.Option(..., "--instance"),
+    seat_type: str = typer.Option(..., "--seat-type"),
+    provider: str = typer.Option(..., "--provider"),
+    backend: str = typer.Option(..., "--backend"),
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+    sovereign_session: str | None = typer.Option(None, "--sovereign-session"),
+    provider_session: str | None = typer.Option(None, "--provider-session"),
+    capability_manifest_ref: str | None = typer.Option(None, "--capability-manifest-ref"),
+) -> None:
+    runtime = _runtime(config_file)
+    registry = SeatRegistry(runtime)
+    record = registry.register(
+        instance_id=SeatInstanceId(instance),
+        seat_id=SeatId(seat_type),
+        provider=provider,
+        backend=backend,
+        sovereign_session_id=sovereign_session,
+        provider_session_id=provider_session,
+        capability_manifest_ref=capability_manifest_ref,
+    )
+    _json(record.to_dict())
+
+
+@relay_app.command("send")
+def relay_send_command(
+    sender: str = typer.Option(..., "--from"),
+    recipient: str = typer.Option(..., "--to"),
+    kind: str = typer.Option(..., "--kind"),
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+    body: str = typer.Option("", "--body"),
+    message_id: str | None = typer.Option(None, "--message-id"),
+    conversation_id: str | None = typer.Option(None, "--conversation-id"),
+    artifact_ref: list[str] = typer.Option((), "--artifact-ref"),
+) -> None:
+    runtime = _runtime(config_file)
+    registry = SeatRegistry(runtime)
+    relay = DurableRelay(runtime, registry)
+    envelope = RelayMessage(
+        message_id=RelayMessageId(message_id or f"msg-{int(datetime.now(UTC).timestamp())}"),
+        sender=RuntimeAddress(sender if sender.startswith("local://") else f"local://{sender}"),
+        recipient=RuntimeAddress(
+            recipient if recipient.startswith("local://") else f"local://{recipient}"
+        ),
+        kind=kind,
+        payload=FrozenDict((("body", body),)),
+        created_at=datetime.now(UTC),
+        conversation_id=conversation_id,
+        artifact_refs=tuple(artifact_ref),
+    )
+    _json(relay.enqueue(envelope).to_dict())
+
+
+@relay_app.command("receive")
+def relay_receive_command(
+    recipient: str = typer.Option(..., "--to"),
+    owner: str = typer.Option(..., "--owner"),
+    config_file: Path = typer.Option(..., "--config", exists=True, dir_okay=False),
+    ack: bool = typer.Option(False, "--ack"),
+) -> None:
+    runtime = _runtime(config_file)
+    registry = SeatRegistry(runtime)
+    relay = DurableRelay(runtime, registry)
+    address = RuntimeAddress(
+        recipient if recipient.startswith("local://") else f"local://{recipient}"
+    )
+    claimed = relay.claim(address, owner=owner)
+    if claimed is None:
+        _json({"claimed": False})
+        raise typer.Exit(EXIT_NOT_FOUND)
+    if ack:
+        acknowledgement = relay.ack(
+            claimed.message.message_id, owner=owner, lease_token=claimed.lease_token
+        )
+        _json(
+            {
+                "claimed": True,
+                "message": claimed.message.to_dict(),
+                "ack": acknowledgement.to_dict(),
+            }
+        )
+        return
+    _json(
+        {
+            "claimed": True,
+            "message": claimed.message.to_dict(),
+            "lease_token": claimed.lease_token,
+            "attempt_count": claimed.attempt_count,
+        }
+    )
+
+
+def register_execution_commands(app: typer.Typer) -> None:
+    """Attach Unit 7 command names and keep the governed aliases."""
+    app.add_typer(governed_app, name="governed")
+    app.add_typer(seat_app, name="seat")
+    app.add_typer(execution_app, name="execution")
+    app.add_typer(receipt_app, name="receipt")
+    app.add_typer(relay_app, name="relay")
+    app.command("execute")(execute_command)
+
+
+def _execute_request(request_file: Path, config_file: Path) -> None:
+    try:
+        request = GovernedExecutionRequest.from_dict(_read_object(request_file))
+        engine = _engine(config_file)
+        receipt = asyncio.run(engine.run(request))
+    except AdmissionRejected as exc:
+        _json({"admitted": False, "reason": exc.reason, "detail": exc.detail})
+        raise typer.Exit(EXIT_INPUT) from exc
+    except Exception as exc:  # noqa: BLE001
+        _json({"error": type(exc).__name__, "detail": str(exc)})
+        raise typer.Exit(EXIT_INPUT) from exc
+    _json(receipt.to_dict())
+    if not receipt.is_successful:
+        raise typer.Exit(EXIT_FAILED)
+
+
+def _status(execution_id: str, config_file: Path) -> None:
+    try:
+        _json(_engine(config_file).status(execution_id).to_dict())
+    except ExecutionNotFound as exc:
+        _json({"error": "not_found", "execution_id": execution_id})
+        raise typer.Exit(EXIT_NOT_FOUND) from exc
+
+
+def _show_receipt(execution_id: str, config_file: Path) -> None:
+    receipt = _engine(config_file).receipt(execution_id)
+    if receipt is None:
+        _json({"error": "not_found", "execution_id": execution_id})
+        raise typer.Exit(EXIT_NOT_FOUND)
+    _json(receipt.to_dict())
+
+
+def _engine(config_file: Path) -> GovernedExecutionEngine:
+    config = _read_object(config_file)
+    runtime = RuntimeRoot(Path(str(config["runtime_root"]))).initialize()
+    repositories_raw = config.get("repositories", ())
+    if not isinstance(repositories_raw, list):
+        raise ValueError("config.repositories must be an array")
+    repositories = tuple(
+        RepositoryConfig(
+            repository_id=RepositoryId(str(item["repository_id"])),
+            checkout=Path(str(item["checkout"])),
+            default_remote=str(item.get("default_remote", "origin")),
+            protected_branches=tuple(item.get("protected_branches", ("main", "master"))),
+        )
+        for item in repositories_raw
+    )
+    providers: dict[str, AgentProvider] = {}
+    providers_raw = config.get("providers", ())
+    if not isinstance(providers_raw, list):
+        raise ValueError("config.providers must be an array")
+    for item in providers_raw:
+        kind = str(item["kind"])
+        kwargs = {
+            "name": str(item.get("name", kind)),
+            "executable": str(item.get("executable", kind)),
+        }
+        if kind == "claude":
+            provider: AgentProvider = ClaudeCodeProvider(**kwargs)
+        elif kind == "codex":
+            provider = CodexCliProvider(**kwargs)
+        elif kind == "native":
+            raise ValueError(
+                "native provider must be wired in-process with NativeProvider; "
+                "JSON config cannot supply an LLM client"
+            )
+        else:
+            raise ValueError(f"unsupported configured provider kind: {kind}")
+        declared = item.get("capabilities")
+        if isinstance(declared, dict):
+            capability_values = dict(declared)
+            level = capability_values.get("evidence_level")
+            if isinstance(level, str):
+                capability_values["evidence_level"] = EvidenceLevel.from_wire(level)
+            provider.capabilities = ProviderCapabilities(**capability_values)
+        providers[provider.name] = provider
+
+    async def unused_advance(session_id: str, session_dir: Path) -> WorkerOutcome:
+        del session_dir
+        return WorkerOutcome(session_id, False, False, "provider-owned execution")
+
+    backends: dict[str, Any] = {}
+    for name in config.get("backends", ("bare",)):
+        if name == "bare":
+            backends[name] = BareWorker(unused_advance)
+        elif name == "subprocess":
+            backends[name] = SubprocessWorker()
+        elif name in {"os-isolated", "os_isolated"}:
+            from sovereign_agent._internal.isolation import detect_best_policy
+
+            backends["os-isolated"] = OSIsolatedWorker(isolation_policy=detect_best_policy())
+        elif name == "docker":
+            backends[name] = DockerWorker()
+        else:
+            raise ValueError(f"unsupported configured backend: {name}")
+    seats = SeatRegistry(runtime)
+    return GovernedExecutionEngine(
+        runtime_root=runtime,
+        repository_manager=RepositoryManager(runtime, repositories),
+        seat_registry=seats,
+        providers=providers,
+        backends=backends,
+    )
+
+
+def _runtime(config_file: Path) -> RuntimeRoot:
+    config = _read_object(config_file)
+    return RuntimeRoot(Path(str(config["runtime_root"]))).initialize()
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        import yaml  # type: ignore[import-untyped]
+
+        value = yaml.safe_load(text)
+    else:
+        value = json.loads(text)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def _json(value: Any) -> None:
+    typer.echo(json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False))
+
+
+__all__ = [
+    "EXIT_FAILED",
+    "EXIT_INPUT",
+    "EXIT_NOT_FOUND",
+    "EXIT_OK",
+    "execute_command",
+    "governed_app",
+    "register_execution_commands",
+]

--- a/src/sovereign_agent/execution/engine.py
+++ b/src/sovereign_agent/execution/engine.py
@@ -1,0 +1,1541 @@
+"""Governed, durable composition of the v0.3 execution primitives."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sovereign_agent._internal.atomic import atomic_append_jsonl, atomic_write_bytes
+from sovereign_agent._internal.file_lock import exclusive_file_lock
+from sovereign_agent.contracts import (
+    CommitEvidence,
+    EvidenceLevel,
+    ExecutionId,
+    ExecutionReceipt,
+    FrozenDict,
+    GovernedExecutionRequest,
+    ReceiptStatus,
+    ReceiptTermination,
+    RelayMessageId,
+    RepositoryReceipt,
+    VerificationCommand,
+    canonical_json_bytes,
+    redact_json,
+    redact_text,
+)
+from sovereign_agent.contracts._core import thaw_json
+from sovereign_agent.orchestrator.lifecycle import (
+    CloseResult,
+    ExecResult,
+    ExecutionLifecycle,
+    LifecycleResult,
+    LifecycleTimeouts,
+    RuntimeHandle,
+    TerminalReason,
+    WorkerBackend,
+    WorkerRequest,
+)
+from sovereign_agent.providers import (
+    AgentProvider,
+    CliProvider,
+    InvocationRequest,
+    InvocationResult,
+    ProviderRegistry,
+    StructuredResultEvent,
+)
+from sovereign_agent.registry import RuntimeAddress, SeatInstance, SeatRegistry
+from sovereign_agent.relay import DurableRelay, RelayMessage
+from sovereign_agent.repository import (
+    DeliveryResult,
+    DeliveryState,
+    DirtyWorktreePolicy,
+    GitEvidence,
+    RepositoryExecution,
+    RepositoryManager,
+)
+from sovereign_agent.runtime import RuntimeRoot
+from sovereign_agent.session import Session, create_session, load_session
+
+Clock = Callable[[], datetime]
+
+_SUPPORTED_CONSTRAINTS = frozenset(
+    {
+        "base_ref",
+        "dirty_worktree",
+        "filesystem_isolation",
+        "network_isolation",
+        "preserve_on_failure",
+        "structured_output",
+        "timeouts",
+        "trunk_mutation",
+        "self_merge",
+        "sandbox_minimum",
+        "network",
+        "max_invocations",
+        "idle_timeout_seconds",
+        "delivery_enabled",
+        "delivery_remote",
+        "delivery_branch",
+    }
+)
+_TERMINAL_PHASES = frozenset({"finalized", "rejected"})
+
+
+class AdmissionRejected(ValueError):
+    """A request failed deterministic admission before execution side effects."""
+
+    def __init__(self, reason: str, detail: str) -> None:
+        self.reason = reason
+        self.detail = redact_text(detail)
+        super().__init__(f"{reason}: {self.detail}")
+
+
+class ExecutionNotFound(LookupError):
+    """No execution or rejection exists for an execution ID."""
+
+
+@dataclass(frozen=True)
+class ExecutionStatus:
+    execution_id: str
+    phase: str
+    terminal: bool
+    receipt_sha256: str | None = None
+    cancellation_requested: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class _ProviderLifecycleBackend:
+    """Run a provider inside Unit 3's prepare/close lifecycle.
+
+    The configured backend remains responsible for preparation, isolation
+    evidence, cancellation teardown and close. Provider invocation is the
+    lifecycle's execute operation, avoiding a second provider-specific runner.
+    """
+
+    def __init__(
+        self,
+        backend: WorkerBackend,
+        provider: AgentProvider,
+        invocation: InvocationRequest,
+        observer: Callable[[Any], None],
+    ) -> None:
+        self.name = backend.name
+        self._backend = backend
+        self._provider = provider
+        self._invocation = invocation
+        self._observer = observer
+
+    def capabilities(self) -> Any:
+        return self._backend.capabilities()
+
+    async def prepare(self, request: WorkerRequest) -> RuntimeHandle:
+        return await self._backend.prepare(request)
+
+    async def execute(self, handle: RuntimeHandle, invocation: Any = None) -> ExecResult:
+        del invocation
+        try:
+            result = await self._provider.invoke(
+                self._invocation,
+                observers=(self._observer,),
+                activity_callbacks=(),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            raise _ProviderInvocationError(str(exc)) from exc
+        return ExecResult(
+            returncode=0 if result.success else 1,
+            value=result,
+            terminal_reason=None if result.success else TerminalReason.PROVIDER_ERROR,
+        )
+
+    async def close(self, handle: RuntimeHandle, preserve: bool = False) -> CloseResult:
+        return await self._backend.close(handle, preserve)
+
+
+class GovernedExecutionEngine:
+    """Admission, execution, verification, delivery and receipt finalization."""
+
+    def __init__(
+        self,
+        *,
+        runtime_root: RuntimeRoot,
+        repository_manager: RepositoryManager,
+        seat_registry: SeatRegistry,
+        providers: ProviderRegistry | Mapping[str, AgentProvider],
+        backends: Mapping[str, WorkerBackend],
+        relay: DurableRelay | None = None,
+        relay_recipient: RuntimeAddress | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self.runtime = runtime_root.initialize()
+        self.repositories = repository_manager
+        self.seats = seat_registry
+        self.providers = providers
+        self.backends = dict(backends)
+        self.relay = relay
+        self.relay_recipient = relay_recipient
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self.lifecycle = ExecutionLifecycle()
+        self._active_tasks: dict[ExecutionId, asyncio.Task[ExecutionReceipt]] = {}
+
+    async def run(self, request: GovernedExecutionRequest) -> ExecutionReceipt:
+        """Run or safely resume one execution ID."""
+        if not isinstance(request, GovernedExecutionRequest):
+            raise TypeError("request must be GovernedExecutionRequest")
+        paths = self._paths(request.execution_id)
+        paths["directory"].mkdir(mode=0o700, parents=True, exist_ok=True)
+        async with _async_file_lock(paths["lock"]):
+            existing = self._read_receipt(paths["receipt"])
+            if existing is not None:
+                return existing
+            state = self._read_state(paths["state"])
+            if state is None:
+                try:
+                    admitted = self._admit(request)
+                except AdmissionRejected as exc:
+                    return self._persist_rejection(request, exc, paths)
+                state = {
+                    "schema_version": 1,
+                    "execution_id": str(request.execution_id),
+                    "invocation_id": str(request.invocation_id),
+                    "phase": "admitted",
+                    "started_at": self._now().isoformat(),
+                    "request": _redact_persistence(request.to_dict()),
+                    "request_sha256": hashlib.sha256(
+                        canonical_json_bytes(request.to_dict())
+                    ).hexdigest(),
+                    "seat": admitted["seat"].to_dict(),
+                    "provider": admitted["provider"].name,
+                    "backend": admitted["backend"].name,
+                    "cancellation_requested": False,
+                }
+                self._checkpoint(paths, state, "admitted")
+                self._emit(request, admitted["seat"], "execution.requested", {}, None)
+            else:
+                self._validate_resume_identity(request, state)
+                admitted = self._admit(request)
+
+            if state["phase"] == "provider_invoking":
+                return self._finalize_failure(
+                    request,
+                    state,
+                    paths,
+                    "ambiguous-provider-invocation",
+                    "recovery refused to duplicate an invocation whose outcome was not journaled",
+                    admitted["seat"],
+                )
+            if state["phase"] == "delivering":
+                return self._finalize_failure(
+                    request,
+                    state,
+                    paths,
+                    "ambiguous-delivery",
+                    "recovery refused to duplicate a delivery whose outcome was not journaled",
+                    admitted["seat"],
+                )
+            if state.get("cancellation_requested") or paths["cancel"].exists():
+                return self._finalize_failure(
+                    request,
+                    state,
+                    paths,
+                    TerminalReason.ABORTED.value,
+                    "execution was cancelled",
+                    admitted["seat"],
+                    cancelled=True,
+                )
+
+            task = asyncio.current_task()
+            if task is not None:
+                self._active_tasks[request.execution_id] = task
+            try:
+                return await self._continue(request, admitted, state, paths)
+            finally:
+                self._active_tasks.pop(request.execution_id, None)
+
+    async def _continue(
+        self,
+        request: GovernedExecutionRequest,
+        admitted: dict[str, Any],
+        state: dict[str, Any],
+        paths: dict[str, Path],
+    ) -> ExecutionReceipt:
+        seat: SeatInstance = admitted["seat"]
+        provider: AgentProvider = admitted["provider"]
+        backend: WorkerBackend = admitted["backend"]
+        governance = _mapping(request.governance)
+        constraints = request.constraints.to_dict()
+
+        try:
+            repo = self._repository_from_state(state)
+            if repo is None:
+                repo = self.repositories.prepare(
+                    request.repository_id,
+                    request.execution_id,
+                    base_ref=request.base_ref,
+                    dirty_policy=DirtyWorktreePolicy(
+                        str(constraints.get("dirty_worktree", "fail"))
+                    ),
+                )
+                state["repository"] = _repository_to_dict(repo)
+                self._checkpoint(paths, state, "repository_prepared")
+            else:
+                resumed = self.repositories.resume(repo)
+                if resumed.lock_token != repo.lock_token:
+                    repo = resumed
+                    state["repository"] = _repository_to_dict(repo)
+                    self._checkpoint(paths, state, "repository_recovered")
+
+            session = self._session(request)
+            if "session_id" not in state:
+                state["session_id"] = session.session_id
+                self._checkpoint(paths, state, "session_ready")
+
+            if "provider_result" not in state:
+                if state.get("cancellation_requested"):
+                    raise _TerminalFailure(TerminalReason.ABORTED, "execution was cancelled")
+                events: list[dict[str, Any]] = []
+
+                def observe(event: Any) -> None:
+                    payload = _redact_persistence(event.to_dict())
+                    assert isinstance(payload, dict)
+                    events.append(payload)
+                    atomic_append_jsonl(paths["events"], payload)
+
+                task_text = str(_mapping(request.input).get("task", request.operation))
+                invocation_context = _mapping(request.input)
+                invocation_context["repository_worktree"] = str(repo.worktree_path)
+                invocation_context["governance"] = _redact_persistence(governance)
+                invocation_context["constraints"] = request.constraints.to_dict()
+                invocation_context["authority_refs"] = list(request.authority_refs)
+                invocation_context["work_artifact_refs"] = list(request.work_artifact_refs)
+                invocation = InvocationRequest(
+                    execution_id=request.execution_id,
+                    invocation_id=request.invocation_id,
+                    task=task_text,
+                    session=session,
+                    context=FrozenDict(tuple(invocation_context.items())),
+                    provider_session_id=request.provider_session_id,
+                )
+                worker_request = WorkerRequest(
+                    execution_id=request.execution_id,
+                    session_id=session.session_id,
+                    session_dir=session.directory,
+                    require_filesystem_isolation=bool(
+                        constraints.get("filesystem_isolation", False)
+                    )
+                    or request.constraints.sandbox_minimum.value
+                    in {"filesystem-isolated", "network-restricted"},
+                    require_network_isolation=bool(constraints.get("network_isolation", False))
+                    or request.constraints.sandbox_minimum.value == "network-restricted"
+                    or request.constraints.network.value in {"restricted", "denied"},
+                    preserve_on_failure=bool(constraints.get("preserve_on_failure", True)),
+                    timeouts=_timeouts_from_request(request),
+                    metadata=FrozenDict(
+                        (
+                            ("repository_worktree", str(repo.worktree_path)),
+                            ("operation", request.operation),
+                        )
+                    ),
+                )
+                self._checkpoint(paths, state, "provider_invoking")
+                self._emit(request, seat, "execution.started", {}, "execution.requested")
+                wrapped = _ProviderLifecycleBackend(backend, provider, invocation, observe)
+                lifecycle = await self._run_lifecycle_with_cancellation(
+                    wrapped, worker_request, paths["cancel"]
+                )
+                state["worker_lifecycle"] = {
+                    "reason": lifecycle.reason.value,
+                    "error": redact_text(lifecycle.error or ""),
+                    "transitions": [item.state.value for item in lifecycle.transitions],
+                    "close": (
+                        asdict(lifecycle.close_result)
+                        if lifecycle.close_result is not None
+                        else None
+                    ),
+                }
+                if lifecycle.reason is not TerminalReason.SUCCEEDED:
+                    lifecycle_reason = lifecycle.reason
+                    if lifecycle_reason is TerminalReason.WORKER_TIMEOUT and any(
+                        item.state.value == "executing" for item in lifecycle.transitions
+                    ):
+                        lifecycle_reason = TerminalReason.PROVIDER_TIMEOUT
+                    raise _TerminalFailure(
+                        lifecycle_reason,
+                        lifecycle.error or lifecycle.reason.value,
+                    )
+                result = lifecycle.exec_result.value if lifecycle.exec_result else None
+                if not isinstance(result, InvocationResult):
+                    raise _TerminalFailure(
+                        TerminalReason.PROVIDER_ERROR,
+                        "provider lifecycle returned no normalized InvocationResult",
+                    )
+                normalized_events = [
+                    _redact_persistence(event.to_dict()) for event in result.events
+                ]
+                atomic_write_bytes(
+                    paths["events"],
+                    b"".join(canonical_json_bytes(event) + b"\n" for event in normalized_events),
+                )
+                state["provider_result"] = {
+                    "success": result.success,
+                    "output": _redact_persistence(thaw_json(result.output)),
+                    "summary": redact_text(result.summary),
+                    "next_action": result.next_action,
+                    "events": normalized_events,
+                }
+                self._checkpoint(paths, state, "provider_completed")
+
+            result_data = _mapping(state["provider_result"])
+            if not bool(result_data.get("success")):
+                raise _TerminalFailure(TerminalReason.PROVIDER_ERROR, "provider reported failure")
+            self._verify_structured(constraints, result_data)
+            self._checkpoint(paths, state, "structured_output_verified")
+
+            evidence = self.repositories.capture_evidence(
+                repo,
+                artifact_references=(str(paths["events"]),),
+            )
+            state["git_evidence"] = _git_evidence_to_dict(evidence)
+            self._checkpoint(paths, state, "evidence_captured")
+
+            if request.acceptance_commands:
+                state["verification_commands"] = self._run_acceptance_commands(request, repo)
+                self._checkpoint(paths, state, "commands_verified")
+            self._verify_predicates(governance.get("verification", ()), result_data, evidence, repo)
+            self._checkpoint(paths, state, "verification_passed")
+            self._verify_business(governance.get("business_completion", ()), result_data, evidence)
+            self._checkpoint(paths, state, "business_verified")
+
+            if "delivery" not in state:
+                delivery_cfg = _mapping(governance.get("delivery", {}))
+                delivery_enabled = request.constraints.delivery_enabled
+                if delivery_enabled:
+                    self._checkpoint(paths, state, "delivering")
+                delivery = self.repositories.deliver(
+                    repo,
+                    enabled=delivery_enabled,
+                    remote=request.constraints.delivery_remote
+                    or _optional_str(delivery_cfg.get("remote")),
+                    remote_branch=request.constraints.delivery_branch
+                    or _optional_str(delivery_cfg.get("branch")),
+                )
+                state["delivery"] = _delivery_to_dict(delivery)
+                self._checkpoint(paths, state, "delivery_verified")
+            delivery_data = _mapping(state["delivery"])
+            if delivery_data.get("state") == DeliveryState.FAILED.value:
+                delivery_reason = str(delivery_data.get("failure_reason") or "delivery_failed")
+                raise _TerminalFailure(
+                    TerminalReason.DELIVERY_FAILED,
+                    delivery_reason,
+                    receipt_reason=f"delivery-{delivery_reason.replace('_', '-')}",
+                )
+            self._verify_required_evidence(request, state)
+
+            return self._finalize_success(request, state, paths, seat)
+        except _TerminalFailure as exc:
+            return self._finalize_failure(
+                request,
+                state,
+                paths,
+                exc.receipt_reason,
+                exc.detail,
+                seat,
+                cancelled=exc.reason is TerminalReason.ABORTED,
+            )
+        except Exception as exc:  # every admitted attempt receives one receipt
+            failure_reason = _exception_reason(exc)
+            return self._finalize_failure(
+                request,
+                state,
+                paths,
+                failure_reason,
+                f"{type(exc).__name__}: {exc}",
+                seat,
+            )
+        finally:
+            repo = self._repository_from_state(state)
+            if repo is not None:
+                try:
+                    self.repositories.release(repo)
+                except Exception:
+                    pass
+
+    def cancel(self, execution_id: ExecutionId | str) -> bool:
+        eid = execution_id if isinstance(execution_id, ExecutionId) else ExecutionId(execution_id)
+        paths = self._paths(eid)
+        state = self._read_state(paths["state"])
+        if state is None or state.get("phase") in _TERMINAL_PHASES:
+            return False
+        atomic_write_bytes(
+            paths["cancel"],
+            canonical_json_bytes(
+                {
+                    "execution_id": str(eid),
+                    "requested_at": self._now().isoformat(),
+                }
+            ),
+        )
+        state["cancellation_requested"] = True
+        self._checkpoint(paths, state, "cancellation_requested")
+        self.lifecycle.cancel(eid)
+        task = self._active_tasks.get(eid)
+        if task is not None and task.done():
+            self._active_tasks.pop(eid, None)
+        return True
+
+    async def _run_lifecycle_with_cancellation(
+        self,
+        backend: WorkerBackend,
+        request: WorkerRequest,
+        marker: Path,
+    ) -> LifecycleResult:
+        running = asyncio.create_task(self.lifecycle.run(backend, request))
+        while not running.done():
+            if marker.exists():
+                self.lifecycle.cancel(request.execution_id)
+            try:
+                return await asyncio.wait_for(asyncio.shield(running), timeout=0.05)
+            except TimeoutError:
+                continue
+        return await running
+
+    def status(self, execution_id: ExecutionId | str) -> ExecutionStatus:
+        eid = execution_id if isinstance(execution_id, ExecutionId) else ExecutionId(execution_id)
+        paths = self._paths(eid)
+        receipt = self._read_receipt(paths["receipt"])
+        if receipt is not None:
+            return ExecutionStatus(
+                str(eid),
+                "finalized",
+                True,
+                receipt.evidence_sha256,
+                receipt.status is ReceiptStatus.CANCELLED,
+            )
+        state = self._read_state(paths["state"])
+        if state is None:
+            rejection = self._read_state(paths["rejection"])
+            if rejection is None:
+                raise ExecutionNotFound(str(eid))
+            return ExecutionStatus(str(eid), "rejected", True)
+        return ExecutionStatus(
+            str(eid),
+            str(state["phase"]),
+            False,
+            cancellation_requested=bool(state.get("cancellation_requested")),
+        )
+
+    def receipt(self, execution_id: ExecutionId | str) -> ExecutionReceipt | None:
+        eid = execution_id if isinstance(execution_id, ExecutionId) else ExecutionId(execution_id)
+        return self._read_receipt(self._paths(eid)["receipt"])
+
+    def _admit(self, request: GovernedExecutionRequest) -> dict[str, Any]:
+        governance = _mapping(request.governance)
+        authority = governance.get("authority")
+        if authority is not None and (not isinstance(authority, Mapping) or not authority):
+            raise AdmissionRejected(
+                "invalid-authority", "governance.authority must be a non-empty object"
+            )
+        legacy_constraints = governance.get("constraints", {})
+        if not isinstance(legacy_constraints, Mapping):
+            raise AdmissionRejected(
+                "invalid-constraints", "governance.constraints must be an object"
+            )
+        constraints = request.constraints.to_dict()
+        required_unknown = sorted(
+            name
+            for name, value in request.constraints.unknown_fields.items()
+            if name not in _SUPPORTED_CONSTRAINTS and _constraint_required(value)
+        )
+        if required_unknown:
+            raise AdmissionRejected(
+                "unsupported-required-constraint",
+                f"unsupported required constraints: {', '.join(required_unknown)}",
+            )
+        self._validate_governance_structure(governance, constraints)
+        try:
+            seat = self.seats.get(request.seat_instance_id)
+        except Exception as exc:
+            raise AdmissionRejected("seat-not-registered", str(exc)) from exc
+        expected_address = governance.get("seat_address")
+        if expected_address is not None and str(seat.address) != expected_address:
+            raise AdmissionRejected(
+                "seat-address-mismatch", "declared seat address does not match registry"
+            )
+        if seat.seat_id != request.seat_type:
+            raise AdmissionRejected(
+                "seat-type-mismatch", "request seat_type does not match registered seat"
+            )
+        if (
+            seat.sovereign_session_id is not None
+            and seat.sovereign_session_id != request.sovereign_session_id
+        ):
+            raise AdmissionRejected(
+                "session-mismatch",
+                "request sovereign_session_id does not match the registered binding",
+            )
+        if request.constraints.max_invocations != 1:
+            raise AdmissionRejected(
+                "unsupported-required-constraint",
+                "this engine supports exactly one provider invocation per execution",
+            )
+        if governance.get("provider") not in (None, seat.provider):
+            raise AdmissionRejected(
+                "provider-mismatch", "declared provider does not match registered seat"
+            )
+        if governance.get("backend") not in (None, seat.backend):
+            raise AdmissionRejected(
+                "backend-mismatch", "declared backend does not match registered seat"
+            )
+        provider = self._provider(seat.provider)
+        if provider is None:
+            raise AdmissionRejected("provider-unavailable", seat.provider)
+        backend = self.backends.get(seat.backend)
+        if backend is None:
+            raise AdmissionRejected("backend-unavailable", seat.backend)
+        backend_available = backend.capabilities().get("available")
+        if backend_available is not None and not backend_available.is_available():
+            raise AdmissionRejected(
+                "backend-unavailable",
+                f"{seat.backend} reports unavailable with "
+                f"{backend_available.evidence_level.to_wire()} evidence",
+            )
+        try:
+            self.repositories.resolve(request.repository_id)
+        except Exception as exc:
+            raise AdmissionRejected("repository-not-governed", str(exc)) from exc
+        if constraints.get("structured_output") and not provider.capabilities.structured_result:
+            raise AdmissionRejected(
+                "capability-mismatch", "structured_output requires provider support"
+            )
+        if (
+            "structured_result" in request.required_evidence
+            and not provider.capabilities.structured_result
+        ):
+            raise AdmissionRejected(
+                "capability-mismatch",
+                "required structured_result evidence is unavailable",
+            )
+        if "verification_commands" in request.required_evidence and not request.acceptance_commands:
+            raise AdmissionRejected(
+                "missing-required-evidence",
+                "verification_commands evidence requires acceptance_commands",
+            )
+        if (
+            "remote_containment" in request.required_evidence
+            and not request.constraints.delivery_enabled
+        ):
+            raise AdmissionRejected(
+                "missing-required-evidence",
+                "remote_containment evidence requires requested delivery",
+            )
+        backend_manifest = backend.capabilities()
+        sandbox_minimum = request.constraints.sandbox_minimum.value
+        if sandbox_minimum == "process" and not backend_manifest.is_available("process_isolation"):
+            raise AdmissionRejected("capability-mismatch", "process sandbox minimum is unavailable")
+        require_filesystem = bool(constraints.get("filesystem_isolation")) or (
+            sandbox_minimum in {"filesystem-isolated", "network-restricted"}
+        )
+        require_network = bool(constraints.get("network_isolation")) or (
+            sandbox_minimum == "network-restricted"
+            or request.constraints.network.value in {"restricted", "denied"}
+        )
+        if sandbox_minimum != "none" and not isinstance(provider, CliProvider):
+            raise AdmissionRejected(
+                "capability-mismatch",
+                "in-process providers cannot satisfy an external process or OS sandbox boundary",
+            )
+        for constraint_name, capability_name in (
+            ("filesystem_isolation", "filesystem_isolation"),
+            ("network_isolation", "network_isolation"),
+        ):
+            required = (
+                require_filesystem if constraint_name == "filesystem_isolation" else require_network
+            )
+            if required and not (
+                backend_manifest.is_available(capability_name)
+                and backend_manifest.has_evidence(capability_name, EvidenceLevel.ENFORCED)
+            ):
+                raise AdmissionRejected(
+                    "capability-mismatch",
+                    f"{constraint_name} requires enforced backend evidence",
+                )
+        if isinstance(provider, CliProvider):
+            provider_backend_manifest = provider.backend.capabilities()
+            required_provider_capabilities = (
+                ("process_isolation", sandbox_minimum != "none"),
+                ("filesystem_isolation", require_filesystem),
+                ("network_isolation", require_network),
+            )
+            for capability_name, required in required_provider_capabilities:
+                if required and not (
+                    provider_backend_manifest.is_available(capability_name)
+                    and provider_backend_manifest.has_evidence(
+                        capability_name,
+                        EvidenceLevel.ENFORCED
+                        if capability_name != "process_isolation"
+                        else EvidenceLevel.PROBED,
+                    )
+                ):
+                    raise AdmissionRejected(
+                        "capability-mismatch",
+                        f"provider invocation backend cannot prove {capability_name}",
+                    )
+        self._check_capabilities(request, seat, provider, backend)
+        return {"seat": seat, "provider": provider, "backend": backend}
+
+    @staticmethod
+    def _validate_governance_structure(
+        governance: Mapping[str, Any], constraints: Mapping[str, Any]
+    ) -> None:
+        for name in (
+            "filesystem_isolation",
+            "network_isolation",
+            "preserve_on_failure",
+        ):
+            if name in constraints and not isinstance(constraints[name], bool):
+                raise AdmissionRejected(
+                    "invalid-constraints", f"constraints.{name} must be boolean"
+                )
+        if "dirty_worktree" in constraints and constraints["dirty_worktree"] not in {
+            "fail",
+            "allow",
+        }:
+            raise AdmissionRejected(
+                "invalid-constraints", "constraints.dirty_worktree must be fail or allow"
+            )
+        if "base_ref" in constraints and not isinstance(constraints["base_ref"], str):
+            raise AdmissionRejected("invalid-constraints", "constraints.base_ref must be a string")
+        if "timeouts" in constraints and not isinstance(constraints["timeouts"], Mapping):
+            raise AdmissionRejected("invalid-constraints", "constraints.timeouts must be an object")
+        if isinstance(constraints.get("timeouts"), Mapping):
+            timeout_names = {
+                "prepare_s",
+                "execute_s",
+                "close_s",
+                "lifecycle_s",
+                "idle_s",
+                "completion_s",
+                "force_teardown_s",
+            }
+            unknown_timeouts = sorted(set(constraints["timeouts"]) - timeout_names)
+            if unknown_timeouts:
+                raise AdmissionRejected(
+                    "invalid-constraints",
+                    f"unknown timeout fields: {', '.join(unknown_timeouts)}",
+                )
+            if any(
+                value is not None
+                and (not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0)
+                for value in constraints["timeouts"].values()
+            ):
+                raise AdmissionRejected(
+                    "invalid-constraints", "timeout values must be positive numbers or null"
+                )
+        structured = constraints.get("structured_output")
+        if structured is not None and not isinstance(structured, (bool, Mapping)):
+            raise AdmissionRejected(
+                "invalid-constraints",
+                "constraints.structured_output must be boolean or object",
+            )
+        _validate_predicate_declarations(
+            governance.get("verification", ()),
+            {
+                "provider_success",
+                "changed_paths_nonempty",
+                "head_changed",
+                "clean_worktree",
+                "file_exists",
+                "output_field_equals",
+            },
+            "verification",
+        )
+        _validate_predicate_declarations(
+            governance.get("business_completion", ()),
+            {
+                "process_complete",
+                "provider_success",
+                "output_field_equals",
+                "changed_paths_nonempty",
+            },
+            "business_completion",
+        )
+        delivery = governance.get("delivery", {})
+        if not isinstance(delivery, Mapping):
+            raise AdmissionRejected("invalid-delivery", "delivery must be an object")
+        if "enabled" in delivery and not isinstance(delivery["enabled"], bool):
+            raise AdmissionRejected("invalid-delivery", "delivery.enabled must be boolean")
+        for name in ("remote", "branch"):
+            if (
+                name in delivery
+                and delivery[name] is not None
+                and not isinstance(delivery[name], str)
+            ):
+                raise AdmissionRejected(
+                    "invalid-delivery", f"delivery.{name} must be a string or null"
+                )
+
+    def _check_capabilities(
+        self,
+        request: GovernedExecutionRequest,
+        seat: SeatInstance,
+        provider: AgentProvider,
+        backend: WorkerBackend,
+    ) -> None:
+        provider_manifest = provider.capabilities.to_manifest()
+        backend_manifest = backend.capabilities()
+        for name, requirement in request.capability_manifest.capabilities.items():
+            if not getattr(requirement, "available", False):
+                continue
+            minimum = requirement.evidence_level
+            supplied = provider_manifest.get(name) or backend_manifest.get(name)
+            if supplied is None and name in seat.capabilities:
+                if minimum <= EvidenceLevel.DECLARED:
+                    continue
+            if (
+                supplied is None
+                or not supplied.is_available()
+                or not supplied.has_evidence(minimum)
+            ):
+                raise AdmissionRejected(
+                    "capability-mismatch",
+                    f"{name} requires {minimum.to_wire()} availability evidence",
+                )
+        if not provider.capabilities.available:
+            raise AdmissionRejected("provider-unavailable", provider.name)
+
+    def _verify_structured(self, constraints: Mapping[str, Any], result: Mapping[str, Any]) -> None:
+        spec = constraints.get("structured_output", False)
+        if not spec:
+            return
+        events = result.get("events", ())
+        structured = [
+            item.get("result")
+            for item in events
+            if isinstance(item, Mapping) and item.get("type") == StructuredResultEvent.EVENT_TYPE
+        ]
+        if not structured:
+            raise _TerminalFailure(
+                TerminalReason.INVALID_STRUCTURED_OUTPUT,
+                "structured output was required but no structured_result event was emitted",
+            )
+        if isinstance(spec, Mapping):
+            fields = spec.get("required_fields", ())
+            if not isinstance(fields, Sequence) or isinstance(fields, str):
+                raise _TerminalFailure(
+                    TerminalReason.INVALID_STRUCTURED_OUTPUT,
+                    "required_fields must be an array",
+                )
+            missing = [name for name in fields if name not in _mapping(structured[-1])]
+            if missing:
+                raise _TerminalFailure(
+                    TerminalReason.INVALID_STRUCTURED_OUTPUT,
+                    f"missing structured fields: {', '.join(map(str, missing))}",
+                )
+
+    def _verify_predicates(
+        self,
+        specs: Any,
+        result: Mapping[str, Any],
+        evidence: GitEvidence,
+        repo: RepositoryExecution,
+    ) -> None:
+        for spec in _predicate_list(specs):
+            kind = str(spec.get("type", ""))
+            passed = False
+            if kind == "provider_success":
+                passed = bool(result.get("success"))
+            elif kind == "changed_paths_nonempty":
+                passed = bool(evidence.changed_paths)
+            elif kind == "head_changed":
+                passed = evidence.head_sha != evidence.base_sha
+            elif kind == "clean_worktree":
+                passed = not evidence.status_porcelain
+            elif kind == "file_exists":
+                path = self.repositories.resolve_relative_path(repo, str(spec.get("path", "")))
+                passed = path.is_file()
+            elif kind == "output_field_equals":
+                passed = _mapping(result.get("output", {})).get(str(spec.get("field"))) == spec.get(
+                    "value"
+                )
+            else:
+                raise _TerminalFailure(
+                    TerminalReason.VERIFICATION_FAILED,
+                    f"unsupported verification predicate: {kind}",
+                )
+            if not passed:
+                raise _TerminalFailure(
+                    TerminalReason.VERIFICATION_FAILED, f"predicate failed: {kind}"
+                )
+
+    def _verify_business(
+        self, specs: Any, result: Mapping[str, Any], evidence: GitEvidence
+    ) -> None:
+        for spec in _predicate_list(specs):
+            kind = str(spec.get("type", ""))
+            if kind == "process_complete":
+                passed = True
+            elif kind == "provider_success":
+                passed = bool(result.get("success"))
+            elif kind == "output_field_equals":
+                passed = _mapping(result.get("output", {})).get(str(spec.get("field"))) == spec.get(
+                    "value"
+                )
+            elif kind == "changed_paths_nonempty":
+                passed = bool(evidence.changed_paths)
+            else:
+                raise _TerminalFailure(
+                    TerminalReason.BUSINESS_VERIFICATION_FAILED,
+                    f"unsupported business predicate: {kind}",
+                )
+            if not passed:
+                raise _TerminalFailure(
+                    TerminalReason.BUSINESS_VERIFICATION_FAILED,
+                    f"business predicate failed: {kind}",
+                )
+
+    def _run_acceptance_commands(
+        self,
+        request: GovernedExecutionRequest,
+        repo: RepositoryExecution,
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        timeout = request.constraints.timeouts.get("completion_s")
+        if timeout is None:
+            timeout = request.constraints.idle_timeout_seconds
+        for command in request.acceptance_commands:
+            try:
+                completed = subprocess.run(
+                    command,
+                    cwd=repo.worktree_path,
+                    env={
+                        name: os.environ[name]
+                        for name in ("PATH", "LANG", "LC_ALL", "TMPDIR")
+                        if name in os.environ
+                    }
+                    | {"GIT_TERMINAL_PROMPT": "0"},
+                    stdin=subprocess.DEVNULL,
+                    capture_output=True,
+                    check=False,
+                    shell=False,
+                    timeout=float(timeout) if timeout is not None else None,
+                    text=True,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise _TerminalFailure(
+                    TerminalReason.VERIFICATION_FAILED,
+                    f"acceptance command timed out: {command[0]}",
+                ) from exc
+            record = {
+                "argv": list(command),
+                "returncode": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+            }
+            results.append(_redact_persistence(record))
+            if completed.returncode != 0:
+                raise _TerminalFailure(
+                    TerminalReason.VERIFICATION_FAILED,
+                    f"acceptance command failed ({completed.returncode}): {command[0]}",
+                )
+        return results
+
+    @staticmethod
+    def _verify_required_evidence(
+        request: GovernedExecutionRequest, state: Mapping[str, Any]
+    ) -> None:
+        for required in request.required_evidence:
+            if required == "structured_result":
+                events = _mapping(state.get("provider_result", {})).get("events", ())
+                present = any(
+                    isinstance(event, Mapping)
+                    and event.get("type") == StructuredResultEvent.EVENT_TYPE
+                    for event in events
+                )
+            elif required == "verification_commands":
+                present = bool(state.get("verification_commands"))
+            elif required == "commit_sha":
+                present = bool(_mapping(state.get("git_evidence", {})).get("head_sha"))
+            elif required == "remote_containment":
+                present = (
+                    _mapping(state.get("delivery", {})).get("state") == DeliveryState.VERIFIED.value
+                )
+            else:
+                present = False
+            if not present:
+                raise _TerminalFailure(
+                    TerminalReason.VERIFICATION_FAILED,
+                    f"required evidence missing: {required}",
+                )
+
+    def _finalize_success(
+        self,
+        request: GovernedExecutionRequest,
+        state: dict[str, Any],
+        paths: dict[str, Path],
+        seat: SeatInstance,
+    ) -> ExecutionReceipt:
+        return self._finalize(
+            request,
+            state,
+            paths,
+            ReceiptStatus.SUCCEEDED,
+            result=_mapping(state["provider_result"]).get("output", {}),
+            error=None,
+            seat=seat,
+        )
+
+    def _finalize_failure(
+        self,
+        request: GovernedExecutionRequest,
+        state: dict[str, Any],
+        paths: dict[str, Path],
+        reason: str,
+        detail: str,
+        seat: SeatInstance,
+        *,
+        cancelled: bool = False,
+    ) -> ExecutionReceipt:
+        return self._finalize(
+            request,
+            state,
+            paths,
+            ReceiptStatus.CANCELLED if cancelled else ReceiptStatus.FAILED,
+            result=None,
+            error={"reason": reason, "detail": redact_text(detail)},
+            seat=seat,
+        )
+
+    def _finalize(
+        self,
+        request: GovernedExecutionRequest,
+        state: dict[str, Any],
+        paths: dict[str, Path],
+        status: ReceiptStatus,
+        *,
+        result: Any,
+        error: Mapping[str, Any] | None,
+        seat: SeatInstance | None,
+    ) -> ExecutionReceipt:
+        existing = self._read_receipt(paths["receipt"])
+        if existing is not None:
+            return existing
+        evidence = {
+            "phase": state.get("phase"),
+            "provider": state.get("provider"),
+            "backend": state.get("backend"),
+            "request_sha256": state.get("request_sha256"),
+            "authority_refs": list(request.authority_refs),
+            "work_artifact_refs": list(request.work_artifact_refs),
+            "worker_lifecycle": state.get("worker_lifecycle"),
+            "git": state.get("git_evidence"),
+            "delivery": state.get("delivery"),
+            "journal_sha256": _file_sha256(paths["journal"]),
+        }
+        git = _mapping(state.get("git_evidence", {}))
+        delivery = _mapping(state.get("delivery", {}))
+        remote_verified = delivery.get("state") == DeliveryState.VERIFIED.value
+        commits = tuple(
+            CommitEvidence(
+                sha=str(sha),
+                remote_contains=(remote_verified and str(sha) == delivery.get("verified_sha"))
+                if request.constraints.delivery_enabled
+                else None,
+            )
+            for sha in git.get("commits", ())
+        )
+        repository_receipt = (
+            RepositoryReceipt(
+                remote=_optional_str(delivery.get("remote")),
+                branch=_optional_str(git.get("execution_branch")),
+                base_commit=_optional_str(git.get("base_sha")),
+                commits=commits,
+            )
+            if git
+            else None
+        )
+        verification_records = tuple(
+            VerificationCommand(
+                command=tuple(str(item) for item in record.get("argv", ())),
+                exit_code=record.get("returncode"),
+            )
+            for record in state.get("verification_commands", ())
+            if isinstance(record, Mapping)
+        )
+        termination = _receipt_termination(status, error)
+        receipt = ExecutionReceipt(
+            execution_id=request.execution_id,
+            invocation_id=request.invocation_id,
+            status=status,
+            started_at=datetime.fromisoformat(str(state["started_at"])),
+            completed_at=self._now(),
+            result=_redact_persistence(result) if result is not None else None,
+            error=_redact_persistence(error) if error is not None else None,
+            evidence=_redact_persistence(evidence),
+            termination=termination,
+            predecessor_execution_id=request.predecessor_execution_id,
+            seat_type=request.seat_type,
+            seat_instance=request.seat_instance_id,
+            sovereign_session=request.sovereign_session_id,
+            provider=str(state.get("provider") or "") or None,
+            provider_session=request.provider_session_id,
+            worker_backend=str(state.get("backend") or "") or None,
+            capability_manifest_ref=hashlib.sha256(
+                canonical_json_bytes(request.capability_manifest.to_dict())
+            ).hexdigest(),
+            completion_signal_seen="provider_result" in state,
+            structured_result_valid=state.get("phase")
+            not in {"provider_completed", "provider_invoking"}
+            if "provider_result" in state
+            else False,
+            technical_verification_valid=(
+                status is ReceiptStatus.SUCCEEDED
+                or state.get("phase")
+                in {"verification_passed", "business_verified", "delivery_verified"}
+            ),
+            dataflow_integrity_valid=(
+                status is ReceiptStatus.SUCCEEDED
+                or state.get("phase") in {"business_verified", "delivery_verified"}
+            ),
+            repository=repository_receipt,
+            verification=verification_records,
+            artifact_refs=tuple(request.work_artifact_refs) + (str(paths["events"]),),
+            warnings=(
+                (str(state.get("backend")),) if state.get("backend") in {"bare", "none"} else ()
+            ),
+        ).finalize()
+        atomic_write_bytes(paths["receipt"], canonical_json_bytes(receipt.to_dict()))
+        state["receipt_sha256"] = receipt.evidence_sha256
+        self._checkpoint(paths, state, "finalized")
+        if seat is not None:
+            self._emit(
+                request,
+                seat,
+                "execution.receipt",
+                {
+                    "status": receipt.status.value,
+                    "reason": error.get("reason") if error else None,
+                    "evidence_sha256": receipt.evidence_sha256,
+                },
+                "execution.started",
+            )
+        persisted = self._read_receipt(paths["receipt"])
+        assert persisted is not None
+        return persisted
+
+    def _persist_rejection(
+        self,
+        request: GovernedExecutionRequest,
+        rejection: AdmissionRejected,
+        paths: dict[str, Path],
+    ) -> ExecutionReceipt:
+        existing = self._read_receipt(paths["receipt"])
+        if existing is not None:
+            return existing
+        now = self._now()
+        record = {
+            "schema_version": 1,
+            "execution_id": str(request.execution_id),
+            "invocation_id": str(request.invocation_id),
+            "phase": "rejected",
+            "rejected_at": now.isoformat(),
+            "reason": rejection.reason,
+            "detail": rejection.detail,
+            "request": _redact_persistence(request.to_dict()),
+        }
+        atomic_write_bytes(paths["rejection"], canonical_json_bytes(record))
+        state = {
+            "schema_version": 1,
+            "execution_id": str(request.execution_id),
+            "invocation_id": str(request.invocation_id),
+            "phase": "rejected",
+            "started_at": now.isoformat(),
+            "request": record["request"],
+        }
+        return self._finalize(
+            request,
+            state,
+            paths,
+            ReceiptStatus.FAILED,
+            result=None,
+            error={"reason": rejection.reason, "detail": rejection.detail},
+            seat=None,
+        )
+
+    def _checkpoint(self, paths: Mapping[str, Path], state: dict[str, Any], phase: str) -> None:
+        state["phase"] = phase
+        event = {
+            "schema_version": 1,
+            "sequence": _journal_length(paths["journal"]),
+            "phase": phase,
+            "timestamp": self._now().isoformat(),
+        }
+        atomic_append_jsonl(paths["journal"], event)
+        atomic_write_bytes(paths["state"], canonical_json_bytes(_redact_persistence(state)))
+
+    def _emit(
+        self,
+        request: GovernedExecutionRequest,
+        seat: SeatInstance,
+        kind: str,
+        payload: Mapping[str, Any],
+        causation_kind: str | None,
+    ) -> None:
+        if self.relay is None:
+            return
+        recipient = self.relay_recipient or seat.address
+        message_id = _relay_id(request.execution_id, kind)
+        causation = (
+            _relay_id(request.execution_id, causation_kind) if causation_kind is not None else None
+        )
+        self.relay.enqueue(
+            RelayMessage(
+                message_id=message_id,
+                sender=seat.address,
+                recipient=recipient,
+                kind=kind,
+                payload=FrozenDict(tuple(_mapping(_redact_persistence(payload)).items())),
+                created_at=self._now(),
+                conversation_id=str(request.execution_id),
+                reply_to=causation,
+            )
+        )
+
+    def _session(self, request: GovernedExecutionRequest) -> Session:
+        session_id = (
+            f"sess_{hashlib.sha256(str(request.sovereign_session_id).encode()).hexdigest()[:12]}"
+        )
+        try:
+            return load_session(session_id, runtime_root=self.runtime)
+        except Exception:
+            return create_session(
+                scenario="governed-execution",
+                task=redact_text(str(_mapping(request.input).get("task", request.operation))),
+                session_id=session_id,
+                runtime_root=self.runtime,
+            )
+
+    def _provider(self, name: str) -> AgentProvider | None:
+        if isinstance(self.providers, ProviderRegistry):
+            return self.providers.get_or_none(name)
+        return self.providers.get(name)
+
+    def _paths(self, execution_id: ExecutionId) -> dict[str, Path]:
+        digest = hashlib.sha256(str(execution_id).encode()).hexdigest()
+        directory = self.runtime.executions_dir / digest
+        return {
+            "directory": directory,
+            "state": directory / "state.json",
+            "journal": directory / "journal.jsonl",
+            "events": directory / "events.jsonl",
+            "cancel": directory / "cancel.json",
+            "rejection": directory / "rejection.json",
+            "receipt": self.runtime.receipts_dir / f"{digest}.json",
+            "lock": self.runtime.locks_dir / f"execution-{digest}.lock",
+        }
+
+    @staticmethod
+    def _read_state(path: Path) -> dict[str, Any] | None:
+        if not path.exists():
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError(f"invalid execution state: {path}")
+        return value
+
+    @staticmethod
+    def _read_receipt(path: Path) -> ExecutionReceipt | None:
+        if not path.exists():
+            return None
+        return ExecutionReceipt.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    @staticmethod
+    def _validate_resume_identity(
+        request: GovernedExecutionRequest, state: Mapping[str, Any]
+    ) -> None:
+        if state.get("execution_id") != str(request.execution_id):
+            raise ValueError("execution state identity mismatch")
+        if state.get("invocation_id") != str(request.invocation_id):
+            raise ValueError("execution ID cannot be reused with a different invocation ID")
+
+    @staticmethod
+    def _repository_from_state(state: Mapping[str, Any]) -> RepositoryExecution | None:
+        value = state.get("repository")
+        if not isinstance(value, Mapping):
+            return None
+        return RepositoryExecution(
+            repository_id=request_id(value["repository_id"]),
+            execution_id=ExecutionId(str(value["execution_id"])),
+            source_checkout=Path(str(value["source_checkout"])),
+            worktree_path=Path(str(value["worktree_path"])),
+            base_ref=str(value["base_ref"]),
+            base_sha=str(value["base_sha"]),
+            branch=str(value["branch"]),
+            lock_token=str(value["lock_token"]),
+        )
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("clock must return a timezone-aware datetime")
+        return value.astimezone(UTC)
+
+
+class _TerminalFailure(Exception):
+    def __init__(
+        self,
+        reason: TerminalReason,
+        detail: str,
+        *,
+        receipt_reason: str | None = None,
+    ) -> None:
+        self.reason = reason
+        self.receipt_reason = receipt_reason or reason.value
+        self.detail = redact_text(detail)
+        super().__init__(self.detail)
+
+
+class _ProviderInvocationError(RuntimeError):
+    terminal_reason = TerminalReason.PROVIDER_ERROR
+
+
+def request_id(value: object) -> Any:
+    from sovereign_agent.contracts import RepositoryId
+
+    return RepositoryId(str(value))
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, FrozenDict):
+        thawed = thaw_json(value)
+        assert isinstance(thawed, dict)
+        return thawed
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _redact_persistence(value: Any) -> Any:
+    """Redact sensitive keys and inline credentials in every persisted string."""
+    redacted = redact_json(value)
+
+    def visit(item: Any) -> Any:
+        if isinstance(item, dict):
+            return {key: visit(child) for key, child in item.items()}
+        if isinstance(item, list):
+            return [visit(child) for child in item]
+        if isinstance(item, str):
+            return redact_text(item)
+        return item
+
+    return visit(redacted)
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _constraint_required(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return bool(value.get("required", True))
+    return bool(value)
+
+
+def _predicate_list(value: Any) -> list[dict[str, Any]]:
+    if value in (None, (), []):
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise _TerminalFailure(TerminalReason.VERIFICATION_FAILED, "predicates must be an array")
+    if any(not isinstance(item, Mapping) for item in value):
+        raise _TerminalFailure(
+            TerminalReason.VERIFICATION_FAILED, "each predicate must be an object"
+        )
+    return [dict(item) for item in value]
+
+
+def _validate_predicate_declarations(value: Any, supported: set[str], label: str) -> None:
+    if value in (None, (), []):
+        return
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise AdmissionRejected("invalid-predicate", f"{label} must be an array")
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise AdmissionRejected("invalid-predicate", f"{label} entries must be objects")
+        kind = item.get("type")
+        if not isinstance(kind, str) or kind not in supported:
+            raise AdmissionRejected(
+                "unsupported-predicate", f"unsupported {label} predicate: {kind}"
+            )
+
+
+def _timeouts_from_request(request: GovernedExecutionRequest) -> LifecycleTimeouts:
+    data = _mapping(request.constraints.timeouts)
+    if request.constraints.idle_timeout_seconds is not None and "idle_s" not in data:
+        data["idle_s"] = request.constraints.idle_timeout_seconds
+    return _timeouts(data)
+
+
+def _timeouts(value: Any) -> LifecycleTimeouts:
+    data = _mapping(value)
+    allowed = {
+        "prepare_s",
+        "execute_s",
+        "close_s",
+        "lifecycle_s",
+        "idle_s",
+        "completion_s",
+        "force_teardown_s",
+    }
+    unknown = sorted(set(data) - allowed)
+    if unknown:
+        raise _TerminalFailure(
+            TerminalReason.WORKER_ERROR, f"unknown timeout fields: {', '.join(unknown)}"
+        )
+    return LifecycleTimeouts(**data)
+
+
+def _repository_to_dict(value: RepositoryExecution) -> dict[str, Any]:
+    return {
+        "repository_id": str(value.repository_id),
+        "execution_id": str(value.execution_id),
+        "source_checkout": str(value.source_checkout),
+        "worktree_path": str(value.worktree_path),
+        "base_ref": value.base_ref,
+        "base_sha": value.base_sha,
+        "branch": value.branch,
+        "lock_token": value.lock_token,
+    }
+
+
+def _git_evidence_to_dict(value: GitEvidence) -> dict[str, Any]:
+    return {
+        "identity": {
+            "repository_id": str(value.identity.repository_id),
+            "checkout": value.identity.checkout,
+            "remote_name": value.identity.remote_name,
+            "remote_url": value.identity.remote_url,
+        },
+        "base_ref": value.base_ref,
+        "base_sha": value.base_sha,
+        "execution_branch": value.execution_branch,
+        "head_sha": value.head_sha,
+        "status_porcelain": value.status_porcelain.decode("utf-8", errors="replace"),
+        "changed_paths": list(value.changed_paths),
+        "diff_stat": value.diff_stat.decode("utf-8", errors="replace"),
+        "patch_sha256": value.patch_sha256,
+        "commits": list(value.commits),
+        "worktree_path": value.worktree_path,
+        "artifact_references": list(value.artifact_references),
+    }
+
+
+def _delivery_to_dict(value: DeliveryResult) -> dict[str, Any]:
+    return {
+        "local_complete": value.local_complete,
+        "state": value.state.value,
+        "local_sha": value.local_sha,
+        "remote": value.remote,
+        "remote_ref": value.remote_ref,
+        "verified_sha": value.verified_sha,
+        "failure_reason": value.failure_reason.value if value.failure_reason else None,
+        "detail": redact_text(value.detail or "") or None,
+    }
+
+
+def _exception_reason(exc: Exception) -> str:
+    name = type(exc).__name__.casefold()
+    if "dirty" in name:
+        return "repository-dirty"
+    if "isolation" in name:
+        return TerminalReason.ISOLATION_UNAVAILABLE.value
+    if "timeout" in name:
+        return TerminalReason.WORKER_TIMEOUT.value
+    if "provider" in name:
+        return TerminalReason.PROVIDER_ERROR.value
+    if "repository" in name:
+        return "repository-error"
+    return TerminalReason.WORKER_ERROR.value
+
+
+def _receipt_termination(
+    status: ReceiptStatus, error: Mapping[str, Any] | None
+) -> ReceiptTermination:
+    if status is ReceiptStatus.SUCCEEDED:
+        return ReceiptTermination.COMPLETED
+    if status is ReceiptStatus.CANCELLED:
+        return ReceiptTermination.ABORTED
+    reason = str(error.get("reason", "")) if error else ""
+    refuse = {
+        "invalid-authority",
+        "invalid-constraints",
+        "invalid-delivery",
+        "invalid-predicate",
+        "unsupported-required-constraint",
+        "unsupported-predicate",
+        "seat-not-registered",
+        "seat-type-mismatch",
+        "seat-address-mismatch",
+        "session-mismatch",
+        "provider-unavailable",
+        "backend-unavailable",
+        "provider-mismatch",
+        "backend-mismatch",
+        "repository-not-governed",
+        "capability-mismatch",
+        "missing-required-evidence",
+    }
+    if reason in refuse:
+        return ReceiptTermination.REFUSED
+    if reason.startswith("delivery-"):
+        return ReceiptTermination.DELIVERY_FAILED
+    try:
+        return ReceiptTermination(reason)
+    except ValueError:
+        return ReceiptTermination.WORKER_ERROR
+
+
+def _relay_id(execution_id: ExecutionId, kind: str) -> RelayMessageId:
+    digest = hashlib.sha256(f"{execution_id}\0{kind}".encode()).hexdigest()[:24]
+    return RelayMessageId(f"exec-{digest}")
+
+
+def _file_sha256(path: Path) -> str:
+    if not path.exists():
+        return hashlib.sha256(b"").hexdigest()
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _journal_length(path: Path) -> int:
+    if not path.exists():
+        return 0
+    return sum(1 for line in path.read_bytes().splitlines() if line)
+
+
+@asynccontextmanager
+async def _async_file_lock(path: Path) -> Any:
+    """Acquire the process-safe Unit 6 lock without blocking the event loop."""
+    manager = exclusive_file_lock(path)
+    await asyncio.to_thread(manager.__enter__)
+    try:
+        yield
+    finally:
+        await asyncio.to_thread(manager.__exit__, None, None, None)
+
+
+__all__ = [
+    "AdmissionRejected",
+    "ExecutionNotFound",
+    "ExecutionStatus",
+    "GovernedExecutionEngine",
+]

--- a/src/sovereign_agent/orchestrator/lifecycle.py
+++ b/src/sovereign_agent/orchestrator/lifecycle.py
@@ -36,6 +36,7 @@ class TerminalReason(StrEnum):
     IDLE_TIMEOUT = "idle-timeout"
     COMPLETION_TIMEOUT = "completion-timeout"
     WORKER_TIMEOUT = "worker-timeout"
+    PROVIDER_TIMEOUT = "provider-timeout"
     LIFECYCLE_TIMEOUT = "lifecycle-timeout"
     PROVIDER_ERROR = "provider-error"
     WORKER_ERROR = "worker-error"

--- a/src/sovereign_agent/providers/claude.py
+++ b/src/sovereign_agent/providers/claude.py
@@ -54,6 +54,7 @@ class ClaudeCodeProvider(CliProvider):
     def invocation_spec(self, request: InvocationRequest) -> InvocationSpec:
         context = thaw_json(request.context)
         assert isinstance(context, dict)
+        cwd = self.working_directory(request)
         schema = object_value(context.get("json_schema"))
         if context.get("require_structured_result") and schema is None:
             raise ProviderUnavailable("claude structured results require context.json_schema")
@@ -69,7 +70,7 @@ class ClaudeCodeProvider(CliProvider):
         if schema is not None:
             command.extend(("--json-schema", json.dumps(schema, sort_keys=True)))
         command.append(request.task)
-        return self.spec(command, cwd=request.session.directory)
+        return self.spec(command, cwd=cwd)
 
     def parse_output(self, stdout: str, request: InvocationRequest) -> list[ProviderEventType]:
         builder = EventBuilder(request)

--- a/src/sovereign_agent/providers/cli.py
+++ b/src/sovereign_agent/providers/cli.py
@@ -258,5 +258,21 @@ class CliProvider(ABC):
             stdin=stdin,
         )
 
+    def working_directory(self, request: InvocationRequest) -> Path:
+        """Use an admitted repository worktree when the execution engine supplies one."""
+        context = thaw_json(request.context)
+        assert isinstance(context, dict)
+        configured = context.get("repository_worktree")
+        if configured is None:
+            return request.session.directory
+        if not isinstance(configured, str):
+            raise ProviderUnavailable("repository_worktree must be an absolute directory path")
+        path = Path(configured)
+        if not path.is_absolute() or path.is_symlink() or not path.is_dir():
+            raise ProviderUnavailable(
+                "repository_worktree must be an existing non-symlink absolute directory"
+            )
+        return path
+
 
 __all__ = ["CliProvider", "ProbeEvidence", "ProviderUnavailable"]

--- a/src/sovereign_agent/providers/codex.py
+++ b/src/sovereign_agent/providers/codex.py
@@ -54,6 +54,7 @@ class CodexCliProvider(CliProvider):
     def invocation_spec(self, request: InvocationRequest) -> InvocationSpec:
         context = thaw_json(request.context)
         assert isinstance(context, dict)
+        cwd = self.working_directory(request)
         schema_path = context.get("output_schema_path")
         if context.get("require_structured_result") and not isinstance(schema_path, str):
             raise ProviderUnavailable("codex structured results require context.output_schema_path")
@@ -80,7 +81,7 @@ class CodexCliProvider(CliProvider):
                 parts.extend(("--output-schema", schema_path))
             parts.extend((str(request.provider_session_id), request.task))
             command = tuple(parts)
-        return self.spec(command, cwd=request.session.directory)
+        return self.spec(command, cwd=cwd)
 
     def parse_output(self, stdout: str, request: InvocationRequest) -> list[ProviderEventType]:
         builder = EventBuilder(request)

--- a/src/sovereign_agent/registry/manager.py
+++ b/src/sovereign_agent/registry/manager.py
@@ -15,7 +15,12 @@ from typing import Any
 from sovereign_agent._internal.atomic import atomic_write_bytes
 from sovereign_agent._internal.file_lock import exclusive_file_lock
 from sovereign_agent.contracts._core import canonical_json_bytes
-from sovereign_agent.contracts.ids import SeatId, SeatInstanceId
+from sovereign_agent.contracts.ids import (
+    ProviderSessionId,
+    SeatId,
+    SeatInstanceId,
+    SovereignSessionId,
+)
 from sovereign_agent.runtime import RuntimeRoot
 
 from .errors import (
@@ -51,6 +56,9 @@ class SeatRegistry:
         address: RuntimeAddress | str | None = None,
         lifecycle: SeatLifecycle = SeatLifecycle.REGISTERED,
         status: Mapping[str, Any] | None = None,
+        sovereign_session_id: SovereignSessionId | str | None = None,
+        provider_session_id: ProviderSessionId | str | None = None,
+        capability_manifest_ref: str | None = None,
     ) -> SeatInstance:
         iid = (
             instance_id if isinstance(instance_id, SeatInstanceId) else SeatInstanceId(instance_id)
@@ -76,6 +84,9 @@ class SeatRegistry:
             heartbeat_at=now,
             lifecycle=lifecycle,
             status=status or {},  # type: ignore[arg-type]
+            sovereign_session_id=sovereign_session_id,  # type: ignore[arg-type]
+            provider_session_id=provider_session_id,  # type: ignore[arg-type]
+            capability_manifest_ref=capability_manifest_ref,
         )
         with self._guard(iid):
             path = self._record_path(iid)
@@ -135,6 +146,9 @@ class SeatRegistry:
                 heartbeat_at=now,
                 lifecycle=lifecycle or current.lifecycle,
                 status=current.status if status is None else status,  # type: ignore[arg-type]
+                sovereign_session_id=current.sovereign_session_id,
+                provider_session_id=current.provider_session_id,
+                capability_manifest_ref=current.capability_manifest_ref,
             )
             atomic_write_bytes(self._record_path(iid), canonical_json_bytes(updated.to_dict()))
             self._fsync_directory(self._records)
@@ -175,6 +189,9 @@ class SeatRegistry:
             item.backend,
             item.capabilities,
             item.address,
+            item.sovereign_session_id,
+            item.provider_session_id,
+            item.capability_manifest_ref,
         )
 
     def _record_path(self, instance_id: SeatInstanceId) -> Path:

--- a/src/sovereign_agent/registry/models.py
+++ b/src/sovereign_agent/registry/models.py
@@ -17,7 +17,12 @@ from sovereign_agent.contracts._core import (
     require_string,
     thaw_json,
 )
-from sovereign_agent.contracts.ids import SeatId, SeatInstanceId
+from sovereign_agent.contracts.ids import (
+    ProviderSessionId,
+    SeatId,
+    SeatInstanceId,
+    SovereignSessionId,
+)
 
 REGISTRY_SCHEMA_VERSION = 1
 _ADDRESS = re.compile(r"^local://([A-Za-z0-9](?:[A-Za-z0-9._:/-]{0,126}[A-Za-z0-9])?)$")
@@ -97,6 +102,9 @@ class SeatInstance:
     heartbeat_at: datetime
     lifecycle: SeatLifecycle = SeatLifecycle.REGISTERED
     status: FrozenDict = field(default_factory=FrozenDict)
+    sovereign_session_id: SovereignSessionId | None = None
+    provider_session_id: ProviderSessionId | None = None
+    capability_manifest_ref: str | None = None
     schema_version: int = REGISTRY_SCHEMA_VERSION
 
     def __post_init__(self) -> None:
@@ -116,6 +124,27 @@ class SeatInstance:
             object.__setattr__(self, "address", RuntimeAddress(str(self.address)))
         if self.address.instance_id != self.instance_id:
             raise ValueError("runtime address does not match instance ID")
+        if self.sovereign_session_id is not None and not isinstance(
+            self.sovereign_session_id, SovereignSessionId
+        ):
+            object.__setattr__(
+                self, "sovereign_session_id", SovereignSessionId(str(self.sovereign_session_id))
+            )
+        if self.provider_session_id is not None:
+            if not isinstance(self.provider_session_id, ProviderSessionId):
+                object.__setattr__(
+                    self, "provider_session_id", ProviderSessionId(str(self.provider_session_id))
+                )
+            if self.provider_session_id.value == self.instance_id.value:
+                raise ValueError("provider session identity cannot be a seat instance identity")
+        if self.capability_manifest_ref is not None:
+            if (
+                not isinstance(self.capability_manifest_ref, str)
+                or not self.capability_manifest_ref
+            ):
+                raise ValueError("capability_manifest_ref must be a non-empty artifact reference")
+            if any(token in self.capability_manifest_ref for token in ("\n", "\r", "\0")):
+                raise ValueError("capability_manifest_ref must be a single-line artifact reference")
         for name in ("registered_at", "updated_at", "heartbeat_at"):
             value = getattr(self, name)
             if value.tzinfo is None or value.utcoffset() is None:
@@ -150,6 +179,13 @@ class SeatInstance:
             "heartbeat_at": format_datetime(self.heartbeat_at, "heartbeat_at"),
             "lifecycle": self.lifecycle.value,
             "status": thaw_json(self.status),
+            "sovereign_session_id": (
+                None if self.sovereign_session_id is None else self.sovereign_session_id.value
+            ),
+            "provider_session_id": (
+                None if self.provider_session_id is None else self.provider_session_id.value
+            ),
+            "capability_manifest_ref": self.capability_manifest_ref,
         }
 
     @classmethod
@@ -172,7 +208,28 @@ class SeatInstance:
             heartbeat_at=parse_datetime(data["heartbeat_at"], "heartbeat_at"),
             lifecycle=SeatLifecycle(str(data["lifecycle"])),
             status=freeze_json(data.get("status", {})),
+            sovereign_session_id=_optional_id(
+                data.get("sovereign_session_id"), SovereignSessionId, "sovereign_session_id"
+            ),
+            provider_session_id=_optional_id(
+                data.get("provider_session_id"), ProviderSessionId, "provider_session_id"
+            ),
+            capability_manifest_ref=_optional_string(data.get("capability_manifest_ref")),
         )
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("expected optional string")
+    return value
+
+
+def _optional_id(value: object, cls: type, name: str) -> Any:
+    if value is None:
+        return None
+    return cls(require_string(value, name))
 
 
 __all__ = [

--- a/src/sovereign_agent/relay/manager.py
+++ b/src/sovereign_agent/relay/manager.py
@@ -109,6 +109,9 @@ class DurableRelay:
                     DeliveryStatus.DEAD_LETTERED,
                 }:
                     continue
+                if self._expired(record, now):
+                    self._dead_letter(path, record, now, "message expired")
+                    continue
                 if record.status is DeliveryStatus.CLAIMED:
                     assert record.lease_expires_at is not None
                     if record.lease_expires_at > now:
@@ -263,6 +266,11 @@ class DurableRelay:
         """Optional in-process wake-up only; callers must always re-check durable state."""
         with self._condition:
             self._condition.wait(timeout)
+
+    @staticmethod
+    def _expired(record: DeliveryRecord, now: datetime) -> bool:
+        expires = record.message.expires_at
+        return expires is not None and expires <= now
 
     def _recover_expired(self, path: Path, record: DeliveryRecord, now: datetime) -> DeliveryRecord:
         if record.attempt_count >= self.max_attempts:

--- a/src/sovereign_agent/relay/models.py
+++ b/src/sovereign_agent/relay/models.py
@@ -16,7 +16,7 @@ from sovereign_agent.contracts._core import (
     require_string,
     thaw_json,
 )
-from sovereign_agent.contracts.ids import RelayMessageId
+from sovereign_agent.contracts.ids import RelayMessageId, SeatInstanceId
 from sovereign_agent.registry import RuntimeAddress
 from sovereign_agent.registry.models import validate_runtime_identifier
 
@@ -38,8 +38,11 @@ class RelayMessage:
     kind: str
     payload: FrozenDict
     created_at: datetime
-    correlation_id: str | None = None
-    causation_id: RelayMessageId | None = None
+    conversation_id: str | None = None
+    reply_to: RelayMessageId | None = None
+    requires_ack: bool = True
+    artifact_refs: tuple[str, ...] = ()
+    expires_at: datetime | None = None
     schema_version: int = RELAY_SCHEMA_VERSION
 
     def __post_init__(self) -> None:
@@ -59,14 +62,34 @@ class RelayMessage:
         if self.created_at.tzinfo is None or self.created_at.utcoffset() is None:
             raise ValueError("created_at must be timezone-aware")
         object.__setattr__(self, "created_at", self.created_at.astimezone(UTC))
-        if self.correlation_id is not None and not self.correlation_id:
-            raise ValueError("correlation_id must not be empty")
-        if self.causation_id is not None and not isinstance(self.causation_id, RelayMessageId):
-            object.__setattr__(self, "causation_id", RelayMessageId(str(self.causation_id)))
-        if self.causation_id is not None:
-            validate_runtime_identifier(self.causation_id.value, "causation_id")
+        if self.conversation_id is not None and not self.conversation_id:
+            raise ValueError("conversation_id must not be empty")
+        if self.reply_to is not None and not isinstance(self.reply_to, RelayMessageId):
+            object.__setattr__(self, "reply_to", RelayMessageId(str(self.reply_to)))
+        if self.reply_to is not None:
+            validate_runtime_identifier(self.reply_to.value, "reply_to")
+        if not isinstance(self.requires_ack, bool):
+            raise ValueError("requires_ack must be a boolean")
+        refs = tuple(self.artifact_refs)
+        if any(
+            not isinstance(item, str) or not item or "\n" in item or "\0" in item for item in refs
+        ):
+            raise ValueError("artifact_refs must be non-empty single-line references")
+        object.__setattr__(self, "artifact_refs", refs)
+        if self.expires_at is not None:
+            if self.expires_at.tzinfo is None or self.expires_at.utcoffset() is None:
+                raise ValueError("expires_at must be timezone-aware")
+            object.__setattr__(self, "expires_at", self.expires_at.astimezone(UTC))
         if self.schema_version != RELAY_SCHEMA_VERSION:
             raise ValueError("unsupported relay schema version")
+
+    @property
+    def from_instance(self) -> SeatInstanceId:
+        return self.sender.instance_id
+
+    @property
+    def to_instance(self) -> SeatInstanceId:
+        return self.recipient.instance_id
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -75,30 +98,46 @@ class RelayMessage:
             "sender": self.sender.value,
             "recipient": self.recipient.value,
             "kind": self.kind,
-            "correlation_id": self.correlation_id,
-            "causation_id": self.causation_id.value if self.causation_id else None,
+            "conversation_id": self.conversation_id,
+            "reply_to": None if self.reply_to is None else self.reply_to.value,
+            "requires_ack": self.requires_ack,
+            "artifact_refs": list(self.artifact_refs),
+            "expires_at": None
+            if self.expires_at is None
+            else format_datetime(self.expires_at, "expires_at"),
             "created_at": format_datetime(self.created_at, "created_at"),
             "payload": thaw_json(self.payload),
         }
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> RelayMessage:
-        causation = data.get("causation_id")
+        conversation = data.get("conversation_id", data.get("correlation_id"))
+        reply = data.get("reply_to", data.get("causation_id"))
         payload = freeze_json(data["payload"], path="payload")
         if not isinstance(payload, FrozenDict):
             raise ValueError("payload must be an object")
+        refs = data.get("artifact_refs", ())
+        if refs is None:
+            refs = ()
+        if not isinstance(refs, (list, tuple)) or any(not isinstance(item, str) for item in refs):
+            raise ValueError("artifact_refs must be an array of strings")
+        requires_ack = data.get("requires_ack", True)
+        if not isinstance(requires_ack, bool):
+            raise ValueError("requires_ack must be a boolean")
+        expires = data.get("expires_at")
         return cls(
             schema_version=int(data["schema_version"]),
             message_id=RelayMessageId(require_string(data["message_id"], "message_id")),
             sender=RuntimeAddress(require_string(data["sender"], "sender")),
             recipient=RuntimeAddress(require_string(data["recipient"], "recipient")),
             kind=require_string(data["kind"], "kind"),
-            correlation_id=None
-            if data.get("correlation_id") is None
-            else require_string(data["correlation_id"], "correlation_id"),
-            causation_id=None
-            if causation is None
-            else RelayMessageId(require_string(causation, "causation_id")),
+            conversation_id=None
+            if conversation is None
+            else require_string(conversation, "conversation_id"),
+            reply_to=None if reply is None else RelayMessageId(require_string(reply, "reply_to")),
+            requires_ack=requires_ack,
+            artifact_refs=tuple(refs),
+            expires_at=None if expires is None else parse_datetime(expires, "expires_at"),
             created_at=parse_datetime(data["created_at"], "created_at"),
             payload=payload,
         )

--- a/src/sovereign_agent/repository/manager.py
+++ b/src/sovereign_agent/repository/manager.py
@@ -17,6 +17,7 @@ from .errors import (
     RepositoryCommandError,
     RepositoryConfigurationError,
     RepositoryDirtyError,
+    RepositoryLockLost,
     RepositoryValidationError,
 )
 from .locking import RepositoryLease, RepositoryLockManager
@@ -179,6 +180,55 @@ class RepositoryManager:
 
     def heartbeat(self, execution: RepositoryExecution) -> None:
         self._lease(execution).heartbeat()
+
+    def resume(
+        self,
+        execution: RepositoryExecution,
+        *,
+        lock_timeout: float = 30.0,
+        lease_seconds: float = 60.0,
+    ) -> RepositoryExecution:
+        """Revalidate an existing worktree and recover its lease generation."""
+        config = self.resolve(execution.repository_id)
+        try:
+            self.heartbeat(execution)
+            return execution
+        except RepositoryLockLost:
+            pass
+        if execution.source_checkout.resolve() != config.checkout.resolve():
+            raise RepositoryValidationError("execution source checkout mapping changed")
+        if not execution.worktree_path.is_dir():
+            raise RepositoryValidationError("execution worktree is missing during recovery")
+        branch = (
+            _git(
+                execution.worktree_path,
+                "symbolic-ref",
+                "--short",
+                "HEAD",
+                operation="recover execution branch",
+            )
+            .stdout.decode()
+            .strip()
+        )
+        if branch != execution.branch:
+            raise RepositoryValidationError("execution branch changed during recovery")
+        lock_key = hashlib.sha256(str(execution.repository_id).encode()).hexdigest()
+        lease = self._locks.acquire(
+            lock_key,
+            timeout=lock_timeout,
+            lease_seconds=lease_seconds,
+            owner=str(execution.execution_id),
+        )
+        return RepositoryExecution(
+            repository_id=execution.repository_id,
+            execution_id=execution.execution_id,
+            source_checkout=execution.source_checkout,
+            worktree_path=execution.worktree_path,
+            base_ref=execution.base_ref,
+            base_sha=execution.base_sha,
+            branch=execution.branch,
+            lock_token=lease.token,
+        )
 
     def resolve_relative_path(
         self, execution: RepositoryExecution, relative_path: str | Path
@@ -434,6 +484,10 @@ class RepositoryManager:
             return removed
         finally:
             lease.release()
+
+    def release(self, execution: RepositoryExecution) -> None:
+        """Release only the execution lease, preserving its evidence worktree."""
+        self._lease(execution).release()
 
     def _lease(self, execution: RepositoryExecution) -> RepositoryLease:
         key = hashlib.sha256(str(execution.repository_id).encode()).hexdigest()

--- a/tests/contracts/test_contracts.py
+++ b/tests/contracts/test_contracts.py
@@ -10,12 +10,16 @@ from sovereign_agent.contracts import (
     CapabilityManifest,
     ContractValidationError,
     EvidenceLevel,
+    ExecutionConstraints,
     ExecutionId,
     ExecutionReceipt,
     GovernedExecutionRequest,
     InvocationId,
+    MutationPolicy,
     ReceiptStatus,
     RepositoryId,
+    SandboxMinimum,
+    SeatId,
     SeatInstanceId,
     SovereignSessionId,
     canonical_json_bytes,
@@ -56,6 +60,20 @@ def request() -> GovernedExecutionRequest:
         governance={"network": "deny"},
         capability_manifest=manifest(),
         requested_at=NOW,
+        conversation_id="round-1",
+        seat_type=SeatId("zeo-stream"),
+        requested_by="projects/zero-employee/sow/runtime/runtime-SOW-1.md",
+        authority_refs=("ruling/RULING-359.md",),
+        work_artifact_refs=("projects/zero-employee/sow/runtime/runtime-SOW-1.md",),
+        base_ref="origin/main",
+        branch="sovereign/seat-01/execution-01",
+        constraints=ExecutionConstraints(
+            structured_output=True,
+            sandbox_minimum=SandboxMinimum.FILESYSTEM_ISOLATED,
+            filesystem_isolation=True,
+        ),
+        required_evidence=("structured_result", "commit_sha"),
+        acceptance_commands=(("make", "verify"),),
     )
 
 
@@ -89,11 +107,23 @@ def test_request_strict_round_trip_and_unknown_preservation() -> None:
 
 def test_request_rejects_missing_wrong_and_naive_values() -> None:
     wire = request().to_dict()
-    del wire["governance"]
+    del wire["conversation_id"]
     with pytest.raises(ContractValidationError, match="missing required"):
         GovernedExecutionRequest.from_dict(wire)
     with pytest.raises(ContractValidationError, match="timezone-aware"):
         GovernedExecutionRequest(**{**request().__dict__, "requested_at": datetime(2026, 1, 1)})
+
+
+def test_request_rejects_impossible_identity_and_mutation_combinations() -> None:
+    with pytest.raises(ContractValidationError, match="authority_refs"):
+        GovernedExecutionRequest(**{**request().__dict__, "authority_refs": ()})
+    with pytest.raises(ContractValidationError, match="trunk mutation"):
+        GovernedExecutionRequest(**{**request().__dict__, "branch": "main"})
+    with pytest.raises(ContractValidationError, match="filesystem-isolated"):
+        ExecutionConstraints(
+            trunk_mutation=MutationPolicy.ALLOWED,
+            sandbox_minimum=SandboxMinimum.FILESYSTEM_ISOLATED,
+        )
 
 
 def test_capability_availability_and_evidence_are_independent() -> None:

--- a/tests/providers/test_cli_providers.py
+++ b/tests/providers/test_cli_providers.py
@@ -133,6 +133,17 @@ def test_codex_command_construction_distinguishes_fresh_and_resume(fresh_session
     assert fresh.cwd == fresh_session.directory
 
 
+def test_cli_provider_uses_admitted_repository_worktree(fresh_session, tmp_path: Path) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    context = FrozenDict((("repository_worktree", str(worktree.resolve())),))
+    codex = CodexCliProvider(backend=FakeBackend(help_stdout=""))
+    claude = ClaudeCodeProvider(backend=FakeBackend(help_stdout=""))
+
+    assert codex.invocation_spec(request(fresh_session, context=context)).cwd == worktree
+    assert claude.invocation_spec(request(fresh_session, context=context)).cwd == worktree
+
+
 def test_claude_command_construction_distinguishes_fresh_and_resume(fresh_session) -> None:
     provider = ClaudeCodeProvider(
         executable="/opt/claude",

--- a/tests/relay/test_registry_relay.py
+++ b/tests/relay/test_registry_relay.py
@@ -87,7 +87,7 @@ def message(system, identifier: str, *, created_offset: int = 0) -> RelayMessage
         sender=sender.address,
         recipient=recipient.address,
         kind="task",
-        correlation_id="corr",
+        conversation_id="corr",
         created_at=clock.now + timedelta(seconds=created_offset),
         payload={"nested": {"value": 1}},
     )
@@ -254,3 +254,112 @@ def test_process_safe_enqueue_is_atomic(system):
         results = pool.map(_process_enqueue, [str(root.root)] * 12)
     assert results == ["process-message"] * 12
     assert relay.get("process-message").attempt_count == 0
+
+
+def test_two_instances_of_the_same_seat_remain_separately_addressable(system):
+    _, _, registry, _, _, _ = system
+    first = registry.register(
+        instance_id="sparring-solweb-01",
+        seat_id="zeo-sparring",
+        provider="codex",
+        backend="os-isolated",
+        sovereign_session_id="sess-one",
+        provider_session_id="prov-one",
+        capability_manifest_ref="receipts/capabilities/one.json",
+    )
+    second = registry.register(
+        instance_id="sparring-solweb-02",
+        seat_id="zeo-sparring",
+        provider="codex",
+        backend="os-isolated",
+        sovereign_session_id="sess-two",
+        provider_session_id="prov-two",
+        capability_manifest_ref="receipts/capabilities/two.json",
+    )
+    assert first.seat_id == second.seat_id
+    assert first.address != second.address
+    assert registry.resolve(first.address).instance_id.value == "sparring-solweb-01"
+    assert registry.resolve(second.address).instance_id.value == "sparring-solweb-02"
+
+
+def test_provider_session_is_never_organizational_identity(system):
+    _, _, registry, _, _, _ = system
+    with pytest.raises(ValueError, match="provider session"):
+        registry.register(
+            instance_id="seat-org",
+            seat_id="zeo-stream",
+            provider="native",
+            backend="bare",
+            provider_session_id="seat-org",
+        )
+    record = registry.register(
+        instance_id="seat-org",
+        seat_id="zeo-stream",
+        provider="native",
+        backend="bare",
+        provider_session_id="opaque-provider-session",
+        sovereign_session_id="sess-bound",
+    )
+    with pytest.raises(RegistrationConflict):
+        registry.register(
+            instance_id="seat-org",
+            seat_id="zeo-stream",
+            provider="native",
+            backend="bare",
+            provider_session_id="different-opaque",
+            sovereign_session_id="sess-bound",
+        )
+    heartbeat = registry.heartbeat("seat-org", status={"pid": 9})
+    assert heartbeat.provider_session_id is not None
+    assert heartbeat.provider_session_id.value == "opaque-provider-session"
+    assert heartbeat.sovereign_session_id is not None
+    assert heartbeat.sovereign_session_id.value == "sess-bound"
+    assert record.address.instance_id.value == "seat-org"
+    assert record.address.instance_id.value != record.provider_session_id.value
+
+
+def test_expired_messages_dead_letter_with_failure_ground(system):
+    clock, _, _, _, recipient, relay = system
+    envelope = RelayMessage(
+        **{
+            **message(system, "expiring").__dict__,
+            "expires_at": clock.now + timedelta(seconds=2),
+        }
+    )
+    relay.enqueue(envelope)
+    clock.advance(3)
+    assert relay.claim(recipient.address, owner="worker") is None
+    dead = relay.dead_letters()
+    assert len(dead) == 1
+    assert dead[0].message.message_id.value == "expiring"
+    assert dead[0].last_error == "message expired"
+
+
+def test_artifact_refs_round_trip_without_copying_bytes(system):
+    _, root, _, _, _, relay = system
+    artifact = root.root / "outside-artifact.bin"
+    artifact.write_bytes(b"secret-bytes" * 1024)
+    envelope = RelayMessage(
+        **{
+            **message(system, "refs").__dict__,
+            "artifact_refs": ("projects/zero-employee/sow/runtime/runtime-SOW-1.md",),
+            "payload": {"body": "Review the proposed ruling against doctrine."},
+        }
+    )
+    stored = relay.enqueue(envelope).message
+    assert stored.artifact_refs == envelope.artifact_refs
+    assert stored.to_instance.value == "recipient-1"
+    assert stored.from_instance.value == "sender-1"
+    queue_bytes = b"".join(
+        path.read_bytes() for path in (root.relay_dir / "messages").glob("*.json")
+    )
+    assert b"secret-bytes" not in queue_bytes
+    restored = RelayMessage.from_dict(
+        {
+            **stored.to_dict(),
+            "correlation_id": stored.conversation_id,
+            "causation_id": None,
+        }
+    )
+    assert restored.conversation_id == "corr"
+    assert restored.requires_ack is True

--- a/tests/test_governed_execution.py
+++ b/tests/test_governed_execution.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from sovereign_agent.cli import app
+from sovereign_agent.contracts import (
+    CapabilityManifest,
+    ExecutionConstraints,
+    ExecutionId,
+    FrozenDict,
+    GovernedExecutionRequest,
+    InvocationId,
+    ReceiptStatus,
+    ReceiptTermination,
+    RepositoryId,
+    SeatId,
+    SeatInstanceId,
+    SovereignSessionId,
+)
+from sovereign_agent.execution import GovernedExecutionEngine
+from sovereign_agent.orchestrator import BareWorker, WorkerOutcome
+from sovereign_agent.providers import (
+    InvocationResult,
+    ProviderCapabilities,
+    StructuredResultEvent,
+)
+from sovereign_agent.registry import SeatRegistry
+from sovereign_agent.relay import DurableRelay
+from sovereign_agent.repository import RepositoryConfig, RepositoryManager
+from sovereign_agent.runtime import RuntimeRoot
+
+
+class FakeProvider:
+    kind = "provider"
+    name = "fake"
+    capabilities = ProviderCapabilities(structured_result=True)
+
+    def __init__(self, *, business_done: bool = True, structured: bool = True) -> None:
+        self.calls = 0
+        self.business_done = business_done
+        self.structured = structured
+        self.delay = 0.0
+        self.error: Exception | None = None
+
+    async def invoke(
+        self, request: Any, *, observers: Any = (), activity_callbacks: Any = ()
+    ) -> Any:
+        self.calls += 1
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.error is not None:
+            raise self.error
+        worktree = Path(str(request.context["repository_worktree"]))
+        (worktree / "result.txt").write_text("governed\n", encoding="utf-8")
+        _git(worktree, "add", "result.txt")
+        _git(
+            worktree,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-qm",
+            "provider result",
+        )
+        events = ()
+        if self.structured:
+            event = StructuredResultEvent(
+                execution_id=request.execution_id,
+                invocation_id=request.invocation_id,
+                sequence=0,
+                timestamp=datetime.now(UTC),
+                result=FrozenDict((("done", self.business_done),)),
+            )
+            events = (event,)
+            for callback in (*observers, *activity_callbacks):
+                value = callback(event)
+                if inspect.isawaitable(value):
+                    await value
+        return InvocationResult(
+            success=True,
+            output=FrozenDict((("done", self.business_done),)),
+            summary="done",
+            next_action="stop",
+            events=events,
+        )
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(("git", "-C", str(cwd), *args), check=True, capture_output=True)
+
+
+@pytest.fixture
+def governed(tmp_path: Path) -> tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot]:
+    checkout = tmp_path / "repo"
+    checkout.mkdir()
+    _git(checkout, "init", "-q")
+    (checkout / "README.md").write_text("base\n", encoding="utf-8")
+    _git(checkout, "add", "README.md")
+    _git(
+        checkout,
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "-qm",
+        "base",
+    )
+    remote = tmp_path / "remote.git"
+    subprocess.run(("git", "init", "--bare", "-q", str(remote)), check=True)
+    _git(checkout, "remote", "add", "origin", str(remote))
+    runtime = RuntimeRoot(tmp_path / "runtime").initialize()
+    seats = SeatRegistry(runtime)
+    seats.register(
+        instance_id=SeatInstanceId("seat-instance"),
+        seat_id=SeatId("worker-seat"),
+        provider="fake",
+        backend="bare",
+        capabilities=("structured_result",),
+    )
+    provider = FakeProvider()
+
+    async def unused(session_id: str, directory: Path) -> WorkerOutcome:
+        del directory
+        return WorkerOutcome(session_id, False, False, "unused")
+
+    engine = GovernedExecutionEngine(
+        runtime_root=runtime,
+        repository_manager=RepositoryManager(
+            runtime,
+            (RepositoryConfig(RepositoryId("repo"), checkout),),
+        ),
+        seat_registry=seats,
+        providers={"fake": provider},
+        backends={"bare": BareWorker(unused)},
+    )
+    return engine, provider, runtime
+
+
+def _request(
+    *,
+    execution_id: str = "execution-1",
+    governance: dict[str, Any] | None = None,
+) -> GovernedExecutionRequest:
+    governance_value = governance or {
+        "authority": {"grant": "test"},
+        "constraints": {"structured_output": {"required_fields": ["done"]}},
+        "verification": [{"type": "changed_paths_nonempty"}],
+        "business_completion": [
+            {
+                "type": "output_field_equals",
+                "field": "done",
+                "value": True,
+            }
+        ],
+        "delivery": {"enabled": False},
+    }
+    constraint_values = dict(governance_value.get("constraints", {}))
+    known_constraint_names = {
+        "dirty_worktree",
+        "filesystem_isolation",
+        "network_isolation",
+        "preserve_on_failure",
+        "structured_output",
+        "timeouts",
+    }
+    delivery = dict(governance_value.get("delivery", {}))
+    return GovernedExecutionRequest(
+        seat_instance_id=SeatInstanceId("seat-instance"),
+        sovereign_session_id=SovereignSessionId("session-1"),
+        execution_id=ExecutionId(execution_id),
+        invocation_id=InvocationId(f"{execution_id}-invocation"),
+        repository_id=RepositoryId("repo"),
+        operation="edit",
+        input=FrozenDict((("task", "write result"),)),
+        governance=FrozenDict(tuple(governance_value.items())),
+        conversation_id=f"conversation-{execution_id}",
+        seat_type=SeatId("worker-seat"),
+        requested_by="test-suite",
+        authority_refs=("authority:test",),
+        work_artifact_refs=(),
+        base_ref="HEAD",
+        branch=f"sovereign/{execution_id}",
+        constraints=ExecutionConstraints(
+            dirty_worktree=str(constraint_values.get("dirty_worktree", "fail")),
+            filesystem_isolation=bool(constraint_values.get("filesystem_isolation", False)),
+            network_isolation=bool(constraint_values.get("network_isolation", False)),
+            preserve_on_failure=bool(constraint_values.get("preserve_on_failure", True)),
+            structured_output=constraint_values.get("structured_output", False),
+            timeouts=FrozenDict(tuple(dict(constraint_values.get("timeouts", {})).items())),
+            delivery_enabled=bool(delivery.get("enabled", False)),
+            delivery_remote=delivery.get("remote"),
+            delivery_branch=delivery.get("branch"),
+            unknown_fields=FrozenDict(
+                tuple(
+                    (name, value)
+                    for name, value in constraint_values.items()
+                    if name not in known_constraint_names
+                )
+            ),
+        ),
+        capability_manifest=CapabilityManifest(FrozenDict()),
+        requested_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_happy_path_receipt_is_final_and_retry_is_idempotent(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, _ = governed
+    request = _request()
+    first = await engine.run(request)
+    second = await engine.run(request)
+
+    assert first == second
+    assert first.status is ReceiptStatus.SUCCEEDED
+    assert first.verify_evidence()
+    assert provider.calls == 1
+    assert first.evidence["delivery"]["state"] == "not_requested"
+
+
+@pytest.mark.asyncio
+async def test_process_success_does_not_imply_business_completion(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, _ = governed
+    provider.business_done = False
+
+    receipt = await engine.run(_request(execution_id="business-fail"))
+
+    assert receipt.status is ReceiptStatus.FAILED
+    assert receipt.error["reason"] == "business-verification-failed"
+    assert provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_structured_output_has_distinct_reason(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, _ = governed
+    provider.structured = False
+
+    receipt = await engine.run(_request(execution_id="structured-fail"))
+
+    assert receipt.error["reason"] == "invalid-structured-output"
+
+
+@pytest.mark.asyncio
+async def test_rejection_writes_refused_receipt_and_redacts_secrets(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, runtime = governed
+    request = _request(
+        execution_id="rejected",
+        governance={
+            "authority": {"grant": "test", "api_key": "top-secret"},
+            "constraints": {"future_required_boundary": True},
+        },
+    )
+
+    receipt = await engine.run(request)
+
+    assert receipt.termination is ReceiptTermination.REFUSED
+    assert receipt.status is ReceiptStatus.FAILED
+    assert receipt.is_finalized
+    assert provider.calls == 0
+    persisted = (
+        runtime.executions_dir / _digest(request.execution_id) / "rejection.json"
+    ).read_text(encoding="utf-8")
+    assert "top-secret" not in persisted
+    assert "[REDACTED]" in persisted
+    assert "top-secret" not in (
+        runtime.receipts_dir / f"{_digest(request.execution_id)}.json"
+    ).read_text(encoding="utf-8")
+
+
+def _digest(execution_id: object) -> str:
+    return hashlib.sha256(str(execution_id).encode()).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_provider_error_and_timeout_have_distinct_reasons(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, _ = governed
+    provider.error = RuntimeError("provider exploded")
+    errored = await engine.run(_request(execution_id="provider-error"))
+    assert errored.error["reason"] == "provider-error"
+
+    provider.error = None
+    provider.delay = 0.1
+    timed = await engine.run(
+        _request(
+            execution_id="provider-timeout",
+            governance={
+                "authority": {"grant": "test"},
+                "constraints": {"timeouts": {"execute_s": 0.01}},
+            },
+        )
+    )
+    assert timed.error["reason"] == "provider-timeout"
+
+
+@pytest.mark.asyncio
+async def test_requested_filesystem_isolation_refuses_before_invoke(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, _ = governed
+    receipt = await engine.run(
+        _request(
+            execution_id="isolation-refused",
+            governance={
+                "authority": {"grant": "test"},
+                "constraints": {"filesystem_isolation": True},
+            },
+        )
+    )
+    assert receipt.termination is ReceiptTermination.REFUSED
+    assert receipt.error["reason"] == "capability-mismatch"
+    assert provider.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_cancellation_persists_terminal_receipt(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, _ = governed
+    provider.delay = 1.0
+    request = _request(execution_id="cancelled")
+    running = asyncio.create_task(engine.run(request))
+    await asyncio.sleep(0.02)
+
+    assert engine.cancel(request.execution_id)
+    receipt = await running
+
+    assert receipt.status is ReceiptStatus.CANCELLED
+    assert receipt.error["reason"] == "aborted"
+    assert engine.status(request.execution_id).cancellation_requested
+
+
+@pytest.mark.asyncio
+async def test_requested_delivery_is_pushed_and_independently_verified(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, _, _ = governed
+    receipt = await engine.run(
+        _request(
+            execution_id="delivered",
+            governance={
+                "authority": {"grant": "test"},
+                "constraints": {},
+                "delivery": {"enabled": True},
+            },
+        )
+    )
+
+    assert receipt.status is ReceiptStatus.SUCCEEDED
+    assert receipt.evidence["delivery"]["state"] == "verified"
+    assert receipt.evidence["delivery"]["local_sha"] == receipt.evidence["delivery"]["verified_sha"]
+
+
+@pytest.mark.asyncio
+async def test_relay_messages_are_correlated_causal_and_ack_safe(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, _, runtime = governed
+    relay = DurableRelay(runtime, engine.seats)
+    engine.relay = relay
+    request = _request(execution_id="relayed")
+
+    await engine.run(request)
+
+    claimed = relay.claim("local://seat-instance", owner="test")
+    assert claimed is not None
+    assert claimed.message.conversation_id == str(request.execution_id)
+    ack = relay.ack(
+        claimed.message.message_id,
+        owner="test",
+        lease_token=claimed.lease_token,
+    )
+    assert relay.acknowledgement(ack.message_id) == ack
+
+
+@pytest.mark.asyncio
+async def test_cli_receipt_json_and_stable_not_found_exit(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+    tmp_path: Path,
+) -> None:
+    engine, _, runtime = governed
+    request = _request(execution_id="cli-receipt")
+    receipt = await engine.run(request)
+    checkout = receipt.evidence["git"]["identity"]["checkout"]
+    config = tmp_path / "wiring.json"
+    config.write_text(
+        json.dumps(
+            {
+                "runtime_root": str(runtime.root),
+                "repositories": [{"repository_id": "repo", "checkout": checkout}],
+                "providers": [],
+                "backends": ["bare"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    found = runner.invoke(
+        app,
+        ["governed", "receipt", str(request.execution_id), "--config", str(config)],
+    )
+    missing = runner.invoke(
+        app,
+        ["governed", "receipt", "missing", "--config", str(config)],
+    )
+
+    assert found.exit_code == 0
+    assert json.loads(found.stdout)["evidence_sha256"] == receipt.evidence_sha256
+    assert missing.exit_code == 4
+    assert json.loads(missing.stdout)["error"] == "not_found"
+
+    shown = runner.invoke(
+        app,
+        ["receipt", "show", str(request.execution_id), "--config", str(config)],
+    )
+    assert shown.exit_code == 0
+    assert json.loads(shown.stdout)["termination"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_resume_from_completed_provider_checkpoint_does_not_reinvoke(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, runtime = governed
+    request = _request(execution_id="checkpoint-resume")
+    await engine.run(request)
+    digest = hashlib.sha256(str(request.execution_id).encode()).hexdigest()
+    receipt_path = runtime.receipts_dir / f"{digest}.json"
+    state_path = runtime.executions_dir / digest / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    receipt_path.unlink()
+    state["phase"] = "provider_completed"
+    for key in ("delivery", "git_evidence", "receipt_sha256"):
+        state.pop(key, None)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    recovered = await engine.run(request)
+
+    assert recovered.status is ReceiptStatus.SUCCEEDED
+    assert provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_provider_checkpoint_fails_without_duplicate_invocation(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, runtime = governed
+    request = _request(execution_id="checkpoint-ambiguous")
+    await engine.run(request)
+    digest = hashlib.sha256(str(request.execution_id).encode()).hexdigest()
+    receipt_path = runtime.receipts_dir / f"{digest}.json"
+    state_path = runtime.executions_dir / digest / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    receipt_path.unlink()
+    state["phase"] = "provider_invoking"
+    state.pop("provider_result", None)
+    state.pop("receipt_sha256", None)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    recovered = await engine.run(request)
+
+    assert recovered.status is ReceiptStatus.FAILED
+    assert recovered.error["reason"] == "ambiguous-provider-invocation"
+    assert provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_isolation_capability_mismatch_rejects_before_provider_side_effect(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, _ = governed
+    request = _request(
+        execution_id="isolation-rejected",
+        governance={
+            "authority": {"grant": "test"},
+            "constraints": {"filesystem_isolation": True},
+        },
+    )
+
+    receipt = await engine.run(request)
+
+    assert receipt.termination is ReceiptTermination.REFUSED
+    assert receipt.error["reason"] == "capability-mismatch"
+    assert provider.calls == 0
+    assert engine.receipt(request.execution_id) == receipt
+
+
+@pytest.mark.asyncio
+async def test_dirty_repository_failure_is_distinct_and_precedes_provider(
+    governed: tuple[GovernedExecutionEngine, FakeProvider, RuntimeRoot],
+) -> None:
+    engine, provider, _ = governed
+    checkout = engine.repositories.resolve(RepositoryId("repo")).checkout
+    (checkout / "operator-dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+    receipt = await engine.run(_request(execution_id="dirty-repository"))
+
+    assert receipt.status is ReceiptStatus.FAILED
+    assert receipt.error["reason"] == "repository-dirty"
+    assert provider.calls == 0


### PR DESCRIPTION
## Summary
- add durable governed admission, execution journaling, cancellation, recovery, and immutable receipts
- compose provider/backend execution with repository verification, optional verified delivery, and relay lifecycle events
- add offline JSON execution controls, expanded wire contracts, and regression coverage for confinement and compatibility

## Test plan
- [x] `uv run pytest -q` (476 passed, 1 skipped)
- [x] `make verify`
- [x] `uv run mkdocs build --strict`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)