### PR TITLE
Declare the Apache license as an SPDX expression.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.5.1"
 description = "A framework for building always-on AI agents that you actually own"
 readme = "README.md"
 requires-python = ">=3.13"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [{ name = "Rod Rivera" }]
 keywords = ["agent", "llm", "always-on", "ai", "orchestration"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries :: Python Modules",
@@ -79,7 +79,7 @@ dev = [
 # when building wheels via `uv build`. No need to move to uv_build for a
 # single-package project.
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Setuptools 77 deprecates table-form project.license and license classifiers; keep the wheel metadata valid through the 2027 cutoff.