### PR TITLE
Wrap long capability signatures for ruff format

### DIFF
--- a/examples/code_reviewer/run.py
+++ b/examples/code_reviewer/run.py
@@ -134,7 +134,9 @@ class CheckPythonResponse(BaseModel):
         ),
     ),
 )
-def check_python_file(request: CheckPythonRequest, ctx: ToolContext) -> CapabilityResult[CheckPythonResponse]:
+def check_python_file(
+    request: CheckPythonRequest, ctx: ToolContext
+) -> CapabilityResult[CheckPythonResponse]:
     result = _check_python(request.source)
     _TOOL_CALL_LOG.append(
         {
@@ -146,7 +148,9 @@ def check_python_file(request: CheckPythonRequest, ctx: ToolContext) -> Capabili
             "line_count": result.output["line_count"],
         }
     )
-    return CapabilityResult.ok(data=CheckPythonResponse.model_validate(result.output), msg=result.summary)
+    return CapabilityResult.ok(
+        data=CheckPythonResponse.model_validate(result.output), msg=result.summary
+    )
 
 
 def _build_surface(session):

--- a/examples/hitl_deposit/run.py
+++ b/examples/hitl_deposit/run.py
@@ -92,7 +92,9 @@ class DepositResponse(BaseModel):
         ),
     ),
 )
-def commit_booking_with_deposit(request: DepositRequest, ctx: ToolContext) -> CapabilityResult[DepositResponse]:
+def commit_booking_with_deposit(
+    request: DepositRequest, ctx: ToolContext
+) -> CapabilityResult[DepositResponse]:
     needs_approval = request.deposit_gbp > AUTO_APPROVE_CEILING_GBP
     proposed = {
         "venue_id": request.venue_id,


### PR DESCRIPTION
## Summary
- `make ready-to-ship` failed preflight on `ruff format` for two example files after the v0.6 capability signatures landed.
- Wrap `check_python_file` / `commit_booking_with_deposit` and one `CapabilityResult.ok(...)` call so `ruff format --check` passes.

## Test plan
- [x] `uv run ruff format --check src/sovereign_agent tests/ chapters/ examples/ scripts/ tools/`
- [x] `make preflight` green
- [ ] `make ready-to-ship` on this branch (full suite)


Made with [Cursor](https://cursor.com)