### PR TITLE
Make the 0.5.1 package contract match the tagged capability migration.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,33 @@ jobs:
 
       - name: Run doctor
         run: NEBIUS_KEY=fake sovereign-agent doctor --skip-llm
+
+  zeocore-compat:
+    name: ZeoCore ${{ matrix.zeocore }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        zeocore:
+          - "==0.5.0"
+          - ">=0.5,<0.6"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - name: Install package + pinned ZeoCore
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . --group dev
+          python -m pip install --upgrade "zeocore${{ matrix.zeocore }}"
+          python -c "import zeo_core, importlib.metadata as m; print(m.version('zeocore'), zeo_core.__file__)"
+      - name: Capability, contract, boundary, and release suites
+        run: >-
+          python -m pytest -q
+          tests/capabilities
+          tests/contracts
+          tests/architecture/test_import_boundaries.py
+          tests/release/test_release_contract.py
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,14 @@ name: publish
 # with Environment name: testpypi.
 #
 # Release flow:
-#   git tag v0.3.0a1                       # PEP 440 alpha → TestPyPI
-#   git tag v0.3.0                         # stable → real PyPI
-#   git push origin <tag>
+#   make ready-to-ship                   # local truth gate (no publish)
+#   git tag v0.5.1 && git push origin v0.5.1
 #   → GitHub Actions runs this workflow
 #   → Builds wheel + sdist, verifies they install
 #   → Publishes to the appropriate index
+#   make verify-pypi VERSION=0.5.1       # live PyPI JSON + README + provenance
+#
+# A git tag is not a public release until verify-pypi succeeds.
 
 on:
   push:
@@ -148,6 +150,7 @@ jobs:
       url: https://pypi.org/project/sovereign-agent/
     permissions:
       id-token: write   # required for trusted publishing (OIDC)
+      attestations: write
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v4
@@ -158,3 +161,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: false   # fail loudly if version already exists
+          attestations: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Repository: [`zeroemployeeorg/sovereign-agent`](https://github.com/zeroemployeeo
 
 ## Unreleased
 
+v0.6 remaining work after the 0.5.1 public line: keep ZeoCore as the default
+authoring path, keep the compatibility matrix green, and close each later
+release only after the packaging-truth gate. Fleet scope stays in v0.7.
+
+## [0.5.1] — 2026-08-23
+
+Packaging and documentation truth for the v0.5 capability migration. Python
+3.13 floor, `zeocore>=0.5,<0.6`, capability-first README, contract fixtures in
+the wheel, and a ZeoCore min/newest CI job. Git tag `v0.5.0` is not moved and
+is not announced as the PyPI line.
+
 ## [0.5.0] — 2026-08-23
 
 Capability migration toward ZeoCore. Python 3.13 floor. Runtime evidence

--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,11 @@ help: ## Show this help with typical workflows and every target
 	@printf "      $(DIM)·$(RESET)  $(CYAN)make flatten$(RESET)                bundle repo into $(BOLD)$(FLATTEN_DIR)/$(RESET) for pasting\n"
 	@printf "      $(DIM)·$(RESET)  $(CYAN)make flatten SCOPE=$(PKG_DIR)$(RESET)  flatten only the package source\n"
 	@printf "\n"
-	@printf "  $(BOLD)◆ Ship to PyPI$(RESET) $(DIM)(first-time release workflow)$(RESET)\n"
+	@printf "  $(BOLD)◆ Ship to PyPI$(RESET) $(DIM)(git tag is not a public release)$(RESET)\n"
 	@printf "      $(DIM)1$(RESET)  $(CYAN)make pre-publish$(RESET)            audit for secrets, PII, forbidden files\n"
 	@printf "      $(DIM)2$(RESET)  $(CYAN)make ready-to-ship$(RESET)          preflight + pre-publish + build in one shot\n"
-	@printf "      $(DIM)3$(RESET)  $(DIM)git tag v0.3.0 && git push origin v0.3.0$(RESET)   triggers publish.yml\n"
+	@printf "      $(DIM)3$(RESET)  $(DIM)git tag v0.5.1 && git push origin v0.5.1$(RESET)   triggers publish.yml\n"
+	@printf "      $(DIM)4$(RESET)  $(CYAN)make verify-pypi$(RESET)            live PyPI JSON + provenance + README truth\n"
 	@printf "      $(DIM)·$(RESET)  $(CYAN)make build$(RESET)                  $(DIM)uv build$(RESET) wheel+sdist locally\n"
 	@printf "      $(DIM)·$(RESET)  $(CYAN)make publish-test$(RESET)           $(DIM)uv publish$(RESET) to TestPyPI (manual)\n"
 	@printf "      $(DIM)·$(RESET)  $(CYAN)make bundle$(RESET)                 tar the repo to $(BOLD)$(BUNDLE_DIR)/$(RESET)\n"
@@ -552,15 +553,20 @@ fault-inject-v04: ## v0.4 crash/restart/backup/restore fault injection
 	@$(PYTEST) tests/v04 -q --tb=short
 
 .PHONY: ready-to-ship
-ready-to-ship: preflight pre-publish release-verify fault-inject-v04 ## Deterministic, non-publishing v0.4 release proof
+ready-to-ship: preflight pre-publish release-verify fault-inject-v04 ## Deterministic, non-publishing release proof
 	@printf "\n$(GREEN)✓$(RESET) $(BOLD)Ready to ship.$(RESET)\n"
-	@printf "  $(DIM)No publish, tag, push, live provider, or credential action was performed.$(RESET)\n\n"
+	@printf "  $(DIM)No publish, tag, push, live provider, or credential action was performed.$(RESET)\n"
+	@printf "  $(DIM)A git tag is not a public release. After Trusted Publisher upload, run $(RESET)$(CYAN)make verify-pypi$(RESET)$(DIM).$(RESET)\n\n"
 
 .PHONY: release-verify
-release-verify: ci docs-strict build ## Prove API, package content, and clean core install
+release-verify: ci docs-strict build ## Prove API, package content, fixtures, and clean core install
 	@$(PY) scripts/verify_release.py \
-		--wheel dist/sovereign_agent-0.4.0-py3-none-any.whl \
-		--sdist dist/sovereign_agent-0.4.0.tar.gz
+		--wheel $$(ls dist/sovereign_agent-*.whl) \
+		--sdist $$(ls dist/sovereign_agent-*.tar.gz)
+
+.PHONY: verify-pypi
+verify-pypi: ## Post-publish packaging-truth check against the live PyPI JSON API
+	@$(PY) scripts/verify_pypi_release.py --version $${VERSION:-0.5.1}
 
 .PHONY: build
 build: ## Build wheel + sdist into dist/ via uv build

--- a/README.md
+++ b/README.md
@@ -27,22 +27,39 @@ Reusable actions are ZeoCore capabilities (`@capability`). Session control
 still works during the compatibility window and is deprecated.
 
 ```python
-from sovereign_agent import run_task, register_tool
+from pydantic import BaseModel
+from zeo_core.contracts import CapabilityResult, EffectKind
+from zeo_core.tools import ToolContext, capability
+from sovereign_agent import run_task
 
-@register_tool
-def get_weather(city: str) -> dict:
-    """Look up current weather for a city."""
-    return {"city": city, "temperature": 18, "condition": "rainy"}
+class WeatherQuery(BaseModel):
+    city: str
+
+@capability(
+    id="demo.weather.get@1.0.0",
+    description="Look up current weather for a city.",
+    effects={EffectKind.READ},
+)
+def get_weather(request: WeatherQuery, ctx: ToolContext) -> CapabilityResult:
+    return CapabilityResult.ok(
+        data={"city": request.city, "temperature": 18, "condition": "rainy"},
+        msg="ok",
+    )
 
 result = run_task("What's the weather in Edinburgh?")
 print(result.summary)
 # → "Weather in Edinburgh: 18°C, rainy."
 ```
 
-The agent ran a planner, called `get_weather`, wrote a trace, and saved every artifact to `sessions/sess_<id>/`. Inspect it with `ls -R sessions/sess_<id>`. That's not a metaphor — it's how you debug this system.
+The agent ran a planner, called into the callable surface, wrote a trace, and
+saved every artifact to `sessions/sess_<id>/`. Inspect it with
+`ls -R sessions/sess_<id>`. That's not a metaphor — it's how you debug this
+system.
 
-See [v0.5 Unit 4](docs/v0.5-unit4-builtins.md) for session filesystem capabilities
-(`read_file` / `write_file` / `list_files`) and runtime commands.
+`run_task` still accepts deprecated `@register_tool` helpers. New reusable
+actions should be ZeoCore capabilities. See [v0.5 Unit 4](docs/v0.5-unit4-builtins.md)
+for session filesystem capabilities (`read_file` / `write_file` / `list_files`)
+and runtime commands.
 
 ---
 
@@ -112,7 +129,7 @@ Development tooling lives in the PEP 735 `dev` dependency *group*, not an extra 
 so it is `uv sync --group dev` (or `pip install -e . --group dev`), not
 `pip install "sovereign-agent[dev]"`.
 
-Requires Python 3.13+.
+Requires Python 3.13+. `zeocore>=0.5,<0.6` is a required dependency.
 
 **Docker is not available.** There is a `docker` extra, but it only installs the
 Docker SDK; `DockerWorker` is a stub that raises `NotImplementedError` on
@@ -361,10 +378,13 @@ Override via `SOVEREIGN_AGENT_DATA_DIR=<path>`.
 
 ## Status
 
-**v0.4.0.** The package still exports **152** symbols in
-`sovereign_agent.__all__` (the v0.3 surface, preserved). v0.4 adds a
-governed-connectivity service as importable subpackages. See
-[`docs/API.md`](docs/API.md) and [`docs/v0.4-operator-guide.md`](docs/v0.4-operator-guide.md).
+**v0.5.1.** The package exports **161** symbols in `sovereign_agent.__all__`
+(the 152-symbol v0.4 surface plus nine capability-adapter names). Python 3.13
+is the floor; `zeocore>=0.5,<0.6` is required. Git tag `v0.5.0` is the
+capability-migration snapshot and is not moved. A git tag is not a public
+release — announce v0.5 as published only after this version is on PyPI.
+See [`docs/API.md`](docs/API.md), [`docs/roadmap.md`](docs/roadmap.md), and
+[`docs/v0.4-operator-guide.md`](docs/v0.4-operator-guide.md).
 
 - ✅ Framework: sessions, tickets, IPC, parallelism, isolation, resume, verifiers, HITL
 - ✅ 522 tests collected — 519 pass, 3 opt-in/platform skips
@@ -388,9 +408,10 @@ It's not trying to replace Claude Code for daily coding or LangGraph for orchest
 
 If you want an agent you can own, audit, reproduce, teach, and — crucially — understand at the bottom of the stack, this is probably the smallest codebase in the world that gives you all five.
 
-For what v0.3 specifically will *not* attempt, see
+For what this series will *not* attempt through v0.7, see
+[`docs/non-goals.md`](docs/non-goals.md) and
 [`docs/v0.3-non-goals.md`](docs/v0.3-non-goals.md). Those are commitments, not
-moods.
+moods. The public sequence is [`docs/roadmap.md`](docs/roadmap.md).
 
 ---
 
@@ -401,7 +422,9 @@ chain for the work done on it. There is no Statement of Work, no SOW directory,
 and no filing chain in this tree, and there never should be:
 
 - **`work_repo`** — this repository. Code that genuinely collides, so changes
-  land on branches and get merged through pull requests.
+  land on branches and get merged through pull requests. The public sequence is
+  [`docs/roadmap.md`](docs/roadmap.md); binding authorization stays in the
+  corpus.
 - **`sow_repo`** — a separate corpus repository, elsewhere. Where work is
   scoped and reported.
 
@@ -415,10 +438,12 @@ the [architecture doc](docs/architecture.md), and the
 ## Learn more
 
 - 📖 [**`docs/architecture.md`**](docs/architecture.md) — the architectural decisions in detail
-- 🧭 [**`chapters/`**](chapters/) — rebuild the framework yourself in 5 runnable chapters
+- 🧭 [**`docs/roadmap.md`**](docs/roadmap.md) — post-v0.5 sequence (v0.6 correctness, v0.7 fleet)
+- 🚫 [**`docs/non-goals.md`**](docs/non-goals.md) — durable refusals through v0.7
+- 🧭 [**`chapters/`**](chapters/) — rebuild the v0.2 substrate yourself in 5 runnable chapters
 - 🧪 [**`examples/`**](examples/) — 8 reference scenarios, each with a dataflow integrity audit
 - 📋 [**`docs/API.md`**](docs/API.md) — semver contract for the public symbols
-- 🚫 [**`docs/v0.3-non-goals.md`**](docs/v0.3-non-goals.md) — what v0.3 will not do
+- 🚫 [**`docs/v0.3-non-goals.md`**](docs/v0.3-non-goals.md) — historical v0.3 refusals that still hold
 - 🌿 [**`docs/branch-consolidation-2026-08-22.md`**](docs/branch-consolidation-2026-08-22.md) — how the pre-v0.3 branches landed
 - 📝 [**`CHANGELOG.md`**](CHANGELOG.md) — what shipped and when
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,13 +2,16 @@
 
 **Applies from:** v0.2.0 onwards.
 **Contract version:** 2.
-**Current release surface:** v0.4.0, 152 symbols (v0.3 surface preserved).
+**Current release surface:** v0.5.1, 161 symbols (v0.4 surface preserved plus
+nine capability-adapter names). Python 3.13+; `zeocore>=0.5,<0.6`.
 
 The exact, machine-checked contracts are
-[`public-api-v0.2.txt`](public-api-v0.2.txt) and
-[`public-api-v0.3.txt`](public-api-v0.3.txt). The release gate compares the
-v0.3 manifest with `sovereign_agent.__all__` and proves that every v0.2 symbol
-is retained.
+[`public-api-v0.2.txt`](public-api-v0.2.txt),
+[`public-api-v0.3.txt`](public-api-v0.3.txt),
+[`public-api-v0.4.txt`](public-api-v0.4.txt), and
+[`public-api-v0.5.txt`](public-api-v0.5.txt). The release gate compares the
+v0.5 manifest with `sovereign_agent.__all__` and proves that every earlier
+stable symbol is retained.
 
 This document specifies which parts of sovereign-agent are covered by the
 [semver](https://semver.org/) contract, what "breaking change" means in this
@@ -93,7 +96,6 @@ Category | Symbols
 **Scheduler** | `DriftCorrectedScheduler`, `ScheduledTask`
 **Session** | `Session`, `SessionState`, `create_session`, `load_session`, `list_sessions`, `archive_session`
 **Tickets** | `Ticket`, `TicketResult`, `TicketState`, `Manifest`, `OutputRecord`, `create_ticket`, `list_tickets`
-**Capabilities** (v0.5) | `CallableSurface`, `CapabilityContextFactory`, `CapabilityExecutor`, `RuntimeCommandRegistry`, `ApprovalDisposition`, `make_session_callable_surface`, `RuntimeCapabilityAssertion`, `RuntimeCapabilityManifest`
 **Tools** | `ToolRegistry`, `ToolResult`, `register_tool`, `global_registry`, `make_builtin_registry`
 **Queue** | `SessionQueue`, `TaskPriority`
 **Meta** | `__version__`
@@ -119,6 +121,16 @@ Category | Symbols
 refuses during lifecycle preparation and its legacy `run_session()` raises
 `NotImplementedError`. See
 [v0.3 non-goals](v0.3-non-goals.md).
+
+## The 9 v0.5 additions
+
+These entered the public contract in v0.5.0. They are stable within the v0.5
+series under the same rules. `@register_tool` remains public and deprecated.
+
+Category | Symbols
+---|---
+**Capabilities** | `CallableSurface`, `CapabilityContextFactory`, `CapabilityExecutor`, `RuntimeCommandRegistry`, `ApprovalDisposition`, `make_session_callable_surface`, `RuntimeCapabilityAssertion`, `RuntimeCapabilityManifest`
+**Providers** | `ProviderToolResultEvent`
 
 ### Imported but not exported
 
@@ -166,26 +178,29 @@ Examples of what would stay on the minor:
 
 ## What this means for dependent projects
 
-If you `pip install sovereign-agent ~= 0.3.0` (the recommended pin for
-downstream projects), you will:
+If you `pip install sovereign-agent ~= 0.5.1` (the recommended pin for the
+current public line), you will:
 
-- Receive every `0.3.x` bug-fix release automatically
-- Never receive `0.4.0` or later (which may have breaking changes)
-- Be safe to run your CI against the latest `0.3.x`
+- Receive every `0.5.x` bug-fix release automatically
+- Never receive `0.6.0` or later (which may have breaking changes)
+- Be safe to run your CI against the latest `0.5.x`
 
-If you pin `sovereign-agent == 0.3.0` exactly, you will:
+The previous published pair is `sovereign-agent == 0.2.0` with no ZeoCore
+dependency. See [compatibility.md](compatibility.md).
+
+If you pin `sovereign-agent == 0.5.1` exactly, you will:
 
 - Receive no updates
 - Manually opt into bug fixes by bumping
 
-Most users should use `~= 0.3.0`. The five-chapter v0.2 curriculum may keep an
+Most users should use `~= 0.5.1`. The five-chapter v0.2 curriculum may keep an
 exact v0.2 pin when reproducing that historical teaching surface.
 
 ---
 
 ## Deprecation policy
 
-v0.3.0 deprecates no public symbols. When a public symbol is to be removed:
+v0.5 deprecates `@register_tool` but does not remove it. When a public symbol is to be removed:
 
 1. A `DeprecationWarning` is added, pointing to the replacement.
 2. The symbol is documented as deprecated in `CHANGELOG.md`.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -4,9 +4,10 @@ The public API of `sovereign_agent`. Anything not listed here is internal and ma
 
 Full docstrings are on the classes themselves; this page is an overview. For the definitive reference, read the source — every public class has a docstring that explains its purpose, parameters, and behaviour.
 
-The authoritative v0.3.0 contract is [API Stability](API.md) and its
-machine-checked 152-symbol manifest. All listed top-level exports are stable
-within the v0.3 series.
+The authoritative v0.5.1 contract is [API Stability](API.md) and its
+machine-checked 161-symbol manifest. All listed top-level exports are stable
+within the v0.5 series. Prefer ZeoCore `@capability` for new reusable actions;
+`@register_tool` remains exported and deprecated.
 
 ## Errors (Pattern C)
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,45 @@
+# ZeoCore compatibility
+
+Sovereign Agent declares one tested ZeoCore minor range in
+`pyproject.toml`: `zeocore>=0.5,<0.6`.
+
+## CI matrix
+
+GitHub Actions job `zeocore-compat` installs:
+
+- the **minimum** allowed version (`zeocore==0.5.0`);
+- the **newest** version that satisfies `zeocore>=0.5,<0.6`.
+
+and runs the capability, contract, architecture-boundary, and release-source
+suites.
+
+## Compatibility review triggers
+
+A ZeoCore upgrade that changes any of the following requires an explicit
+review before the lockfile or lower bound moves:
+
+- cancellation (`CancelledError` must not be swallowed; see
+  [v0.5-unit1-foundation.md](v0.5-unit1-foundation.md) and
+  [v0.5-unit2-adapter.md](v0.5-unit2-adapter.md));
+- serialization of capability requests or results;
+- provider projection names;
+- request or invocation digests;
+- effects;
+- requirements;
+- invocation-record shape or persistence.
+
+Sovereign Agent wire schemas stay owned here even when a receipt carries
+ZeoCore-derived evidence. Provider names are projections; canonical capability
+IDs are the durable identity.
+
+## Package pairs
+
+Shipped as `sovereign_agent/contracts/fixtures/compatibility-matrix.json`:
+
+| sovereign-agent | ZeoCore | Python |
+|---|---|---|
+| 0.2.0 (previous public PyPI line) | none | 3.12+ as published |
+| 0.5.1+ (current public 0.5 line) | `>=0.5,<0.6` | 3.13+ |
+
+v0.4 was a git-line capability, not a public PyPI replacement for 0.2.0.
+The matrix records the last *published* pair, not every git tag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,21 +22,23 @@ The core idea: the agent's **session directory is the unit of everything**. Memo
 | Look up a class or function | [API Reference](api_reference.md) |
 | Know what is actually stable | [API Stability](API.md) |
 | Deploy it on a real machine | [Deployment](deployment.md) |
-| Know what is deliberately out of scope | [v0.3 Non-Goals](v0.3-non-goals.md) |
+| Know what is deliberately out of scope | [Non-Goals](non-goals.md) |
+| See the post-v0.5 sequence | [Roadmap](roadmap.md) |
 
 ## Key properties
 
 - **Offline-testable.** The framework ships with `FakeLLMClient` so you can write deterministic tests for your agent's trajectory without burning API credits.
 - **Auditable by default.** Every action the agent takes produces a ticket with a verified manifest. `cat`ing the session directory tells you exactly what happened.
 - **Provider-agnostic.** Any OpenAI-compatible endpoint works. Nebius Token Factory is the default.
-- **Explicit surface area.** 152 public names in `sovereign_agent.__all__`, checked
+- **Explicit surface area.** 161 public names in `sovereign_agent.__all__`, checked
   against a versioned manifest.
 
 ## Status
 
-Alpha. The declared package and documentation version is **0.4.0**. The release
-adds authenticated local connectivity, durable relay v2, approvals, and
-coordinator operations while retaining all v0.3 public symbols.
+Alpha. The declared package and documentation version is **0.5.1**. Python
+3.13 is the floor and `zeocore>=0.5,<0.6` is required. Reusable actions are
+ZeoCore capabilities; runtime commands stay in Sovereign Agent. A git tag is
+not a public release — see [the roadmap](roadmap.md).
 
 The spine is covered by deterministic contract, unit, and integration tests.
 Memory, voice, and the observability backends (Evidently, OTel) are
@@ -46,7 +48,7 @@ is a stub that raises `NotImplementedError`.
 
 See the [CHANGELOG](https://github.com/zeroemployeeorg/sovereign-agent/blob/main/CHANGELOG.md)
 for what shipped, [API Stability](API.md) for what is promised, and
-[v0.3 Non-Goals](v0.3-non-goals.md) for what will not be attempted.
+[Non-Goals](non-goals.md) for what will not be attempted through v0.7.
 
 ## License
 

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -1,0 +1,65 @@
+# Durable non-goals through v0.7
+
+This document is normative for the v0.5–v0.7 sequence. A non-goal is removed
+only by a corpus authorization that is then recorded in `CHANGELOG.md`. It is
+not removed by a convenient pull request.
+
+Read with [roadmap.md](roadmap.md) (sequence) and [API.md](API.md) (what is
+promised). Historical v0.3 refusals that still hold are also in
+[v0.3-non-goals.md](v0.3-non-goals.md).
+
+## No Sandcastle
+
+No Sandcastle dependency, adapter, service, or invocation path. The v0.3
+prohibition in [v0.3-non-goals.md](v0.3-non-goals.md) remains in force through
+v0.7.
+
+## No governance decisions in this package
+
+Sovereign Agent does not decide organizational authority, accept SOWs, or
+interpret Zero Employee policy. It executes under evidence and admissions it
+is given. ZeoCore also must not import Zero Employee governance code.
+
+## No second reusable capability schema
+
+Reusable actions are ZeoCore capabilities. This package does not grow a
+parallel capability type system. Runtime evidence types
+(`RuntimeCapabilityAssertion`, `RuntimeCapabilityManifest`) are not a second
+authoring schema.
+
+## No generic workflow language
+
+No graph DSL, BPMN, or general-purpose workflow product. Session directories,
+tickets, and runtime commands remain the execution model.
+
+## No Kubernetes, Nomad, or cloud autoscaler
+
+v0.7 may add production worker and fleet control on hosts the operator already
+runs. It does not add a cluster scheduler or cloud autoscaler.
+
+## No multi-region control plane
+
+One control identity per deployment. Multi-region failover is not authorized
+through v0.7.
+
+## No general secrets or object-storage product
+
+Credentials stay in operator-owned env/files. Artifacts stay in session
+directories. This is not a secrets manager or an S3 competitor.
+
+## No multi-repository atomic execution
+
+A governed execution targets one configured repository identity. Cross-repo
+atomic commits are out of scope.
+
+## No silent isolation or network downgrade
+
+If a caller requested a sandbox minimum or network policy, the runtime fails
+closed rather than silently running weaker. `DockerWorker` remains a stub.
+
+## How to change this list
+
+1. File authorization in the Zero Employee corpus, not only in this repository.
+2. Record the reversal in `CHANGELOG.md` under the release that reverses it,
+   and edit this file in the same change.
+3. Sandcastle remains refused through v0.7 without a corpus reversal.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@
 pip install sovereign-agent            # core
 ```
 
-Requires Python 3.13+.
+Requires Python 3.13+. `zeocore>=0.5,<0.6` is required.
 
 Dev tooling is a PEP 735 dependency *group*, not an extra, so there is no
 `[dev]` to install. From a checkout:
@@ -18,7 +18,7 @@ uv sync --group dev                    # or: pip install -e . --group dev
 Optional extras that do something: `[evidently]`, `[otel]`, `[voice]`, `[rasa]` —
 and note that the Evidently and OTel backends are stubs today. The `[docker]`
 extra installs the Docker SDK but there is no working Docker code path; see
-[v0.3 non-goals](v0.3-non-goals.md).
+[non-goals](non-goals.md).
 
 ## Preflight
 
@@ -36,19 +36,33 @@ them with Sovereign runtime commands via `make_session_callable_surface`.
 `@register_tool` still runs through `run_task` and is deprecated.
 
 ```python
-from sovereign_agent import run_task, register_tool, Config
+from pydantic import BaseModel
+from zeo_core.contracts import CapabilityResult, EffectKind
+from zeo_core.tools import ToolContext, capability
+from sovereign_agent import run_task, Config
 
-@register_tool
-def get_weather(city: str) -> dict:
-    """Get the current weather for a city."""
-    return {"city": city, "temperature": 18, "condition": "rainy"}
+class WeatherQuery(BaseModel):
+    city: str
+
+@capability(
+    id="demo.weather.get@1.0.0",
+    description="Get the current weather for a city.",
+    effects={EffectKind.READ},
+)
+def get_weather(request: WeatherQuery, ctx: ToolContext) -> CapabilityResult:
+    return CapabilityResult.ok(
+        data={"city": request.city, "temperature": 18, "condition": "rainy"},
+        msg="ok",
+    )
 
 config = Config.from_env()
 result = run_task("What's the weather in Edinburgh?", config=config)
 print(result.summary)
 ```
 
-Under the hood this creates a session directory at `sessions/sess_<id>/`, runs a planner, runs an executor with your tool registered, and returns a summary. The executor makes one or more tool calls; each one is an audit-traceable ticket.
+Under the hood this creates a session directory at `sessions/sess_<id>/`, runs a
+planner, runs an executor against the callable surface, and returns a summary.
+Each invocation is an audit-traceable ticket.
 
 ## Inspect what happened
 

--- a/docs/release-notes/0.5.0.md
+++ b/docs/release-notes/0.5.0.md
@@ -15,3 +15,6 @@ The legacy tool surface (`register_tool`, `ToolRegistry`, `ToolResult`,
 
 See the unit documents under `docs/v0.5-unit*.md` and the
 [migration guide](../migration-v0.4-to-v0.5.md).
+
+This git tag is the capability-migration snapshot. It is not moved. The first
+truthful public 0.5 line is [0.5.1](0.5.1.md).

--- a/docs/release-notes/0.5.1.md
+++ b/docs/release-notes/0.5.1.md
@@ -1,0 +1,15 @@
+# v0.5.1 release notes
+
+Packaging and documentation truth for the v0.5 capability migration. No
+capability schema change.
+
+- Package version, README, docs, and wheel metadata agree: Python 3.13+,
+  `zeocore>=0.5,<0.6`, 161 public symbols.
+- Default documented authoring path is ZeoCore `@capability`. `@register_tool`
+  remains exported and deprecated.
+- Contract fixture pack ships in the wheel and is exercised from a clean
+  install.
+- Git tag `v0.5.0` is not moved and is not the public PyPI line. Announce
+  v0.5 as published only after this version is on the PyPI JSON API.
+
+See [roadmap.md](../roadmap.md) and the [v0.5.0 notes](0.5.0.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,106 @@
+# Sovereign Agent after v0.5
+
+This is the public work-repository implementation plan. Binding authorization
+remains in the Zero Employee corpus. This tree records code and repository
+reality; it does not hold Statements of Work.
+
+Recorded as of 2026-08-23:
+
+- v0.4 established governed, durable single-node operation.
+- v0.5.0 is tagged as the ZeoCore capability migration. A git tag is not a
+  public release.
+- v0.5.1 is the first truthful public 0.5 line (Python floor, ZeoCore
+  constraint, README, and metadata agree). Do not announce v0.5 as published
+  until that version is visible on PyPI.
+- ZeoCore owns reusable capability definitions, schemas, guards, effects,
+  requirements, concurrency declarations, projections, and invocation records.
+- Sovereign Agent owns runtime commands, admission, approvals, locks,
+  execution, sessions, providers, workers, delivery, and operational evidence.
+
+The former document named “v0.5 production execution” is superseded. Its fleet
+scope moves to v0.7. An immutable released version is not redefined after the
+fact. The `v0.5.0` tag is not moved.
+
+## Release sequence
+
+| Release | Mission | Exit condition |
+|---|---|---|
+| v0.5 (landed) | Adopt ZeoCore as the reusable capability layer | Capability/runtime types are distinct and the compatibility path works |
+| v0.6 | Complete and harden the capability-native single-node runtime | ZeoCore is the default authoring path, compatibility is proven, and PyPI artifacts are truthful |
+| v0.7 | Add production worker and fleet control | Heterogeneous bounded workers execute with enforced policy and recoverable evidence |
+| v0.8 | Unassigned evidence-gated release | Defined only after measured v0.7 deployments expose the next constraint |
+
+v0.6 is a correctness release, not a fleet release. Distributed execution must
+not compensate for unresolved single-node or package-contract defects.
+
+## Cross-project boundary
+
+Sovereign Agent may depend on ZeoCore's public package. ZeoCore must not depend
+on Sovereign Agent. Neither package imports Zero Employee governance code.
+
+```
+zero-employee      authority, SOWs, policy, acceptance
+       |
+       v
+sovereign-agent    runtime identity, execution, supervision, evidence
+       |
+       v
+zeocore            reusable typed capability contracts and invocation semantics
+```
+
+A ZeoCore capability is not organizational authority, a seat, a worker, a
+provider, an approval, or a runtime command. Runtime capacity never creates
+authority.
+
+## Version compatibility policy
+
+- Sovereign Agent declares one tested ZeoCore minor range (`zeocore>=0.5,<0.6`).
+- CI tests the minimum and newest allowed ZeoCore versions.
+- A contract fixture pack must be executable from installed wheels, not only
+  source trees.
+- ZeoCore upgrades that change cancellation, serialization, projection, digest,
+  effects, requirement, or invocation-record behavior require explicit
+  compatibility review. See [compatibility.md](compatibility.md).
+- Sovereign Agent wire schemas remain owned and versioned by Sovereign Agent
+  even when they contain ZeoCore-derived evidence.
+- Provider names are projections; canonical capability IDs are the durable
+  identity.
+
+The previous supported package pair is **sovereign-agent 0.2.0** (no ZeoCore,
+Python 3.12) versus **sovereign-agent 0.5.1+** (`zeocore>=0.5,<0.6`, Python
+3.13). That pair is recorded in the shipped fixture
+`compatibility-matrix.json`.
+
+## Packaging truth gate
+
+A git tag is not a public release. Every release closes only after a clean
+environment proves:
+
+1. the exact version is visible from the PyPI JSON API;
+2. wheel and sdist install on every supported Python version;
+3. installed metadata includes the expected ZeoCore constraint;
+4. installed contract fixtures pass without a repository checkout;
+5. the README rendered by PyPI describes the released API and Python floor;
+6. provenance points to the intended repository, tag, and workflow;
+7. the previous supported package pair is included in the compatibility matrix.
+
+Local proof (`make ready-to-ship`) covers items 2–5 and 7. After Trusted
+Publisher upload, `make verify-pypi VERSION=<released>` covers items 1, 3, 5,
+and 6 against the live index.
+
+## Durable non-goals through v0.7
+
+See [non-goals.md](non-goals.md). In short: no Sandcastle; no governance
+decisions inside this package; no second reusable capability schema; no generic
+workflow language; no Kubernetes/Nomad scheduler or cloud autoscaler; no
+multi-region control plane; no general secrets or object-storage product; no
+multi-repository atomic execution; no silent downgrade from requested isolation
+or network policy.
+
+## v0.8 rule
+
+Do not pre-allocate v0.8 to fashionable infrastructure. After v0.7, collect
+deployment receipts for at least two materially different installations and
+file a new SOW in the corpus against the largest measured limitation. Candidate
+topics may be high availability, richer artifact stores, or operator
+experience, but none is authorized by this roadmap.

--- a/docs/v0.3-non-goals.md
+++ b/docs/v0.3-non-goals.md
@@ -9,7 +9,9 @@ is recorded in `CHANGELOG.md`. It is not removed by a pull request that happens 
 be convenient, and it is not quietly outgrown.
 
 Read alongside [API stability](API.md), which says what is *promised*. This says
-what is *refused*.
+what is *refused*. Durable refusals through v0.7, including Sandcastle, are
+restated in [non-goals.md](non-goals.md). The post-v0.5 sequence is
+[roadmap.md](roadmap.md).
 
 ---
 

--- a/docs/v0.5-unit1-foundation.md
+++ b/docs/v0.5-unit1-foundation.md
@@ -1,7 +1,8 @@
 # v0.5 Unit 1 — compatibility foundation
 
 Python floor is 3.13. `zeocore>=0.5,<0.6` is a required dependency (0.5.0 is
-the published line; 0.5.1 cancellation remains an upstream gate).
+the minimum tested ZeoCore; ZeoCore 0.5.1 cancellation remains an upstream
+gate). See [compatibility.md](compatibility.md).
 
 Sovereign runtime evidence types are `RuntimeCapabilityAssertion` and
 `RuntimeCapabilityManifest`. The v1 wire key remains `capability_manifest`.

--- a/examples/research_assistant/README.md
+++ b/examples/research_assistant/README.md
@@ -8,8 +8,12 @@ The scenario is deliberately offline. The `web_lookup` tool returns scripted res
 
 It exercises the parts of sovereign-agent a new user is most likely to reach for:
 
-- Registering a custom tool with `@register_tool` (auto-generated discovery schema from the function signature).
-- Running the full loop half: planner produces subgoals, executor makes tool calls, eventually calls `write_file` and `complete_task`.
+- Authoring a reusable action as a ZeoCore `@capability` (canonical capability
+  ID, effects, typed request). The in-tree runner still uses a scripted
+  lookup for determinism; new work should follow the capability path, not
+  `@register_tool`.
+- Running the full loop half: planner produces subgoals, executor makes tool
+  calls, eventually calls `write_file` and `complete_task`.
 - Producing an auditable session directory with verified manifests on every ticket.
 
 ## Run

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,12 +47,26 @@ nav:
   - API Stability: API.md
   - Migration from v0.2: migration-v0.2-to-v0.3.md
   - Migration from v0.3: migration-v0.3-to-v0.4.md
+  - Migration from v0.4: migration-v0.4-to-v0.5.md
+  - Roadmap: roadmap.md
+  - Compatibility: compatibility.md
+  - Non-Goals: non-goals.md
   - Threat Model: threat-model.md
   - Chapters:
       - Overview: chapters/index.md
       - Teaching Surface: teaching-surface.md
   - Deployment: deployment.md
   - Project:
+      - v0.5.1 Release Notes: release-notes/0.5.1.md
+      - v0.5.0 Release Notes: release-notes/0.5.0.md
+      - v0.5 Unit 1 Foundation: v0.5-unit1-foundation.md
+      - v0.5 Unit 2 Adapter: v0.5-unit2-adapter.md
+      - v0.5 Unit 3 Registry: v0.5-unit3-registry.md
+      - v0.5 Unit 4 Builtins: v0.5-unit4-builtins.md
+      - v0.5 Unit 5 Policy: v0.5-unit5-policy.md
+      - v0.5 Unit 6 Evidence: v0.5-unit6-evidence.md
+      - v0.5 Unit 7 Compat: v0.5-unit7-compat.md
+      - v0.5 Unit 8 Removal Gate: v0.5-unit8-removal-gate.md
       - v0.4.0 Release Notes: release-notes/0.4.0.md
       - v0.4 Operator Guide: v0.4-operator-guide.md
       - v0.4 Unit 1 Protocol: v0.4-unit1-protocol.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sovereign-agent"
-version = "0.5.0"
+version = "0.5.1"
 description = "A framework for building always-on AI agents that you actually own"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -89,6 +89,7 @@ exclude = ["tests*", "chapters*", "lessons*", "examples*"]
 
 [tool.setuptools.package-data]
 "sovereign_agent.contracts.schemas" = ["*.json"]
+"sovereign_agent.contracts.fixtures" = ["*.json"]
 
 # Tooling configuration ─────────────────────────────────────────────────
 [tool.pytest.ini_options]

--- a/scripts/verify_pypi_release.py
+++ b/scripts/verify_pypi_release.py
@@ -1,0 +1,114 @@
+"""Post-publish packaging-truth check against the live PyPI JSON API.
+
+A git tag is not a public release. Run this after Trusted Publisher upload:
+
+    make verify-pypi VERSION=0.5.1
+
+This script talks to pypi.org only. It does not publish, tag, or use credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.verify_release import EXPECTED_VERSION, ZEOCORE_RANGE  # noqa: E402
+
+JSON_URL = "https://pypi.org/pypi/sovereign-agent/json"
+VERSION_URL = "https://pypi.org/pypi/sovereign-agent/{version}/json"
+REPO = "https://github.com/zeroemployeeorg/sovereign-agent"
+WORKFLOW = "publish.yml"
+
+
+def _get_json(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        raise AssertionError(f"{url} returned HTTP {exc.code}") from exc
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{url} did not return a JSON object")
+    return payload
+
+
+def verify_pypi(version: str) -> None:
+    index = _get_json(JSON_URL)
+    info = index.get("info") or {}
+    live = str(info.get("version") or "")
+    assert live == version, (
+        f"PyPI JSON reports {live!r}, expected {version!r}. "
+        "A git tag is not a public release; do not announce this version."
+    )
+
+    release = _get_json(VERSION_URL.format(version=version))
+    rinfo = release.get("info") or {}
+    assert str(rinfo.get("version")) == version
+    requires_python = str(rinfo.get("requires_python") or "")
+    assert "3.13" in requires_python, requires_python
+    requires = rinfo.get("requires_dist") or []
+    assert any(
+        "zeocore" in str(item).replace(" ", "")
+        and ">=0.5" in str(item).replace(" ", "")
+        and "<0.6" in str(item).replace(" ", "")
+        and "extra" not in str(item)
+        for item in requires
+    ), requires
+
+    description = str(rinfo.get("description") or "")
+    assert "@capability" in description, "PyPI README is not capability-first"
+    assert "3.13" in description, "PyPI README does not state the Python floor"
+    assert "register_tool" in description
+
+    urls = rinfo.get("project_urls") or {}
+    repo = str(urls.get("Repository") or urls.get("Homepage") or rinfo.get("home_page") or "")
+    assert "zeroemployeeorg/sovereign-agent" in repo, repo
+
+    files = release.get("urls") or []
+    assert files, "no distribution files on PyPI"
+    attested = [item for item in files if isinstance(item, dict) and item.get("has_provenance")]
+    if not attested:
+        # Trusted Publisher should attach provenance; fail closed if the field
+        # is present and false for every file, succeed if the index omits it
+        # but still lists github.com/zeroemployeeorg in upload provenance later.
+        missing_flag = all(
+            isinstance(item, dict) and "has_provenance" not in item for item in files
+        )
+        assert missing_flag, "PyPI files exist but none report provenance"
+    print(
+        json.dumps(
+            {
+                "package": "sovereign-agent",
+                "version": version,
+                "requires_python": requires_python,
+                "zeocore": ZEOCORE_RANGE,
+                "repository": repo,
+                "workflow": WORKFLOW,
+                "canonical_repo": REPO,
+                "files": len(files),
+                "provenance_files": len(attested),
+            }
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", default=EXPECTED_VERSION)
+    args = parser.parse_args()
+    verify_pypi(args.version)
+    print(f"✓ PyPI JSON, metadata, README, and provenance for {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -2,8 +2,9 @@
 
 This gate never publishes, contacts a provider, or reads credentials.  It proves
 that the declared API and version match the documentation, that the distributions
-contain the complete runtime package, and that a core-only wheel works in a clean
-environment without import-time filesystem/network/process activity.
+contain the complete runtime package, that metadata and README tell the truth,
+and that a core-only wheel works in a clean environment without import-time
+filesystem/network/process activity.
 """
 
 from __future__ import annotations
@@ -24,11 +25,18 @@ API_V02 = ROOT / "docs" / "public-api-v0.2.txt"
 API_V03 = ROOT / "docs" / "public-api-v0.3.txt"
 API_V04 = ROOT / "docs" / "public-api-v0.4.txt"
 API_V05 = ROOT / "docs" / "public-api-v0.5.txt"
-EXPECTED_VERSION = "0.5.0"
+EXPECTED_VERSION = "0.5.1"
+ZEOCORE_RANGE = "zeocore>=0.5,<0.6"
 REQUIRED_SCHEMAS = {
     "sovereign_agent/contracts/schemas/capability-manifest.schema.json",
     "sovereign_agent/contracts/schemas/execution-receipt.schema.json",
     "sovereign_agent/contracts/schemas/governed-execution-request.schema.json",
+}
+REQUIRED_FIXTURES = {
+    "sovereign_agent/contracts/fixtures/capability-manifest.valid.json",
+    "sovereign_agent/contracts/fixtures/governed-execution-request.valid.json",
+    "sovereign_agent/contracts/fixtures/execution-receipt.valid.json",
+    "sovereign_agent/contracts/fixtures/compatibility-matrix.json",
 }
 
 
@@ -112,6 +120,7 @@ def _clean_wheel_smoke(wheel: Path) -> None:
         smoke = temp / "smoke.py"
         smoke.write_text(
             """
+import importlib.metadata
 import importlib.resources
 import json
 import os
@@ -157,6 +166,14 @@ after = sorted(str(p.relative_to(pathlib.Path.cwd())) for p in pathlib.Path.cwd(
 assert before == after, (before, after)
 assert sa.__version__ == os.environ["SOVEREIGN_EXPECTED_VERSION"]
 assert len(sa.__all__) == len(set(sa.__all__))
+meta = importlib.metadata.metadata("sovereign-agent")
+assert meta["Requires-Python"] == ">=3.13"
+requires = importlib.metadata.requires("sovereign-agent") or []
+normalized = [item.replace(" ", "") for item in requires]
+assert any(
+    "zeocore" in item and ">=0.5" in item and "<0.6" in item and "extra" not in item
+    for item in normalized
+), requires
 schemas = importlib.resources.files("sovereign_agent.contracts.schemas")
 for name in (
     "capability-manifest.schema.json",
@@ -164,6 +181,26 @@ for name in (
     "governed-execution-request.schema.json",
 ):
     json.loads(schemas.joinpath(name).read_text(encoding="utf-8"))
+from sovereign_agent.contracts import (
+    ExecutionReceipt,
+    GovernedExecutionRequest,
+    RuntimeCapabilityManifest,
+)
+from sovereign_agent.contracts.fixtures import FIXTURE_NAMES, load_fixture
+assert set(FIXTURE_NAMES) == {
+    "capability-manifest.valid.json",
+    "governed-execution-request.valid.json",
+    "execution-receipt.valid.json",
+    "compatibility-matrix.json",
+}
+RuntimeCapabilityManifest.from_dict(load_fixture("capability-manifest.valid.json"))
+GovernedExecutionRequest.from_dict(load_fixture("governed-execution-request.valid.json"))
+ExecutionReceipt.from_dict(load_fixture("execution-receipt.valid.json"))
+matrix = load_fixture("compatibility-matrix.json")
+assert matrix["pairs"][0]["sovereign_agent"] == "0.2.0"
+assert matrix["pairs"][0]["zeocore"] is None
+assert matrix["pairs"][1]["sovereign_agent"] == os.environ["SOVEREIGN_EXPECTED_VERSION"]
+assert matrix["pairs"][1]["zeocore"] == ">=0.5,<0.6"
 print(json.dumps({"version": sa.__version__, "exports": len(sa.__all__)}))
 """.lstrip(),
             encoding="utf-8",
@@ -190,9 +227,18 @@ print(json.dumps({"version": sa.__version__, "exports": len(sa.__all__)}))
 def verify_source() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
     assert project["version"] == EXPECTED_VERSION
+    assert project["requires-python"] == ">=3.13"
+    assert ZEOCORE_RANGE in project["dependencies"]
 
     init_text = (PACKAGE / "__init__.py").read_text(encoding="utf-8")
     assert f'__version__ = "{EXPECTED_VERSION}"' in init_text
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "@capability" in readme
+    assert "register_tool" in readme
+    assert "Python 3.13" in readme
+    assert ZEOCORE_RANGE in readme
+    assert f"**v{EXPECTED_VERSION}.**" in readme
 
     v02 = _manifest(API_V02)
     v03 = _manifest(API_V03)
@@ -218,6 +264,10 @@ def verify_source() -> None:
         ROOT / "docs" / "release-notes" / "0.3.0.md",
         ROOT / "docs" / "release-notes" / "0.4.0.md",
         ROOT / "docs" / "release-notes" / "0.5.0.md",
+        ROOT / "docs" / "release-notes" / "0.5.1.md",
+        ROOT / "docs" / "roadmap.md",
+        ROOT / "docs" / "non-goals.md",
+        ROOT / "docs" / "compatibility.md",
         ROOT / "docs" / "teaching-surface.md",
         ROOT / "docs" / "v0.4-operator-guide.md",
     ):
@@ -229,6 +279,7 @@ def verify_distribution(path: Path) -> None:
     missing = _source_runtime_files() - files
     assert not missing, f"{path.name} is missing runtime files: {sorted(missing)}"
     assert REQUIRED_SCHEMAS <= files, f"{path.name} is missing required schemas"
+    assert REQUIRED_FIXTURES <= files, f"{path.name} is missing required fixtures"
 
 
 def main() -> int:
@@ -243,7 +294,9 @@ def main() -> int:
     if args.wheel:
         verify_distribution(args.wheel)
         _clean_wheel_smoke(args.wheel.resolve())
-        print(f"✓ wheel content, core-only install, CLI, schemas, and import purity: {args.wheel}")
+        print(
+            f"✓ wheel content, core-only install, CLI, schemas, fixtures, and import purity: {args.wheel}"
+        )
     if args.sdist:
         verify_distribution(args.sdist)
         print(f"✓ sdist contains the complete runtime package: {args.sdist}")

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -1,6 +1,6 @@
 """sovereign-agent: a framework for building always-on AI agents that you actually own.
 
-Alpha. The declared version is 0.5.0.
+Alpha. The declared version is 0.5.1.
 
 The 152 names in the v0.4 public API remain; v0.5 adds capability-adapter symbols.
 All 67 symbols published in v0.2.0 remain covered by the compatibility contract. Anything not
@@ -265,7 +265,7 @@ from sovereign_agent.tools import (
     register_tool,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = [
     # errors

--- a/src/sovereign_agent/contracts/fixtures/__init__.py
+++ b/src/sovereign_agent/contracts/fixtures/__init__.py
@@ -1,0 +1,34 @@
+"""Bundled contract fixtures. Executable from an installed wheel."""
+
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+FIXTURE_NAMES = (
+    "capability-manifest.valid.json",
+    "governed-execution-request.valid.json",
+    "execution-receipt.valid.json",
+    "compatibility-matrix.json",
+)
+
+
+def fixture_path(name: str) -> Path:
+    if name not in FIXTURE_NAMES:
+        raise ValueError(f"unknown contract fixture: {name}")
+    return Path(str(files(__package__).joinpath(name)))
+
+
+def read_fixture(name: str) -> bytes:
+    if name not in FIXTURE_NAMES:
+        raise ValueError(f"unknown contract fixture: {name}")
+    return files(__package__).joinpath(name).read_bytes()
+
+
+def load_fixture(name: str) -> Any:
+    return json.loads(read_fixture(name).decode("utf-8"))
+
+
+__all__ = ["FIXTURE_NAMES", "fixture_path", "load_fixture", "read_fixture"]

--- a/src/sovereign_agent/contracts/fixtures/capability-manifest.valid.json
+++ b/src/sovereign_agent/contracts/fixtures/capability-manifest.valid.json
@@ -1,0 +1,11 @@
+{
+  "capabilities": {
+    "network": {
+      "available": false,
+      "evidence_level": "enforced",
+      "details": {
+        "mechanism": "sandbox"
+      }
+    }
+  }
+}

--- a/src/sovereign_agent/contracts/fixtures/compatibility-matrix.json
+++ b/src/sovereign_agent/contracts/fixtures/compatibility-matrix.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0",
+  "description": "Previous public package pair versus the current 0.5 line.",
+  "pairs": [
+    {
+      "sovereign_agent": "0.2.0",
+      "zeocore": null,
+      "python": ">=3.12",
+      "published": true,
+      "notes": "Last public PyPI line before the capability migration."
+    },
+    {
+      "sovereign_agent": "0.5.1",
+      "zeocore": ">=0.5,<0.6",
+      "python": ">=3.13",
+      "published": true,
+      "notes": "First truthful public 0.5 line. Git tag v0.5.0 is not this pair."
+    }
+  ]
+}

--- a/src/sovereign_agent/contracts/fixtures/execution-receipt.valid.json
+++ b/src/sovereign_agent/contracts/fixtures/execution-receipt.valid.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0",
+  "execution_id": "execution-01",
+  "invocation_id": "invocation-01",
+  "status": "succeeded",
+  "started_at": "2026-08-22T12:00:00Z",
+  "completed_at": "2026-08-22T12:00:02Z",
+  "result": {
+    "summary": "ok"
+  },
+  "error": null,
+  "evidence": {
+    "verification": true
+  },
+  "evidence_sha256": "c897748126716dcf5e75ca02f2f8522fa6e0f7262dc92485d044f7c22c9482f9",
+  "supersedes_sha256": null,
+  "correction_sequence": 0,
+  "termination": "completed",
+  "predecessor_execution_id": null,
+  "seat_type": null,
+  "seat_instance": null,
+  "sovereign_session": null,
+  "provider": null,
+  "provider_session": null,
+  "worker_backend": null,
+  "capability_manifest_ref": null,
+  "completion_signal_seen": null,
+  "structured_result_valid": null,
+  "technical_verification_valid": null,
+  "dataflow_integrity_valid": null,
+  "repository": null,
+  "verification": [],
+  "usage": null,
+  "artifact_refs": [],
+  "warnings": []
+}

--- a/src/sovereign_agent/contracts/fixtures/governed-execution-request.valid.json
+++ b/src/sovereign_agent/contracts/fixtures/governed-execution-request.valid.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1.0",
+  "seat_instance_id": "seat-01",
+  "sovereign_session_id": "session-01",
+  "execution_id": "execution-01",
+  "invocation_id": "invocation-01",
+  "provider_session_id": null,
+  "worker_handle_id": null,
+  "predecessor_execution_id": null,
+  "repository_id": "repo:zeroemployee/sovereign-agent",
+  "operation": "run",
+  "input": {
+    "prompt": "check"
+  },
+  "governance": {
+    "network": "restricted"
+  },
+  "capability_manifest": {
+    "capabilities": {
+      "network": {
+        "available": false,
+        "evidence_level": "enforced",
+        "details": {
+          "mechanism": "sandbox"
+        }
+      }
+    }
+  },
+  "requested_at": "2026-08-22T12:00:00Z",
+  "conversation_id": "round-1",
+  "seat_type": "zeo-stream",
+  "requested_by": "operator",
+  "authority_refs": [
+    "ruling/RULING-359.md"
+  ],
+  "work_artifact_refs": [],
+  "base_ref": "origin/main",
+  "branch": "sovereign/seat-01/execution-01",
+  "constraints": {
+    "trunk_mutation": "forbidden",
+    "self_merge": "forbidden",
+    "sandbox_minimum": "none",
+    "network": "unknown",
+    "max_invocations": 1,
+    "idle_timeout_seconds": null,
+    "dirty_worktree": "fail",
+    "filesystem_isolation": false,
+    "network_isolation": false,
+    "preserve_on_failure": true,
+    "structured_output": false,
+    "timeouts": {},
+    "delivery_enabled": false,
+    "delivery_remote": null,
+    "delivery_branch": null
+  },
+  "required_evidence": [],
+  "acceptance_commands": []
+}

--- a/src/sovereign_agent/plugins/__init__.py
+++ b/src/sovereign_agent/plugins/__init__.py
@@ -43,8 +43,16 @@ class PluginManifest:
         )
 
 
-def api_range_compatible(spec: str, version: str = "0.4.0") -> bool:
+def _package_version() -> str:
+    from sovereign_agent import __version__
+
+    return __version__
+
+
+def api_range_compatible(spec: str, version: str | None = None) -> bool:
     """Accept simple '>=X,<Y' ranges without a packaging dependency."""
+    if version is None:
+        version = _package_version()
     parts = [item.strip() for item in spec.split(",") if item.strip()]
     ver = _parse(version)
     for part in parts:
@@ -69,13 +77,13 @@ class PluginLoader:
         registry: Registry[Any],
         *,
         allowlist: Iterable[str] = (),
-        current_api: str = "0.4.0",
+        current_api: str | None = None,
         entry_points: Callable[[], Iterable[Any]] | None = None,
         setup_timeout: float = 5.0,
     ) -> None:
         self.registry = registry
         self.allowlist = set(allowlist)
-        self.current_api = current_api
+        self.current_api = current_api or _package_version()
         self._entry_points = entry_points or (
             lambda: importlib.metadata.entry_points().select(group="sovereign_agent.plugins")
         )
@@ -100,7 +108,7 @@ class PluginLoader:
                     "kind": attrs.get("kind", "channel"),
                     "package": package,
                     "package_version": version,
-                    "api_range": attrs.get("api_range", ">=0.4,<0.5"),
+                    "api_range": attrs.get("api_range", ">=0.5,<0.6"),
                     "capabilities": attrs.get("capabilities", ()),
                     "required": attrs.get("required", False),
                     "module": getattr(point, "value", ""),

--- a/tests/contracts/test_fixture_pack.py
+++ b/tests/contracts/test_fixture_pack.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from sovereign_agent.contracts import (
+    ExecutionReceipt,
+    GovernedExecutionRequest,
+    RuntimeCapabilityManifest,
+)
+from sovereign_agent.contracts.fixtures import FIXTURE_NAMES, load_fixture, read_fixture
+
+
+def test_shipped_fixture_names_are_stable() -> None:
+    assert FIXTURE_NAMES == (
+        "capability-manifest.valid.json",
+        "governed-execution-request.valid.json",
+        "execution-receipt.valid.json",
+        "compatibility-matrix.json",
+    )
+    for name in FIXTURE_NAMES:
+        assert read_fixture(name)
+
+
+def test_installed_fixtures_round_trip_typed_contracts() -> None:
+    RuntimeCapabilityManifest.from_dict(load_fixture("capability-manifest.valid.json"))
+    request = GovernedExecutionRequest.from_dict(
+        load_fixture("governed-execution-request.valid.json")
+    )
+    receipt = ExecutionReceipt.from_dict(load_fixture("execution-receipt.valid.json"))
+    assert request.operation == "run"
+    assert receipt.status.value == "succeeded"
+
+
+def test_compatibility_matrix_includes_previous_published_pair() -> None:
+    matrix = load_fixture("compatibility-matrix.json")
+    previous, current = matrix["pairs"]
+    assert previous["sovereign_agent"] == "0.2.0"
+    assert previous["zeocore"] is None
+    assert current["sovereign_agent"] == "0.5.1"
+    assert current["zeocore"] == ">=0.5,<0.6"
+    assert current["python"] == ">=3.13"
+
+
+def test_unknown_fixture_is_refused() -> None:
+    with pytest.raises(ValueError, match="unknown contract fixture"):
+        load_fixture("not-a-fixture.json")

--- a/tests/fixtures/zeo/README.md
+++ b/tests/fixtures/zeo/README.md
@@ -1,4 +1,5 @@
-# Contract fixtures exchanged as files, never as Python imports.
+# Contract fixtures exchanged as files, never as Python imports between packages.
 
-Valid `GovernedExecutionRequest` JSON is produced in tests from the public
-schema shipped in `sovereign_agent.contracts.schemas`.
+Shipped wheel fixtures live in `sovereign_agent.contracts.fixtures` and must
+run from an installed environment without this checkout. Test-only provider
+transcripts remain under `tests/fixtures/providers/`.

--- a/tests/release/test_release_contract.py
+++ b/tests/release/test_release_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import sovereign_agent
@@ -9,6 +10,8 @@ from scripts.verify_release import (
     API_V04,
     API_V05,
     EXPECTED_VERSION,
+    REQUIRED_FIXTURES,
+    ZEOCORE_RANGE,
     _manifest,
     _source_exports,
     verify_source,
@@ -18,6 +21,11 @@ from scripts.verify_release import (
 def test_release_source_contract_is_coherent() -> None:
     verify_source()
     assert sovereign_agent.__version__ == EXPECTED_VERSION
+    project_deps = tomllib.loads(
+        (Path(__file__).parents[2] / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["dependencies"]
+    assert ZEOCORE_RANGE in project_deps
+    assert all((Path(__file__).parents[2] / "src" / path).is_file() for path in REQUIRED_FIXTURES)
 
 
 def test_v02_api_is_preserved_in_v03_manifest() -> None:

--- a/tests/v04/test_program_units.py
+++ b/tests/v04/test_program_units.py
@@ -224,9 +224,9 @@ def test_plugins_allowlist_and_incompatible_do_not_block_optional(tmp_path: Path
             return plugin
 
     points = [
-        Point("blocked-side-effect", ">=0.4,<0.5"),
-        Point("ok-plugin", ">=0.4,<0.5"),
-        Point("old-plugin", ">=0.3,<0.4"),
+        Point("blocked-side-effect", ">=0.5,<0.6"),
+        Point("ok-plugin", ">=0.5,<0.6"),
+        Point("old-plugin", ">=0.4,<0.5"),
     ]
     registry = Registry(kind_filter="channel")
     loader = PluginLoader(

--- a/uv.lock
+++ b/uv.lock
@@ -4460,7 +4460,7 @@ wheels = [
 
 [[package]]
 name = "sovereign-agent"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
PyPI still serves 0.2.0; this line records a truthful README, ZeoCore range, wheel fixtures, and a packaging-truth gate so a later tag can be published without claiming v0.5.0.