### PR TITLE
Complete governed assignments for Claude, Codex, and Cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ Capability claims retain probe evidence and fail closed. Terminal events,
 sessions, usage, malformed streams, reports, canonical receipts, and receipt
 digests are validated by fake-executable integration tests. Credentialed live
 assignments remain explicitly opt-in and outside default CI. Chapter 3 lands
-with a runnable provider-rebinding exercise.
+with a runnable provider-rebinding exercise. Codex receives an authority-bound
+writable sandbox for its mandatory report; refusals and timeouts finalize
+durable failed receipts; provider credentials use explicit environment
+allowlists.
 
 ### 1.x educational reset (authorization only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ sessions, usage, malformed streams, reports, canonical receipts, and receipt
 digests are validated by fake-executable integration tests. Credentialed live
 assignments remain explicitly opt-in and outside default CI. Chapter 3 lands
 with a runnable provider-rebinding exercise. Codex receives an authority-bound
-writable sandbox for its mandatory report; refusals and timeouts finalize
-durable failed receipts; provider credentials use explicit environment
-allowlists.
+writable sandbox, Claude receives `acceptEdits`, and Cursor receives `--force`
+for the mandatory report; refusals and timeouts finalize durable failed
+receipts; provider credentials use explicit environment allowlists.
 
 ### 1.x educational reset (authorization only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ Repository: [`zeroemployeeorg/sovereign-agent`](https://github.com/zeroemployeeo
 ### Providers (Unit 6)
 
 Claude, Codex, and Cursor adapters implement `probe` / `build_invocation` /
-`parse_event`. Capability claims come from `--help` probes and fail closed.
-Default tests use committed fixtures. `pytest -m live` is opt-in and never
-part of default CI. Chapter 3 lands with this unit.
+`parse_event`. One provider-neutral envelope supplies actor identity,
+authority, SOW, workspace/output boundaries, and the exact report schema.
+Capability claims retain probe evidence and fail closed. Terminal events,
+sessions, usage, malformed streams, reports, canonical receipts, and receipt
+digests are validated by fake-executable integration tests. Credentialed live
+assignments remain explicitly opt-in and outside default CI. Chapter 3 lands
+with a runnable provider-rebinding exercise.
 
 ### 1.x educational reset (authorization only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Repository: [`zeroemployeeorg/sovereign-agent`](https://github.com/zeroemployeeo
 
 ## Unreleased
 
+### Providers (Unit 6)
+
+Claude, Codex, and Cursor adapters implement `probe` / `build_invocation` /
+`parse_event`. Capability claims come from `--help` probes and fail closed.
+Default tests use committed fixtures. `pytest -m live` is opt-in and never
+part of default CI. Chapter 3 lands with this unit.
+
 ### 1.x educational reset (authorization only)
 
 Principal ruling 2026-08-25 authorizes Sovereign Agent 1.x as an executable

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Sovereign Agent's disposable workspace.
 
 Provider subprocesses receive only base process variables plus documented
 credential allowlists: Claude (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
-`CLAUDE_CODE_OAUTH_TOKEN`), Codex (`OPENAI_API_KEY`), and Cursor
+`CLAUDE_CODE_OAUTH_TOKEN`), Codex (`CODEX_API_KEY`), and Cursor
 (`CURSOR_API_KEY`). Other parent secrets are not forwarded.
 
 ## Unit 1 gates

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Sovereign Agent doctor
   Pydantic: 2.x OK
   Network:  not required
   Tokens:   not required
-Ready for the offline curriculum.
+  Providers:
+    scripted available (streaming)
+    claude   missing executable
+    ...
+Ready for the offline curriculum. Live providers are optional.
 ```
 
 Chapter 0 is runnable as a **manually dispatched** store shift (no Pulse):
@@ -39,7 +43,8 @@ Chapter 0 is runnable as a **manually dispatched** store shift (no Pulse):
 sovereign-agent demo store --mode simulated
 ```
 
-See [`book/ch00_first_shift`](book/ch00_first_shift/README.md).
+See [`book/ch00_first_shift`](book/ch00_first_shift/README.md) and
+[`book/ch03_actor_is_not_a_model`](book/ch03_actor_is_not_a_model/README.md).
 
 ## Product vocabulary
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ See [`book/ch00_first_shift`](book/ch00_first_shift/README.md) and
 | Intelligence CLI | `provider` |
 | Governed identity | `actor` |
 
+An actor is not a model. Every provider receives the same governed assignment
+envelope and must emit a valid terminal event and write the exact
+`ActorReport`. A zero exit without both is a failed receipt. Cursor's
+`--workspace` is directory selection, not sandboxing; isolation belongs to
+Sovereign Agent's disposable workspace.
+
 ## Unit 1 gates
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ envelope and must emit a valid terminal event and write the exact
 `--workspace` is directory selection, not sandboxing; isolation belongs to
 Sovereign Agent's disposable workspace.
 
+Provider subprocesses receive only base process variables plus documented
+credential allowlists: Claude (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
+`CLAUDE_CODE_OAUTH_TOKEN`), Codex (`OPENAI_API_KEY`), and Cursor
+(`CURSOR_API_KEY`). Other parent secrets are not forwarded.
+
 ## Unit 1 gates
 
 ```bash

--- a/book/README.md
+++ b/book/README.md
@@ -5,4 +5,6 @@ package; it does not copy or fork it.
 
 - [Chapter 0: Andrea's first shift](ch00_first_shift/README.md) — runnable
   simulated store shift (manually dispatched replenishment, no Pulse)
+- [Chapter 3: The actor is not a model](ch03_actor_is_not_a_model/README.md) —
+  providers are probed CLIs; Cursor is equal to Claude and Codex
 

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -45,6 +45,11 @@ write its mandatory report. The live read-only smoke verifies that tracked
 domain files remain unchanged; it does not make the report directory
 unwritable.
 
+The same authority becomes Claude `--permission-mode acceptEdits` and Cursor
+`--force`, but only when those exact controls are present in the installed
+CLI's help output. These flags authorize writes inside the disposable run
+workspace; they do not expand the actor's organizational authority.
+
 ## Reflection
 
 1. Which fields stayed constant after rebinding the provider?

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -1,0 +1,23 @@
+# Chapter 3 — The actor is not a model
+
+## Status: runnable (offline)
+
+An actor is a governed identity with a role and authority. A provider is an
+external intelligence CLI: `scripted`, `claude`, `codex`, or `cursor`. Binding
+`operator-course` to `claude` does not make Claude the operator. The same
+actor can be rebound to `scripted` without changing the outcome, the SOW, or
+the evidence rules.
+
+Cursor is a first-class adapter, equal to Claude and Codex. It is not a
+documentation bridge.
+
+Default tests never call those CLIs. They parse committed fixtures. Live
+probes are opt-in and must not be in default CI:
+
+```bash
+python -m pytest -q -m live
+```
+
+Those probes run `--help` / `--version` only. They do not submit prompts.
+
+`solution.py` imports the production registry rather than copying it.

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -39,6 +39,12 @@ and shell tools. Chapter 3 relies on a disposable Sovereign Agent run
 workspace, not an invented provider security guarantee. Stronger workspace
 lifecycle policies arrive in Unit 7.
 
+Codex receives `--sandbox workspace-write` when the actor has
+`write_workspace` authority because even a domain-read-only assignment must
+write its mandatory report. The live read-only smoke verifies that tracked
+domain files remain unchanged; it does not make the report directory
+unwritable.
+
 ## Reflection
 
 1. Which fields stayed constant after rebinding the provider?

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -1,23 +1,83 @@
 # Chapter 3 — The actor is not a model
 
-## Status: runnable (offline)
+## Andrea's goal
 
-An actor is a governed identity with a role and authority. A provider is an
-external intelligence CLI: `scripted`, `claude`, `codex`, or `cursor`. Binding
-`operator-course` to `claude` does not make Claude the operator. The same
-actor can be rebound to `scripted` without changing the outcome, the SOW, or
-the evidence rules.
+An **actor** is a governed identity with a role and authority. A **provider**
+is an external intelligence CLI: `scripted`, `claude`, `codex`, or `cursor`.
+Changing intelligence must not silently change who may act.
 
-Cursor is a first-class adapter, equal to Claude and Codex. It is not a
-documentation bridge.
+## Exercise
 
-Default tests never call those CLIs. They parse committed fixtures. Live
-probes are opt-in and must not be in default CI:
+1. Inspect `operator-course` in `sovereign.toml`. Record its id, role,
+   authority, and provider.
+2. Run the exercise with a provider you have installed:
+
+   ```bash
+   python book/ch03_actor_is_not_a_model/solution.py \
+     --root /tmp/andrea-ch03 --provider claude
+   ```
+
+3. Inspect the first scripted receipt under
+   `/tmp/andrea-ch03/.sovereign/runs/*/receipt.json`.
+4. Observe the governed `actor.provider_rebound` event. The Principal changes
+   the provider binding; the actor id, role, and authority remain unchanged.
+5. If the live CLI is absent or cannot prove required print/stream flags, read
+   the refusal. Installing a model does not bypass the gate.
+6. If it runs, inspect `provider_session_ref`, `provider_usage`, normalized
+   events, and the validated `.sovereign-out/report.json`.
+7. Replace `--provider claude` with `codex` or `cursor`. Cursor is an equal
+   adapter, not a documentation bridge.
+
+The provider receives one production-built assignment envelope containing the
+actor, authority, SOW, disposable workspace boundary, output paths, and exact
+`ActorReport` schema. The adapter only translates that envelope into its CLI.
+
+## Isolation warning
+
+`--workspace` selects a directory; it is not a sandbox. Cursor's CLI has file
+and shell tools. Chapter 3 relies on a disposable Sovereign Agent run
+workspace, not an invented provider security guarantee. Stronger workspace
+lifecycle policies arrive in Unit 7.
+
+## Reflection
+
+1. Which fields stayed constant after rebinding the provider?
+2. Why is a provider session id evidence about continuity but not actor
+   identity?
+3. What should happen if a CLI exits zero but omits its terminal event or
+   `report.json`?
+4. Why may an unknown valid event be retained while malformed JSON must fail
+   the receipt?
+5. In your own words: what is the difference between an actor and a provider?
+
+## Production correspondence
+
+| Textbook concept | Production responsibility |
+| --- | --- |
+| Actor id, role, authority | Governed organizational identity and policy |
+| Provider binding | Replaceable intelligence runtime |
+| Assignment envelope | Bounded work contract and output schema |
+| Disposable run directory | Isolation boundary owned by Sovereign Agent |
+| Provider session reference | Runtime continuity evidence, never identity |
+| Terminal event + report | Protocol completion plus validated work claim |
+| Receipt and SHA-256 sidecar | Canonical durable execution evidence |
+
+## Live smoke tests
+
+Default tests use faithful, redacted fixtures and fake executables. Probes are
+opt-in and submit no work:
 
 ```bash
 python -m pytest -q -m live
 ```
 
-Those probes run `--help` / `--version` only. They do not submit prompts.
+Credentialed assignment smokes require a second explicit gate. They run one
+read-only and one workspace-write assignment per installed provider and may
+consume provider credits (typically a short prompt each):
 
-`solution.py` imports the production registry rather than copying it.
+```bash
+SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1 python -m pytest -q -m live
+```
+
+The fixture repository is disposable, and each test proves its trunk commit
+did not move.

--- a/book/ch03_actor_is_not_a_model/solution.py
+++ b/book/ch03_actor_is_not_a_model/solution.py
@@ -1,0 +1,5 @@
+"""Chapter 3 uses the production registry. An actor name is not a model name."""
+
+from sovereign_agent.providers import PROVIDERS, get_provider
+
+__all__ = ["PROVIDERS", "get_provider"]

--- a/book/ch03_actor_is_not_a_model/solution.py
+++ b/book/ch03_actor_is_not_a_model/solution.py
@@ -1,5 +1,81 @@
-"""Chapter 3 uses the production registry. An actor name is not a model name."""
+"""Runnable Chapter 3 exercise using the production organization and registry."""
 
-from sovereign_agent.providers import PROVIDERS, get_provider
+from __future__ import annotations
 
-__all__ = ["PROVIDERS", "get_provider"]
+import argparse
+import json
+from pathlib import Path
+
+from sovereign_agent.errors import Refusal
+from sovereign_agent.models import Role
+from sovereign_agent.organization import Organization
+from sovereign_agent.providers import PROVIDERS
+
+
+def _assignment(org: Organization, scope: str) -> tuple[str, str]:
+    outcome = org.create_outcome(
+        "Chapter 3",
+        "actor identity survives",
+        ["receipt"],
+        "principal-human",
+    )
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, scope, Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    assignment = org.assign(sow.id, "operator-course", "master-course")
+    finished = org.run_assignment(assignment.id)
+    workspace = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    return finished.state, (workspace / "receipt.json").read_text(encoding="utf-8")
+
+
+def run_exercise(root: Path, live_provider: str = "claude") -> dict[str, object]:
+    org = Organization.init(root)
+    actor = org.actor("operator-course")
+    identity_before = {
+        "id": actor.id,
+        "role": actor.role,
+        "authority": actor.authority,
+    }
+    scripted_state, scripted_receipt = _assignment(org, "Write the required offline report.")
+    org.rebind_actor(actor.id, live_provider, "principal-human")
+    rebound = org.actor(actor.id)
+    identity_after = {
+        "id": rebound.id,
+        "role": rebound.role,
+        "authority": rebound.authority,
+    }
+    try:
+        live_state, live_receipt = _assignment(
+            org,
+            "Inspect README.md if present and write the required report "
+            "without expanding authority.",
+        )
+        live: dict[str, object] = {
+            "state": live_state,
+            "receipt": json.loads(live_receipt),
+        }
+    except Refusal as refusal:
+        live = {"refused": str(refusal)}
+    return {
+        "identity_unchanged": identity_before == identity_after,
+        "before": identity_before,
+        "after": identity_after,
+        "scripted": {
+            "state": scripted_state,
+            "receipt": json.loads(scripted_receipt),
+        },
+        "live": live,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--provider", choices=tuple(PROVIDERS), default="claude")
+    args = parser.parse_args()
+    print(json.dumps(run_exercise(args.root, args.provider), indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ include = ["sovereign_agent*", "reference_organizations*"]
 testpaths = ["tests"]
 addopts = "-ra -m 'not live'"
 markers = [
-  "live: installed provider CLI probes; excluded from default CI",
+  "live: installed provider probes/assignments; excluded from default CI",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ include = ["sovereign_agent*", "reference_organizations*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-ra"
+addopts = "-ra -m 'not live'"
+markers = [
+  "live: installed provider CLI probes; excluded from default CI",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/sovereign_agent/cli.py
+++ b/src/sovereign_agent/cli.py
@@ -39,12 +39,23 @@ def _doctor(_: argparse.Namespace) -> int:
     print("  Providers:")
     for name, provider in PROVIDERS.items():
         caps = provider.probe()
-        state = "available" if caps.available else "missing executable"
+        if caps.available:
+            state = f"available {caps.version}".rstrip()
+            if caps.degraded_reason:
+                state += f"; degraded: {caps.degraded_reason}"
+        elif caps.degraded_reason:
+            state = f"degraded: {caps.degraded_reason}"
+        else:
+            state = "missing executable"
         extra = []
         if caps.streaming:
             extra.append("streaming")
         if caps.resume:
             extra.append("resume")
+        if caps.workspace_selection:
+            extra.append("workspace-selection")
+        if caps.sandbox:
+            extra.append("sandbox")
         suffix = f" ({', '.join(extra)})" if extra else ""
         print(f"    {name:8} {state}{suffix}")
     if python_ok and pydantic_ok:

--- a/src/sovereign_agent/cli.py
+++ b/src/sovereign_agent/cli.py
@@ -13,6 +13,7 @@ from sovereign_agent import __version__
 from sovereign_agent.errors import Refusal
 from sovereign_agent.models import Role
 from sovereign_agent.organization import Organization
+from sovereign_agent.providers import PROVIDERS
 
 
 def _installed_version(distribution: str) -> str:
@@ -35,8 +36,19 @@ def _doctor(_: argparse.Namespace) -> int:
     print(f"  Pydantic: {pydantic_version} {'OK' if pydantic_ok else 'MISSING'}")
     print("  Network:  not required")
     print("  Tokens:   not required")
+    print("  Providers:")
+    for name, provider in PROVIDERS.items():
+        caps = provider.probe()
+        state = "available" if caps.available else "missing executable"
+        extra = []
+        if caps.streaming:
+            extra.append("streaming")
+        if caps.resume:
+            extra.append("resume")
+        suffix = f" ({', '.join(extra)})" if extra else ""
+        print(f"    {name:8} {state}{suffix}")
     if python_ok and pydantic_ok:
-        print("Ready for the offline curriculum.")
+        print("Ready for the offline curriculum. Live providers are optional.")
         return 0
     if not python_ok:
         print("Next: install Python 3.14, then rerun `sovereign-agent doctor`.")

--- a/src/sovereign_agent/cli.py
+++ b/src/sovereign_agent/cli.py
@@ -195,9 +195,7 @@ def build_parser() -> argparse.ArgumentParser:
     created.add_argument("--owner", default="principal-human")
     created.set_defaults(handler=_outcome_new)
 
-    plan = subparsers.add_parser(
-        "plan", parents=[shared], help="activate an outcome and add a SOW"
-    )
+    plan = subparsers.add_parser("plan", parents=[shared], help="activate an outcome and add a SOW")
     plan.add_argument("outcome_id")
     plan.add_argument("--scope", default="Advance the outcome by one bounded assignment")
     plan.add_argument("--role", default="operator")
@@ -210,15 +208,11 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--planner", default="master-course")
     run.set_defaults(handler=_run)
 
-    status = subparsers.add_parser(
-        "status", parents=[shared], help="explain outcome and SOW state"
-    )
+    status = subparsers.add_parser("status", parents=[shared], help="explain outcome and SOW state")
     status.add_argument("outcome_id")
     status.set_defaults(handler=_status)
 
-    inbox = subparsers.add_parser(
-        "inbox", parents=[shared], help="list an actor's durable mailbox"
-    )
+    inbox = subparsers.add_parser("inbox", parents=[shared], help="list an actor's durable mailbox")
     inbox.add_argument("actor_id")
     inbox.set_defaults(handler=_inbox)
 
@@ -247,9 +241,7 @@ def build_parser() -> argparse.ArgumentParser:
     accept.add_argument("--evidence", nargs="+", required=True)
     accept.set_defaults(handler=_accept)
 
-    demo = subparsers.add_parser(
-        "demo", parents=[shared], help="run a scripted teaching scenario"
-    )
+    demo = subparsers.add_parser("demo", parents=[shared], help="run a scripted teaching scenario")
     demo.add_argument("target", choices=["store"])
     demo.add_argument("--mode", default="simulated", choices=["simulated"])
     demo.set_defaults(handler=_demo)

--- a/src/sovereign_agent/cli.py
+++ b/src/sovereign_agent/cli.py
@@ -54,6 +54,8 @@ def _doctor(_: argparse.Namespace) -> int:
             extra.append("resume")
         if caps.workspace_selection:
             extra.append("workspace-selection")
+        if caps.workspace_write:
+            extra.append("workspace-write")
         if caps.sandbox:
             extra.append("sandbox")
         suffix = f" ({', '.join(extra)})" if extra else ""

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -171,5 +171,15 @@ class Database:
                 (record_id, payload),
             )
 
+    def put_serialized(self, table: str, record_id: str, payload: str) -> None:
+        """Persist already-canonical JSON without changing its bytes."""
+        json.loads(payload)
+        if table != "receipts":
+            raise ValueError("put_serialized is restricted to canonical receipts")
+        self.connection.execute(
+            "INSERT OR REPLACE INTO receipts(id, record) VALUES (?, ?)",
+            (record_id, payload),
+        )
+
     def close(self) -> None:
         self.connection.close()

--- a/src/sovereign_agent/errors.py
+++ b/src/sovereign_agent/errors.py
@@ -6,9 +6,18 @@ from __future__ import annotations
 class Refusal(Exception):  # noqa: N818
     """A fail-closed decision that must not be treated as success."""
 
-    def __init__(self, happened: str, why: str, inspect: str, next_command: str) -> None:
+    def __init__(
+        self,
+        happened: str,
+        why: str,
+        inspect: str,
+        next_command: str,
+        *,
+        category: str = "refusal",
+    ) -> None:
         self.happened = happened
         self.why = why
         self.inspect = inspect
         self.next_command = next_command
+        self.category = category
         super().__init__(f"{happened} {why} Inspect: {inspect}. Next: {next_command}")

--- a/src/sovereign_agent/execution.py
+++ b/src/sovereign_agent/execution.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from sovereign_agent.errors import Refusal
 from sovereign_agent.ids import new_id, utc_now
 from sovereign_agent.models import ActorReport, Receipt
-from sovereign_agent.providers import PROVIDERS
-from sovereign_agent.providers.scripted import InvocationSpec
+from sovereign_agent.providers import get_provider
+from sovereign_agent.providers.base import InvocationRequest, InvocationSpec
 
 
 def run_spec(spec: InvocationSpec, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
@@ -45,14 +45,7 @@ def run_spec(spec: InvocationSpec, timeout: float = 60.0) -> subprocess.Complete
 def invoke_actor(
     provider_name: str, workspace: Path, output: Path, prompt: str
 ) -> tuple[Receipt, ActorReport | None]:
-    provider = PROVIDERS.get(provider_name)
-    if provider is None:
-        raise Refusal(
-            happened=f"Unknown provider {provider_name}.",
-            why="Fail closed: only probed adapters may run.",
-            inspect="sovereign-agent doctor",
-            next_command="Use scripted until a live adapter is installed.",
-        )
+    provider = get_provider(provider_name)
     capabilities = provider.probe()
     if not capabilities.available:
         raise Refusal(
@@ -61,7 +54,9 @@ def invoke_actor(
             "doctor",
             "Install the CLI or use scripted.",
         )
-    spec = provider.build_invocation(workspace, output, prompt)
+    spec = provider.build_invocation(
+        InvocationRequest(workspace=workspace, output=output, prompt=prompt)
+    )
     started = utc_now()
     result = run_spec(spec)
     ended = utc_now()
@@ -69,6 +64,12 @@ def invoke_actor(
     raw.mkdir(parents=True, exist_ok=True)
     (raw / "stdout.txt").write_text(result.stdout)
     (raw / "stderr.txt").write_text(result.stderr)
+    events = []
+    for line in result.stdout.splitlines():
+        event = provider.parse_event(line)
+        if event is not None:
+            events.append(json.dumps({"kind": event.kind, "payload": event.payload}))
+    (raw / "events.jsonl").write_text("\n".join(events) + ("\n" if events else ""))
     report_path = output / "report.json"
     report: ActorReport | None = None
     status = "failed"

--- a/src/sovereign_agent/execution.py
+++ b/src/sovereign_agent/execution.py
@@ -89,11 +89,14 @@ def build_assignment_envelope(
 
 
 def canonical_receipt_json(receipt: Receipt) -> str:
-    return json.dumps(
-        receipt.model_dump(mode="json"),
-        sort_keys=True,
-        separators=(",", ":"),
-    ) + "\n"
+    return (
+        json.dumps(
+            receipt.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
 
 
 def write_receipt(workspace: Path, receipt: Receipt) -> str:
@@ -208,8 +211,7 @@ def invoke_actor(
     failure_category: str | None = None
     failure_message: str | None = None
     protocol_ok = not malformed and (
-        not provider.requires_terminal_event
-        or (terminal is True and session_ref is not None)
+        not provider.requires_terminal_event or (terminal is True and session_ref is not None)
     )
     if result.returncode == 0 and protocol_ok and report_path.is_file():
         try:

--- a/src/sovereign_agent/execution.py
+++ b/src/sovereign_agent/execution.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from sovereign_agent.errors import Refusal
 from sovereign_agent.ids import new_id, utc_now
-from sovereign_agent.models import ActorReport, Receipt
+from sovereign_agent.models import Actor, ActorReport, Receipt, StatementOfWork
 from sovereign_agent.providers import get_provider
 from sovereign_agent.providers.base import InvocationRequest, InvocationSpec
 
@@ -42,20 +42,75 @@ def run_spec(spec: InvocationSpec, timeout: float = 60.0) -> subprocess.Complete
         ) from error
 
 
+def build_assignment_envelope(
+    actor: Actor,
+    sow: StatementOfWork,
+    workspace: Path,
+    output: Path,
+) -> str:
+    """Build the provider-neutral governed assignment passed to every CLI."""
+    envelope = {
+        "kind": "sovereign-agent.assignment.v1",
+        "actor": {
+            "id": actor.id,
+            "role": actor.role,
+            "authority": actor.authority,
+        },
+        "statement_of_work": sow.model_dump(mode="json"),
+        "workspace": {
+            "root": str(workspace),
+            "boundary": "Do not read or write outside this disposable workspace.",
+        },
+        "output": {
+            "directory": str(output),
+            "report": str(output / "report.json"),
+            "artifacts": str(output / "artifacts.json"),
+            "messages": str(output / "messages"),
+        },
+        "report_contract": {
+            "schema": ActorReport.model_json_schema(),
+            "required_action": (
+                "Before exiting, write report.json as strict JSON matching this schema. "
+                "Use status completed, blocked, or failed. Do not claim authority the actor lacks."
+            ),
+        },
+    }
+    return json.dumps(envelope, sort_keys=True)
+
+
+def canonical_receipt_json(receipt: Receipt) -> str:
+    return json.dumps(
+        receipt.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    ) + "\n"
+
+
 def invoke_actor(
-    provider_name: str, workspace: Path, output: Path, prompt: str
+    actor: Actor,
+    sow: StatementOfWork,
+    workspace: Path,
+    output: Path,
+    provider_session_id: str | None = None,
 ) -> tuple[Receipt, ActorReport | None]:
-    provider = get_provider(provider_name)
+    provider = get_provider(actor.provider)
     capabilities = provider.probe()
     if not capabilities.available:
         raise Refusal(
             "Provider unavailable.",
             "Fail closed on missing executables.",
-            "doctor",
+            "sovereign-agent doctor",
             "Install the CLI or use scripted.",
         )
+    envelope = build_assignment_envelope(actor, sow, workspace, output)
     spec = provider.build_invocation(
-        InvocationRequest(workspace=workspace, output=output, prompt=prompt)
+        InvocationRequest(
+            workspace=workspace,
+            output=output,
+            prompt=envelope,
+            require_resume=provider_session_id is not None,
+            provider_session_id=provider_session_id,
+        )
     )
     started = utc_now()
     result = run_spec(spec)
@@ -65,38 +120,60 @@ def invoke_actor(
     (raw / "stdout.txt").write_text(result.stdout)
     (raw / "stderr.txt").write_text(result.stderr)
     events = []
+    malformed = False
+    terminal: bool | None = None
+    session_ref = provider_session_id
+    usage: dict[str, int] = {}
     for line in result.stdout.splitlines():
         event = provider.parse_event(line)
         if event is not None:
-            events.append(json.dumps({"kind": event.kind, "payload": event.payload}))
+            events.append(
+                json.dumps(
+                    {
+                        "kind": event.kind,
+                        "payload": event.payload,
+                        "malformed": event.malformed,
+                        "terminal": event.terminal,
+                    },
+                    sort_keys=True,
+                )
+            )
+            malformed = malformed or event.malformed
+            if event.terminal:
+                terminal = event.succeeded
+            if event.session_id:
+                if session_ref is not None and session_ref != event.session_id:
+                    malformed = True
+                session_ref = event.session_id
+            usage.update(event.usage)
     (raw / "events.jsonl").write_text("\n".join(events) + ("\n" if events else ""))
     report_path = output / "report.json"
     report: ActorReport | None = None
     status = "failed"
-    if result.returncode == 0 and report_path.is_file():
+    protocol_ok = not malformed and (
+        not provider.requires_terminal_event
+        or (terminal is True and session_ref is not None)
+    )
+    if result.returncode == 0 and protocol_ok and report_path.is_file():
         try:
             report = ActorReport.model_validate_json(report_path.read_text(encoding="utf-8"))
-            status = (
-                report.status if report.status in {"completed", "blocked", "failed"} else "failed"
-            )
+            status = report.status
         except Exception:
             status = "failed"
-    elif result.returncode == 0 and not report_path.is_file():
-        status = "failed"
     receipt = Receipt(
         id=new_id("rct"),
-        actor_id="",
-        provider=provider_name,
-        provider_session_ref=None,
+        actor_id=actor.id,
+        provider=actor.provider,
+        provider_session_ref=session_ref,
+        provider_usage=usage,
         started_at=started,
         ended_at=ended,
         status=status,
         evidence_refs=[],
     )
-    digest = hashlib.sha256(
-        json.dumps(receipt.model_dump(mode="json"), sort_keys=True).encode()
-    ).hexdigest()
-    (workspace / "receipt.json").write_text(
-        receipt.model_dump_json(indent=2) + f"\n# digest {digest}\n"
-    )
+    receipt_json = canonical_receipt_json(receipt)
+    receipt_path = workspace / "receipt.json"
+    receipt_path.write_text(receipt_json, encoding="utf-8")
+    digest = hashlib.sha256(receipt_json.encode()).hexdigest()
+    (workspace / "receipt.json.sha256").write_text(f"{digest}\n", encoding="utf-8")
     return receipt, report

--- a/src/sovereign_agent/execution.py
+++ b/src/sovereign_agent/execution.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from sovereign_agent.errors import Refusal
@@ -39,6 +40,15 @@ def run_spec(spec: InvocationSpec, timeout: float = 60.0) -> subprocess.Complete
             why="A hung provider must not be treated as completion.",
             inspect=str(spec.cwd),
             next_command="Retry with a smaller assignment or inspect provider-raw logs.",
+            category="timeout",
+        ) from error
+    except OSError as error:
+        raise Refusal(
+            happened="Provider process could not start.",
+            why=str(error),
+            inspect=str(spec.cwd),
+            next_command="Run sovereign-agent doctor and inspect the executable.",
+            category="invocation_error",
         ) from error
 
 
@@ -86,6 +96,39 @@ def canonical_receipt_json(receipt: Receipt) -> str:
     ) + "\n"
 
 
+def write_receipt(workspace: Path, receipt: Receipt) -> str:
+    receipt_json = canonical_receipt_json(receipt)
+    receipt_path = workspace / "receipt.json"
+    receipt_path.write_text(receipt_json, encoding="utf-8")
+    digest = hashlib.sha256(receipt_json.encode()).hexdigest()
+    (workspace / "receipt.json.sha256").write_text(f"{digest}\n", encoding="utf-8")
+    return receipt_json
+
+
+def write_failed_receipt(
+    actor: Actor,
+    workspace: Path,
+    category: str,
+    message: str,
+    started_at: datetime | None = None,
+) -> Receipt:
+    receipt = Receipt(
+        id=new_id("rct"),
+        actor_id=actor.id,
+        provider=actor.provider,
+        provider_session_ref=None,
+        provider_usage={},
+        started_at=started_at or utc_now(),
+        ended_at=utc_now(),
+        status="failed",
+        failure_category=category,
+        failure_message=message,
+        evidence_refs=[],
+    )
+    write_receipt(workspace, receipt)
+    return receipt
+
+
 def invoke_actor(
     actor: Actor,
     sow: StatementOfWork,
@@ -93,6 +136,15 @@ def invoke_actor(
     output: Path,
     provider_session_id: str | None = None,
 ) -> tuple[Receipt, ActorReport | None]:
+    workspace_write = "write_workspace" in actor.authority
+    if "report" not in actor.authority or not workspace_write:
+        raise Refusal(
+            "Actor cannot write the mandatory report.",
+            "Every provider assignment must be authorized to write inside its run workspace.",
+            actor.id,
+            "Assign an actor with report and write_workspace authority.",
+            category="authority_refusal",
+        )
     provider = get_provider(actor.provider)
     capabilities = provider.probe()
     if not capabilities.available:
@@ -101,6 +153,7 @@ def invoke_actor(
             "Fail closed on missing executables.",
             "sovereign-agent doctor",
             "Install the CLI or use scripted.",
+            category="provider_unavailable",
         )
     envelope = build_assignment_envelope(actor, sow, workspace, output)
     spec = provider.build_invocation(
@@ -109,6 +162,7 @@ def invoke_actor(
             output=output,
             prompt=envelope,
             require_resume=provider_session_id is not None,
+            require_sandbox=actor.provider == "codex" and workspace_write,
             provider_session_id=provider_session_id,
         )
     )
@@ -150,6 +204,8 @@ def invoke_actor(
     report_path = output / "report.json"
     report: ActorReport | None = None
     status = "failed"
+    failure_category: str | None = None
+    failure_message: str | None = None
     protocol_ok = not malformed and (
         not provider.requires_terminal_event
         or (terminal is True and session_ref is not None)
@@ -158,8 +214,27 @@ def invoke_actor(
         try:
             report = ActorReport.model_validate_json(report_path.read_text(encoding="utf-8"))
             status = report.status
-        except Exception:
-            status = "failed"
+            if status == "failed":
+                failure_category = "actor_reported_failure"
+                failure_message = report.notes
+        except Exception as error:
+            failure_category = "invalid_report"
+            failure_message = str(error)
+    elif result.returncode != 0:
+        failure_category = "nonzero_exit"
+        failure_message = f"Provider exited with status {result.returncode}."
+    elif malformed:
+        failure_category = "malformed_stream"
+        failure_message = "Provider emitted malformed structured output."
+    elif provider.requires_terminal_event and terminal is not True:
+        failure_category = "provider_error" if terminal is False else "missing_terminal"
+        failure_message = "Provider did not emit a successful terminal event."
+    elif provider.requires_terminal_event and session_ref is None:
+        failure_category = "missing_session"
+        failure_message = "Provider did not emit a session reference."
+    elif not report_path.is_file():
+        failure_category = "missing_report"
+        failure_message = "Provider did not write the mandatory report."
     receipt = Receipt(
         id=new_id("rct"),
         actor_id=actor.id,
@@ -169,11 +244,9 @@ def invoke_actor(
         started_at=started,
         ended_at=ended,
         status=status,
+        failure_category=failure_category,
+        failure_message=failure_message,
         evidence_refs=[],
     )
-    receipt_json = canonical_receipt_json(receipt)
-    receipt_path = workspace / "receipt.json"
-    receipt_path.write_text(receipt_json, encoding="utf-8")
-    digest = hashlib.sha256(receipt_json.encode()).hexdigest()
-    (workspace / "receipt.json.sha256").write_text(f"{digest}\n", encoding="utf-8")
+    write_receipt(workspace, receipt)
     return receipt, report

--- a/src/sovereign_agent/execution.py
+++ b/src/sovereign_agent/execution.py
@@ -163,6 +163,7 @@ def invoke_actor(
             prompt=envelope,
             require_resume=provider_session_id is not None,
             require_sandbox=actor.provider == "codex" and workspace_write,
+            require_workspace_write=workspace_write,
             provider_session_id=provider_session_id,
         )
     )

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -156,6 +156,8 @@ class Receipt(StrictModel):
     started_at: datetime
     ended_at: datetime
     status: str
+    failure_category: str | None = None
+    failure_message: str | None = None
     evidence_refs: list[str]
 
 

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -152,6 +152,7 @@ class Receipt(StrictModel):
     actor_id: str
     provider: str
     provider_session_ref: str | None
+    provider_usage: dict[str, int] = Field(default_factory=dict)
     started_at: datetime
     ended_at: datetime
     status: str
@@ -177,7 +178,7 @@ class Signal(StrictModel):
 
 
 class ActorReport(StrictModel):
-    status: str
+    status: str = Field(pattern="^(completed|blocked|failed)$")
     changed_artifacts: list[str] = Field(default_factory=list)
     proposed_checks: list[str] = Field(default_factory=list)
     questions: list[str] = Field(default_factory=list)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -8,7 +8,7 @@ from sovereign_agent.actors import load_actors, write_config
 from sovereign_agent.database import Database
 from sovereign_agent.errors import Refusal
 from sovereign_agent.events import append_event
-from sovereign_agent.execution import invoke_actor
+from sovereign_agent.execution import invoke_actor, write_failed_receipt
 from sovereign_agent.governance import project_outcome, project_ruling
 from sovereign_agent.ids import new_id, utc_now
 from sovereign_agent.models import (
@@ -186,7 +186,30 @@ class Organization:
         workspace.mkdir(parents=True, exist_ok=True)
         assignment.state = AssignmentState.RUNNING
         self._save_assignment(assignment, sow, "assignment.running")
-        receipt, report = invoke_actor(worker, sow, workspace, output)
+        started_at = utc_now()
+        failure: Exception | None = None
+        try:
+            receipt, report = invoke_actor(worker, sow, workspace, output)
+        except Refusal as error:
+            receipt = write_failed_receipt(
+                worker,
+                workspace,
+                error.category,
+                str(error),
+                started_at,
+            )
+            report = None
+            failure = error
+        except Exception as error:
+            receipt = write_failed_receipt(
+                worker,
+                workspace,
+                "internal_error",
+                f"{type(error).__name__}: {error}",
+                started_at,
+            )
+            report = None
+            failure = error
         receipt_json = (workspace / "receipt.json").read_text(encoding="utf-8")
         with self.db.transaction():
             self.db.put_serialized("receipts", receipt.id, receipt_json)
@@ -205,6 +228,8 @@ class Organization:
                 self.db, "assignment.finished", {"id": assignment.id, "status": assignment.state}
             )
         self._project_outcome(sow.outcome_id)
+        if failure is not None:
+            raise failure
         return assignment
 
     def review(self, sow_id: str, reviewer_id: str, performer_id: str) -> StatementOfWork:

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -31,6 +31,7 @@ from sovereign_agent.policy import (
     forbid_self_approval,
     require_authority,
 )
+from sovereign_agent.providers import get_provider
 from sovereign_agent.relay import inbox as relay_inbox
 from sovereign_agent.relay import send as relay_send
 
@@ -69,6 +70,26 @@ class Organization:
                 "Use an id from sovereign.toml.",
             )
         return self.actors[actor_id]
+
+    def rebind_actor(self, actor_id: str, provider: str, authority_id: str) -> Actor:
+        authority = self.actor(authority_id)
+        require_authority(authority.role, "rule")
+        get_provider(provider)
+        actor = self.actor(actor_id)
+        actor.provider = provider
+        config = {
+            "schema_version": 1,
+            "actors": [item.model_dump(mode="json") for item in self.actors.values()],
+        }
+        write_config(self.config_path, config)
+        with self.db.transaction():
+            self.db.put("actors", actor.id, actor.model_dump(mode="json"))
+            append_event(
+                self.db,
+                "actor.provider_rebound",
+                {"actor_id": actor.id, "provider": provider, "by": authority_id},
+            )
+        return actor
 
     def create_outcome(
         self, title: str, desired_state: str, checks: list[str], owner: str
@@ -165,13 +186,16 @@ class Organization:
         workspace.mkdir(parents=True, exist_ok=True)
         assignment.state = AssignmentState.RUNNING
         self._save_assignment(assignment, sow, "assignment.running")
-        receipt, report = invoke_actor(worker.provider, workspace, output, assignment.prompt_ref)
-        receipt.actor_id = worker.id
+        receipt, report = invoke_actor(worker, sow, workspace, output)
+        receipt_json = (workspace / "receipt.json").read_text(encoding="utf-8")
         with self.db.transaction():
-            self.db.put("receipts", receipt.id, receipt.model_dump(mode="json"))
+            self.db.put_serialized("receipts", receipt.id, receipt_json)
             if report and report.status == "completed":
                 assignment.state = AssignmentState.COMPLETED
                 sow.state = advance_sow(SowState.RUNNING, SowState.REVIEW)
+            elif report and report.status == "blocked":
+                assignment.state = AssignmentState.BLOCKED
+                sow.state = advance_sow(SowState.RUNNING, SowState.BLOCKED)
             else:
                 assignment.state = AssignmentState.FAILED
                 sow.state = advance_sow(SowState.RUNNING, SowState.FAILED)

--- a/src/sovereign_agent/providers/__init__.py
+++ b/src/sovereign_agent/providers/__init__.py
@@ -1,5 +1,27 @@
-"""Provider package."""
+"""Provider registry. Cursor is a first-class adapter, equal to Claude and Codex."""
 
+from sovereign_agent.errors import Refusal
+from sovereign_agent.providers.base import IntelligenceProvider
+from sovereign_agent.providers.claude import ClaudeProvider
+from sovereign_agent.providers.codex import CodexProvider
+from sovereign_agent.providers.cursor import CursorProvider
 from sovereign_agent.providers.scripted import ScriptedProvider
 
-PROVIDERS = {"scripted": ScriptedProvider()}
+PROVIDERS: dict[str, IntelligenceProvider] = {
+    "scripted": ScriptedProvider(),
+    "claude": ClaudeProvider(),
+    "codex": CodexProvider(),
+    "cursor": CursorProvider(),
+}
+
+
+def get_provider(name: str) -> IntelligenceProvider:
+    provider = PROVIDERS.get(name)
+    if provider is None:
+        raise Refusal(
+            happened=f"Unknown provider {name}.",
+            why="An actor binds to a registry name, not to a model nickname.",
+            inspect="sovereign-agent doctor",
+            next_command="Use scripted, claude, codex, or cursor.",
+        )
+    return provider

--- a/src/sovereign_agent/providers/base.py
+++ b/src/sovereign_agent/providers/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -31,8 +32,11 @@ class ProviderCapabilities:
     available: bool
     version: str = ""
     print_mode: bool = False
+    print_flag: str | None = None
     streaming: bool = False
     resume: bool = False
+    resume_streaming: bool = False
+    resume_sandbox: bool = False
     structured_result: bool = False
     sandbox: bool = False
     usage: bool = False
@@ -96,6 +100,11 @@ def has_flag(text: str, flag: str) -> bool:
     return re.search(rf"(?<![\w-]){re.escape(flag)}(?![\w-])", text) is not None
 
 
+def allowed_environment(*names: str) -> dict[str, str]:
+    """Copy only explicitly documented provider variables from the parent."""
+    return {name: os.environ[name] for name in names if name in os.environ}
+
+
 def capture(executable: str, *args: str) -> ProbeEvidence:
     command = (executable, *args)
     located = look_up(executable)
@@ -134,6 +143,7 @@ def require_proven(
             "Provider CLIs are external executables, not package dependencies.",
             "sovereign-agent doctor",
             next_command,
+            category="provider_unavailable",
         )
     if request.provider_session_id and not request.require_resume:
         raise Refusal(
@@ -141,6 +151,7 @@ def require_proven(
             "A session id must never be silently discarded.",
             inspect,
             "Run a fresh assignment instead of resuming.",
+            category="resume_refusal",
         )
     required = {
         "print mode": (request.require_print_mode, caps.print_mode),
@@ -166,6 +177,7 @@ def require_proven(
             "Fail closed: adapters may not hard-code unsupported flags or semantics.",
             inspect,
             next_command,
+            category="capability_refusal",
         )
 
 

--- a/src/sovereign_agent/providers/base.py
+++ b/src/sovereign_agent/providers/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -13,15 +14,32 @@ from sovereign_agent.errors import Refusal
 
 
 @dataclass(frozen=True)
+class ProbeEvidence:
+    command: tuple[str, ...]
+    exit_code: int | None
+    stdout: str = ""
+    stderr: str = ""
+    error: str | None = None
+
+    @property
+    def text(self) -> str:
+        return f"{self.stdout}\n{self.stderr}".lower()
+
+
+@dataclass(frozen=True)
 class ProviderCapabilities:
     available: bool
     version: str = ""
+    print_mode: bool = False
     streaming: bool = False
     resume: bool = False
-    fork: bool = False
     structured_result: bool = False
     sandbox: bool = False
     usage: bool = False
+    workspace_selection: bool = False
+    verbose: bool = False
+    evidence: tuple[ProbeEvidence, ...] = ()
+    degraded_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -29,8 +47,13 @@ class InvocationRequest:
     workspace: Path
     output: Path
     prompt: str
+    require_print_mode: bool = True
     require_resume: bool = False
     require_streaming: bool = True
+    require_structured_result: bool = False
+    require_sandbox: bool = False
+    require_usage: bool = False
+    require_workspace_selection: bool = False
     provider_session_id: str | None = None
 
 
@@ -46,11 +69,17 @@ class ProviderEvent:
     kind: str
     payload: dict[str, Any]
     raw: str
+    malformed: bool = False
+    terminal: bool = False
+    succeeded: bool | None = None
+    session_id: str | None = None
+    usage: dict[str, int] = field(default_factory=dict)
 
 
 class IntelligenceProvider(Protocol):
     name: str
     executable: str
+    requires_terminal_event: bool
 
     def probe(self) -> ProviderCapabilities: ...
 
@@ -63,19 +92,32 @@ def look_up(executable: str) -> str | None:
     return shutil.which(executable)
 
 
-def capture(executable: str, *args: str) -> str:
+def has_flag(text: str, flag: str) -> bool:
+    return re.search(rf"(?<![\w-]){re.escape(flag)}(?![\w-])", text) is not None
+
+
+def capture(executable: str, *args: str) -> ProbeEvidence:
+    command = (executable, *args)
     located = look_up(executable)
     if located is None:
-        return ""
-    result = subprocess.run(
-        [located, *args],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=10,
-        shell=False,
+        return ProbeEvidence(command=command, exit_code=None, error="executable not found")
+    try:
+        result = subprocess.run(
+            [located, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            shell=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return ProbeEvidence(command=command, exit_code=None, error=str(error))
+    return ProbeEvidence(
+        command=command,
+        exit_code=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
     )
-    return f"{result.stdout}\n{result.stderr}"
 
 
 def require_proven(
@@ -93,19 +135,37 @@ def require_proven(
             "sovereign-agent doctor",
             next_command,
         )
-    if request.require_streaming and not caps.streaming:
+    if request.provider_session_id and not request.require_resume:
         raise Refusal(
-            f"{missing} cannot prove streaming output.",
-            "Fail closed: adapters may not hard-code unsupported flags.",
-            inspect,
-            next_command,
-        )
-    if request.require_resume and not caps.resume:
-        raise Refusal(
-            f"{missing} cannot prove resume.",
-            "Resume is used only when the probe shows the flag.",
+            f"{missing} received a session id without resume intent.",
+            "A session id must never be silently discarded.",
             inspect,
             "Run a fresh assignment instead of resuming.",
+        )
+    required = {
+        "print mode": (request.require_print_mode, caps.print_mode),
+        "streaming output": (request.require_streaming, caps.streaming),
+        "resume": (request.require_resume, caps.resume),
+        "structured result": (request.require_structured_result, caps.structured_result),
+        "sandbox": (request.require_sandbox, caps.sandbox),
+        "usage": (request.require_usage, caps.usage),
+        "workspace selection": (
+            request.require_workspace_selection,
+            caps.workspace_selection,
+        ),
+    }
+    missing_capabilities = [
+        name
+        for name, (wanted, proven) in required.items()
+        if wanted and not proven
+    ]
+    if missing_capabilities:
+        names = ", ".join(missing_capabilities)
+        raise Refusal(
+            f"{missing} cannot prove required capability: {names}.",
+            "Fail closed: adapters may not hard-code unsupported flags or semantics.",
+            inspect,
+            next_command,
         )
 
 
@@ -116,8 +176,18 @@ def parse_json_line(line: str) -> ProviderEvent | None:
     try:
         payload = json.loads(stripped)
     except json.JSONDecodeError:
-        return ProviderEvent(kind="raw", payload={"text": stripped}, raw=stripped)
+        return ProviderEvent(
+            kind="malformed",
+            payload={"text": stripped},
+            raw=stripped,
+            malformed=True,
+        )
     if not isinstance(payload, dict):
-        return ProviderEvent(kind="raw", payload={"value": payload}, raw=stripped)
+        return ProviderEvent(
+            kind="malformed",
+            payload={"value": payload},
+            raw=stripped,
+            malformed=True,
+        )
     kind = str(payload.get("type") or payload.get("kind") or "raw")
     return ProviderEvent(kind=kind, payload=payload, raw=stripped)

--- a/src/sovereign_agent/providers/base.py
+++ b/src/sovereign_agent/providers/base.py
@@ -172,9 +172,7 @@ def require_proven(
         ),
     }
     missing_capabilities = [
-        name
-        for name, (wanted, proven) in required.items()
-        if wanted and not proven
+        name for name, (wanted, proven) in required.items() if wanted and not proven
     ]
     if missing_capabilities:
         names = ", ".join(missing_capabilities)

--- a/src/sovereign_agent/providers/base.py
+++ b/src/sovereign_agent/providers/base.py
@@ -1,0 +1,123 @@
+"""Intelligence-provider contract. Adapters never use shell=True."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from sovereign_agent.errors import Refusal
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    available: bool
+    version: str = ""
+    streaming: bool = False
+    resume: bool = False
+    fork: bool = False
+    structured_result: bool = False
+    sandbox: bool = False
+    usage: bool = False
+
+
+@dataclass(frozen=True)
+class InvocationRequest:
+    workspace: Path
+    output: Path
+    prompt: str
+    require_resume: bool = False
+    require_streaming: bool = True
+    provider_session_id: str | None = None
+
+
+@dataclass(frozen=True)
+class InvocationSpec:
+    argv: list[str]
+    cwd: Path
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProviderEvent:
+    kind: str
+    payload: dict[str, Any]
+    raw: str
+
+
+class IntelligenceProvider(Protocol):
+    name: str
+    executable: str
+
+    def probe(self) -> ProviderCapabilities: ...
+
+    def build_invocation(self, request: InvocationRequest) -> InvocationSpec: ...
+
+    def parse_event(self, line: str) -> ProviderEvent | None: ...
+
+
+def look_up(executable: str) -> str | None:
+    return shutil.which(executable)
+
+
+def capture(executable: str, *args: str) -> str:
+    located = look_up(executable)
+    if located is None:
+        return ""
+    result = subprocess.run(
+        [located, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        shell=False,
+    )
+    return f"{result.stdout}\n{result.stderr}"
+
+
+def require_proven(
+    caps: ProviderCapabilities,
+    request: InvocationRequest,
+    *,
+    missing: str,
+    inspect: str,
+    next_command: str,
+) -> None:
+    if not caps.available:
+        raise Refusal(
+            f"{missing} is not installed.",
+            "Provider CLIs are external executables, not package dependencies.",
+            "sovereign-agent doctor",
+            next_command,
+        )
+    if request.require_streaming and not caps.streaming:
+        raise Refusal(
+            f"{missing} cannot prove streaming output.",
+            "Fail closed: adapters may not hard-code unsupported flags.",
+            inspect,
+            next_command,
+        )
+    if request.require_resume and not caps.resume:
+        raise Refusal(
+            f"{missing} cannot prove resume.",
+            "Resume is used only when the probe shows the flag.",
+            inspect,
+            "Run a fresh assignment instead of resuming.",
+        )
+
+
+def parse_json_line(line: str) -> ProviderEvent | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return ProviderEvent(kind="raw", payload={"text": stripped}, raw=stripped)
+    if not isinstance(payload, dict):
+        return ProviderEvent(kind="raw", payload={"value": payload}, raw=stripped)
+    kind = str(payload.get("type") or payload.get("kind") or "raw")
+    return ProviderEvent(kind=kind, payload=payload, raw=stripped)

--- a/src/sovereign_agent/providers/base.py
+++ b/src/sovereign_agent/providers/base.py
@@ -39,6 +39,7 @@ class ProviderCapabilities:
     resume_sandbox: bool = False
     structured_result: bool = False
     sandbox: bool = False
+    workspace_write: bool = False
     usage: bool = False
     workspace_selection: bool = False
     verbose: bool = False
@@ -56,6 +57,7 @@ class InvocationRequest:
     require_streaming: bool = True
     require_structured_result: bool = False
     require_sandbox: bool = False
+    require_workspace_write: bool = False
     require_usage: bool = False
     require_workspace_selection: bool = False
     provider_session_id: str | None = None
@@ -159,6 +161,10 @@ def require_proven(
         "resume": (request.require_resume, caps.resume),
         "structured result": (request.require_structured_result, caps.structured_result),
         "sandbox": (request.require_sandbox, caps.sandbox),
+        "workspace write": (
+            request.require_workspace_write,
+            caps.workspace_write,
+        ),
         "usage": (request.require_usage, caps.usage),
         "workspace selection": (
             request.require_workspace_selection,

--- a/src/sovereign_agent/providers/claude.py
+++ b/src/sovereign_agent/providers/claude.py
@@ -8,6 +8,7 @@ from sovereign_agent.providers.base import (
     InvocationSpec,
     ProviderCapabilities,
     ProviderEvent,
+    allowed_environment,
     capture,
     has_flag,
     look_up,
@@ -20,6 +21,11 @@ class ClaudeProvider:
     name = "claude"
     executable = "claude"
     requires_terminal_event = True
+    authentication_environment = (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    )
 
     def probe(self) -> ProviderCapabilities:
         if look_up(self.executable) is None:
@@ -36,10 +42,18 @@ class ClaudeProvider:
             )
         version = version_probe.stdout.strip().splitlines()
         help_text = help_probe.text
+        print_flag = (
+            "-p"
+            if has_flag(help_text, "-p")
+            else "--print"
+            if has_flag(help_text, "--print")
+            else None
+        )
         return ProviderCapabilities(
             available=True,
             version=version[0] if version else "",
-            print_mode=has_flag(help_text, "-p") or has_flag(help_text, "--print"),
+            print_mode=print_flag is not None,
+            print_flag=print_flag,
             streaming=has_flag(help_text, "--output-format") and "stream-json" in help_text,
             resume=has_flag(help_text, "--resume"),
             structured_result=has_flag(help_text, "--json-schema"),
@@ -63,11 +77,29 @@ class ClaudeProvider:
                 "claude --help",
                 "Upgrade Claude Code or bind the actor to scripted.",
             )
-        argv = [self.executable, "-p", "--output-format", "stream-json", "--verbose"]
+        if caps.print_flag is None:
+            raise Refusal(
+                "claude did not prove an exact print-mode flag.",
+                "Adapters emit only the exact flag observed in help output.",
+                "claude --help",
+                "Upgrade Claude Code or bind the actor to scripted.",
+                category="capability_refusal",
+            )
+        argv = [
+            self.executable,
+            caps.print_flag,
+            "--output-format",
+            "stream-json",
+            "--verbose",
+        ]
         if request.provider_session_id and caps.resume:
             argv.extend(["--resume", request.provider_session_id])
         argv.append(request.prompt)
-        return InvocationSpec(argv=argv, cwd=request.workspace)
+        return InvocationSpec(
+            argv=argv,
+            cwd=request.workspace,
+            env=allowed_environment(*self.authentication_environment),
+        )
 
     def parse_event(self, line: str) -> ProviderEvent | None:
         event = parse_json_line(line)

--- a/src/sovereign_agent/providers/claude.py
+++ b/src/sovereign_agent/providers/claude.py
@@ -58,8 +58,7 @@ class ClaudeProvider:
             resume=has_flag(help_text, "--resume"),
             structured_result=has_flag(help_text, "--json-schema"),
             workspace_write=(
-                has_flag(help_text, "--permission-mode")
-                and "acceptEdits".lower() in help_text
+                has_flag(help_text, "--permission-mode") and "acceptEdits".lower() in help_text
             ),
             verbose=has_flag(help_text, "--verbose"),
             evidence=evidence,

--- a/src/sovereign_agent/providers/claude.py
+++ b/src/sovereign_agent/providers/claude.py
@@ -57,6 +57,10 @@ class ClaudeProvider:
             streaming=has_flag(help_text, "--output-format") and "stream-json" in help_text,
             resume=has_flag(help_text, "--resume"),
             structured_result=has_flag(help_text, "--json-schema"),
+            workspace_write=(
+                has_flag(help_text, "--permission-mode")
+                and "acceptEdits".lower() in help_text
+            ),
             verbose=has_flag(help_text, "--verbose"),
             evidence=evidence,
         )
@@ -92,6 +96,8 @@ class ClaudeProvider:
             "stream-json",
             "--verbose",
         ]
+        if request.require_workspace_write:
+            argv.extend(["--permission-mode", "acceptEdits"])
         if request.provider_session_id and caps.resume:
             argv.extend(["--resume", request.provider_session_id])
         argv.append(request.prompt)

--- a/src/sovereign_agent/providers/claude.py
+++ b/src/sovereign_agent/providers/claude.py
@@ -1,0 +1,52 @@
+"""Claude Code CLI adapter. Capabilities come from live --help probes."""
+
+from __future__ import annotations
+
+from sovereign_agent.providers.base import (
+    InvocationRequest,
+    InvocationSpec,
+    ProviderCapabilities,
+    ProviderEvent,
+    capture,
+    look_up,
+    parse_json_line,
+    require_proven,
+)
+
+
+class ClaudeProvider:
+    name = "claude"
+    executable = "claude"
+
+    def probe(self) -> ProviderCapabilities:
+        if look_up(self.executable) is None:
+            return ProviderCapabilities(available=False)
+        version = capture(self.executable, "--version").strip().splitlines()
+        help_text = capture(self.executable, "--help").lower()
+        return ProviderCapabilities(
+            available=True,
+            version=version[0] if version else "",
+            streaming="--output-format" in help_text and "stream-json" in help_text,
+            resume="--resume" in help_text,
+            fork="--fork-session" in help_text,
+            structured_result="--json-schema" in help_text,
+            usage="--verbose" in help_text,
+        )
+
+    def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
+        caps = self.probe()
+        require_proven(
+            caps,
+            request,
+            missing="claude",
+            inspect="claude --help",
+            next_command="Install Claude Code or bind the actor to scripted.",
+        )
+        argv = [self.executable, "-p", "--output-format", "stream-json", "--verbose"]
+        if request.provider_session_id and caps.resume:
+            argv.extend(["--resume", request.provider_session_id])
+        argv.append(request.prompt)
+        return InvocationSpec(argv=argv, cwd=request.workspace)
+
+    def parse_event(self, line: str) -> ProviderEvent | None:
+        return parse_json_line(line)

--- a/src/sovereign_agent/providers/claude.py
+++ b/src/sovereign_agent/providers/claude.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from sovereign_agent.errors import Refusal
 from sovereign_agent.providers.base import (
     InvocationRequest,
     InvocationSpec,
     ProviderCapabilities,
     ProviderEvent,
     capture,
+    has_flag,
     look_up,
     parse_json_line,
     require_proven,
@@ -17,20 +19,32 @@ from sovereign_agent.providers.base import (
 class ClaudeProvider:
     name = "claude"
     executable = "claude"
+    requires_terminal_event = True
 
     def probe(self) -> ProviderCapabilities:
         if look_up(self.executable) is None:
             return ProviderCapabilities(available=False)
-        version = capture(self.executable, "--version").strip().splitlines()
-        help_text = capture(self.executable, "--help").lower()
+        version_probe = capture(self.executable, "--version")
+        help_probe = capture(self.executable, "--help")
+        evidence = (version_probe, help_probe)
+        failed = next((item for item in evidence if item.exit_code != 0), None)
+        if failed is not None:
+            return ProviderCapabilities(
+                available=False,
+                evidence=evidence,
+                degraded_reason=failed.error or f"{' '.join(failed.command)} exited non-zero",
+            )
+        version = version_probe.stdout.strip().splitlines()
+        help_text = help_probe.text
         return ProviderCapabilities(
             available=True,
             version=version[0] if version else "",
-            streaming="--output-format" in help_text and "stream-json" in help_text,
-            resume="--resume" in help_text,
-            fork="--fork-session" in help_text,
-            structured_result="--json-schema" in help_text,
-            usage="--verbose" in help_text,
+            print_mode=has_flag(help_text, "-p") or has_flag(help_text, "--print"),
+            streaming=has_flag(help_text, "--output-format") and "stream-json" in help_text,
+            resume=has_flag(help_text, "--resume"),
+            structured_result=has_flag(help_text, "--json-schema"),
+            verbose=has_flag(help_text, "--verbose"),
+            evidence=evidence,
         )
 
     def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
@@ -42,6 +56,13 @@ class ClaudeProvider:
             inspect="claude --help",
             next_command="Install Claude Code or bind the actor to scripted.",
         )
+        if not caps.verbose:
+            raise Refusal(
+                "claude cannot prove --verbose for stream-json.",
+                "Claude stream-json requires the exact installed CLI flags to be proven.",
+                "claude --help",
+                "Upgrade Claude Code or bind the actor to scripted.",
+            )
         argv = [self.executable, "-p", "--output-format", "stream-json", "--verbose"]
         if request.provider_session_id and caps.resume:
             argv.extend(["--resume", request.provider_session_id])
@@ -49,4 +70,30 @@ class ClaudeProvider:
         return InvocationSpec(argv=argv, cwd=request.workspace)
 
     def parse_event(self, line: str) -> ProviderEvent | None:
-        return parse_json_line(line)
+        event = parse_json_line(line)
+        if event is None or event.malformed:
+            return event
+        payload = event.payload
+        kind = str(payload.get("type") or "raw")
+        session_id = payload.get("session_id")
+        usage = payload.get("usage")
+        normalized_usage = (
+            {str(key): value for key, value in usage.items() if isinstance(value, int)}
+            if isinstance(usage, dict)
+            else {}
+        )
+        terminal = kind == "result"
+        succeeded = None
+        if terminal:
+            succeeded = payload.get("subtype") == "success" and not bool(payload.get("is_error"))
+            if not succeeded:
+                kind = "error"
+        return ProviderEvent(
+            kind=kind,
+            payload=payload,
+            raw=event.raw,
+            terminal=terminal,
+            succeeded=succeeded,
+            session_id=session_id if isinstance(session_id, str) else None,
+            usage=normalized_usage,
+        )

--- a/src/sovereign_agent/providers/codex.py
+++ b/src/sovereign_agent/providers/codex.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
+from sovereign_agent.errors import Refusal
 from sovereign_agent.providers.base import (
     InvocationRequest,
     InvocationSpec,
     ProviderCapabilities,
     ProviderEvent,
+    allowed_environment,
     capture,
     has_flag,
     look_up,
@@ -19,6 +23,7 @@ class CodexProvider:
     name = "codex"
     executable = "codex"
     requires_terminal_event = True
+    authentication_environment = ("OPENAI_API_KEY",)
 
     def probe(self) -> ProviderCapabilities:
         if look_up(self.executable) is None:
@@ -43,6 +48,8 @@ class CodexProvider:
             print_mode=True,
             streaming=has_flag(exec_help, "--json"),
             resume=resume_probe.exit_code == 0 and "resume" in resume_help,
+            resume_streaming=has_flag(resume_help, "--json"),
+            resume_sandbox=has_flag(resume_help, "--sandbox"),
             sandbox=has_flag(exec_help, "--sandbox"),
             evidence=evidence,
             degraded_reason=(
@@ -54,6 +61,28 @@ class CodexProvider:
 
     def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
         caps = self.probe()
+        if request.provider_session_id:
+            if request.require_streaming and not caps.resume_streaming:
+                raise Refusal(
+                    "codex resume cannot prove --json.",
+                    "Parent exec flags are not assumed to apply to the resume subcommand.",
+                    "codex exec resume --help",
+                    "Upgrade Codex or run a fresh assignment.",
+                    category="capability_refusal",
+                )
+            if request.require_sandbox and not caps.resume_sandbox:
+                raise Refusal(
+                    "codex resume cannot prove --sandbox.",
+                    "Writable resume requires evidence from the resume subcommand itself.",
+                    "codex exec resume --help",
+                    "Upgrade Codex or run a fresh assignment.",
+                    category="capability_refusal",
+                )
+            caps = replace(
+                caps,
+                streaming=caps.resume_streaming,
+                sandbox=caps.resume_sandbox,
+            )
         require_proven(
             caps,
             request,
@@ -67,14 +96,19 @@ class CodexProvider:
                 "exec",
                 "resume",
                 "--json",
-                request.provider_session_id,
             ]
         else:
             argv = [self.executable, "exec", "--json"]
         if request.require_sandbox:
             argv.extend(["--sandbox", "workspace-write"])
+        if request.provider_session_id:
+            argv.append(request.provider_session_id)
         argv.append(request.prompt)
-        return InvocationSpec(argv=argv, cwd=request.workspace)
+        return InvocationSpec(
+            argv=argv,
+            cwd=request.workspace,
+            env=allowed_environment(*self.authentication_environment),
+        )
 
     def parse_event(self, line: str) -> ProviderEvent | None:
         event = parse_json_line(line)

--- a/src/sovereign_agent/providers/codex.py
+++ b/src/sovereign_agent/providers/codex.py
@@ -1,0 +1,55 @@
+"""Codex CLI adapter. Capabilities come from live --help probes."""
+
+from __future__ import annotations
+
+from sovereign_agent.providers.base import (
+    InvocationRequest,
+    InvocationSpec,
+    ProviderCapabilities,
+    ProviderEvent,
+    capture,
+    look_up,
+    parse_json_line,
+    require_proven,
+)
+
+
+class CodexProvider:
+    name = "codex"
+    executable = "codex"
+
+    def probe(self) -> ProviderCapabilities:
+        if look_up(self.executable) is None:
+            return ProviderCapabilities(available=False)
+        version = capture(self.executable, "--version").strip().splitlines()
+        help_text = capture(self.executable, "--help").lower()
+        exec_help = capture(self.executable, "exec", "--help").lower()
+        text = f"{help_text}\n{exec_help}"
+        return ProviderCapabilities(
+            available=True,
+            version=version[0] if version else "",
+            streaming="--json" in text,
+            resume="--resume" in text,
+            sandbox="--sandbox" in text,
+            usage="--json" in text,
+        )
+
+    def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
+        caps = self.probe()
+        require_proven(
+            caps,
+            request,
+            missing="codex",
+            inspect="codex exec --help",
+            next_command="Install Codex CLI or bind the actor to scripted.",
+        )
+        argv = [self.executable, "exec", "--json"]
+        if caps.sandbox:
+            argv.extend(["--sandbox", "workspace-write"])
+        if request.provider_session_id and caps.resume:
+            argv.extend(["--resume", request.provider_session_id])
+        argv.append(request.prompt)
+        return InvocationSpec(argv=argv, cwd=request.workspace)
+
+    def parse_event(self, line: str) -> ProviderEvent | None:
+        return parse_json_line(line)

--- a/src/sovereign_agent/providers/codex.py
+++ b/src/sovereign_agent/providers/codex.py
@@ -8,6 +8,7 @@ from sovereign_agent.providers.base import (
     ProviderCapabilities,
     ProviderEvent,
     capture,
+    has_flag,
     look_up,
     parse_json_line,
     require_proven,
@@ -17,21 +18,38 @@ from sovereign_agent.providers.base import (
 class CodexProvider:
     name = "codex"
     executable = "codex"
+    requires_terminal_event = True
 
     def probe(self) -> ProviderCapabilities:
         if look_up(self.executable) is None:
             return ProviderCapabilities(available=False)
-        version = capture(self.executable, "--version").strip().splitlines()
-        help_text = capture(self.executable, "--help").lower()
-        exec_help = capture(self.executable, "exec", "--help").lower()
-        text = f"{help_text}\n{exec_help}"
+        version_probe = capture(self.executable, "--version")
+        exec_probe = capture(self.executable, "exec", "--help")
+        resume_probe = capture(self.executable, "exec", "resume", "--help")
+        evidence = (version_probe, exec_probe, resume_probe)
+        failed = next((item for item in evidence[:2] if item.exit_code != 0), None)
+        if failed is not None:
+            return ProviderCapabilities(
+                available=False,
+                evidence=evidence,
+                degraded_reason=failed.error or f"{' '.join(failed.command)} exited non-zero",
+            )
+        version = version_probe.stdout.strip().splitlines()
+        exec_help = exec_probe.text
+        resume_help = resume_probe.text
         return ProviderCapabilities(
             available=True,
             version=version[0] if version else "",
-            streaming="--json" in text,
-            resume="--resume" in text,
-            sandbox="--sandbox" in text,
-            usage="--json" in text,
+            print_mode=True,
+            streaming=has_flag(exec_help, "--json"),
+            resume=resume_probe.exit_code == 0 and "resume" in resume_help,
+            sandbox=has_flag(exec_help, "--sandbox"),
+            evidence=evidence,
+            degraded_reason=(
+                resume_probe.error or "codex exec resume --help exited non-zero"
+                if resume_probe.exit_code != 0
+                else None
+            ),
         )
 
     def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
@@ -43,13 +61,44 @@ class CodexProvider:
             inspect="codex exec --help",
             next_command="Install Codex CLI or bind the actor to scripted.",
         )
-        argv = [self.executable, "exec", "--json"]
-        if caps.sandbox:
+        if request.provider_session_id:
+            argv = [
+                self.executable,
+                "exec",
+                "resume",
+                "--json",
+                request.provider_session_id,
+            ]
+        else:
+            argv = [self.executable, "exec", "--json"]
+        if request.require_sandbox:
             argv.extend(["--sandbox", "workspace-write"])
-        if request.provider_session_id and caps.resume:
-            argv.extend(["--resume", request.provider_session_id])
         argv.append(request.prompt)
         return InvocationSpec(argv=argv, cwd=request.workspace)
 
     def parse_event(self, line: str) -> ProviderEvent | None:
-        return parse_json_line(line)
+        event = parse_json_line(line)
+        if event is None or event.malformed:
+            return event
+        payload = event.payload
+        kind = str(payload.get("type") or "raw")
+        thread_id = payload.get("thread_id")
+        usage = payload.get("usage")
+        normalized_usage = (
+            {str(key): value for key, value in usage.items() if isinstance(value, int)}
+            if isinstance(usage, dict)
+            else {}
+        )
+        terminal = kind in {"turn.completed", "turn.failed"}
+        succeeded = kind == "turn.completed" if terminal else None
+        if kind in {"turn.failed", "error"}:
+            kind = "error"
+        return ProviderEvent(
+            kind=kind,
+            payload=payload,
+            raw=event.raw,
+            terminal=terminal,
+            succeeded=succeeded,
+            session_id=thread_id if isinstance(thread_id, str) else None,
+            usage=normalized_usage,
+        )

--- a/src/sovereign_agent/providers/codex.py
+++ b/src/sovereign_agent/providers/codex.py
@@ -23,7 +23,7 @@ class CodexProvider:
     name = "codex"
     executable = "codex"
     requires_terminal_event = True
-    authentication_environment = ("OPENAI_API_KEY",)
+    authentication_environment = ("CODEX_API_KEY",)
 
     def probe(self) -> ProviderCapabilities:
         if look_up(self.executable) is None:
@@ -51,6 +51,7 @@ class CodexProvider:
             resume_streaming=has_flag(resume_help, "--json"),
             resume_sandbox=has_flag(resume_help, "--sandbox"),
             sandbox=has_flag(exec_help, "--sandbox"),
+            workspace_write=has_flag(exec_help, "--sandbox"),
             evidence=evidence,
             degraded_reason=(
                 resume_probe.error or "codex exec resume --help exited non-zero"
@@ -82,6 +83,7 @@ class CodexProvider:
                 caps,
                 streaming=caps.resume_streaming,
                 sandbox=caps.resume_sandbox,
+                workspace_write=caps.resume_sandbox,
             )
         require_proven(
             caps,

--- a/src/sovereign_agent/providers/cursor.py
+++ b/src/sovereign_agent/providers/cursor.py
@@ -8,6 +8,7 @@ from sovereign_agent.providers.base import (
     ProviderCapabilities,
     ProviderEvent,
     capture,
+    has_flag,
     look_up,
     parse_json_line,
     require_proven,
@@ -17,18 +18,32 @@ from sovereign_agent.providers.base import (
 class CursorProvider:
     name = "cursor"
     executable = "agent"
+    requires_terminal_event = True
 
     def probe(self) -> ProviderCapabilities:
         if look_up(self.executable) is None:
             return ProviderCapabilities(available=False)
-        version = capture(self.executable, "--version").strip().splitlines()
-        help_text = capture(self.executable, "--help").lower()
+        version_probe = capture(self.executable, "--version")
+        help_probe = capture(self.executable, "--help")
+        evidence = (version_probe, help_probe)
+        failed = next((item for item in evidence if item.exit_code != 0), None)
+        if failed is not None:
+            return ProviderCapabilities(
+                available=False,
+                evidence=evidence,
+                degraded_reason=failed.error or f"{' '.join(failed.command)} exited non-zero",
+            )
+        version = version_probe.stdout.strip().splitlines()
+        help_text = help_probe.text
         return ProviderCapabilities(
             available=True,
             version=version[0] if version else "",
-            streaming="--output-format" in help_text and "stream-json" in help_text,
-            resume="--resume" in help_text,
-            sandbox="--workspace" in help_text,
+            print_mode=has_flag(help_text, "-p") or has_flag(help_text, "--print"),
+            streaming=has_flag(help_text, "--output-format") and "stream-json" in help_text,
+            resume=has_flag(help_text, "--resume"),
+            workspace_selection=has_flag(help_text, "--workspace"),
+            sandbox=False,
+            evidence=evidence,
         )
 
     def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
@@ -40,18 +55,39 @@ class CursorProvider:
             inspect="agent --help",
             next_command="Install Cursor Agent CLI or bind the actor to scripted.",
         )
-        argv = [
-            self.executable,
-            "-p",
-            "--output-format",
-            "stream-json",
-            "--workspace",
-            str(request.workspace),
-        ]
+        argv = [self.executable, "-p", "--output-format", "stream-json"]
+        if caps.workspace_selection:
+            argv.extend(["--workspace", str(request.workspace)])
         if request.provider_session_id and caps.resume:
             argv.extend(["--resume", request.provider_session_id])
         argv.append(request.prompt)
         return InvocationSpec(argv=argv, cwd=request.workspace)
 
     def parse_event(self, line: str) -> ProviderEvent | None:
-        return parse_json_line(line)
+        event = parse_json_line(line)
+        if event is None or event.malformed:
+            return event
+        payload = event.payload
+        kind = str(payload.get("type") or "raw")
+        session_id = payload.get("session_id")
+        usage = payload.get("usage")
+        normalized_usage = (
+            {str(key): value for key, value in usage.items() if isinstance(value, int)}
+            if isinstance(usage, dict)
+            else {}
+        )
+        terminal = kind == "result"
+        succeeded = None
+        if terminal:
+            succeeded = payload.get("subtype") == "success" and not bool(payload.get("is_error"))
+            if not succeeded:
+                kind = "error"
+        return ProviderEvent(
+            kind=kind,
+            payload=payload,
+            raw=event.raw,
+            terminal=terminal,
+            succeeded=succeeded,
+            session_id=session_id if isinstance(session_id, str) else None,
+            usage=normalized_usage,
+        )

--- a/src/sovereign_agent/providers/cursor.py
+++ b/src/sovereign_agent/providers/cursor.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from sovereign_agent.errors import Refusal
 from sovereign_agent.providers.base import (
     InvocationRequest,
     InvocationSpec,
     ProviderCapabilities,
     ProviderEvent,
+    allowed_environment,
     capture,
     has_flag,
     look_up,
@@ -19,6 +21,7 @@ class CursorProvider:
     name = "cursor"
     executable = "agent"
     requires_terminal_event = True
+    authentication_environment = ("CURSOR_API_KEY",)
 
     def probe(self) -> ProviderCapabilities:
         if look_up(self.executable) is None:
@@ -35,10 +38,18 @@ class CursorProvider:
             )
         version = version_probe.stdout.strip().splitlines()
         help_text = help_probe.text
+        print_flag = (
+            "-p"
+            if has_flag(help_text, "-p")
+            else "--print"
+            if has_flag(help_text, "--print")
+            else None
+        )
         return ProviderCapabilities(
             available=True,
             version=version[0] if version else "",
-            print_mode=has_flag(help_text, "-p") or has_flag(help_text, "--print"),
+            print_mode=print_flag is not None,
+            print_flag=print_flag,
             streaming=has_flag(help_text, "--output-format") and "stream-json" in help_text,
             resume=has_flag(help_text, "--resume"),
             workspace_selection=has_flag(help_text, "--workspace"),
@@ -55,13 +66,25 @@ class CursorProvider:
             inspect="agent --help",
             next_command="Install Cursor Agent CLI or bind the actor to scripted.",
         )
-        argv = [self.executable, "-p", "--output-format", "stream-json"]
+        if caps.print_flag is None:
+            raise Refusal(
+                "Cursor CLI did not prove an exact print-mode flag.",
+                "Adapters emit only the exact flag observed in help output.",
+                "agent --help",
+                "Upgrade Cursor CLI or bind the actor to scripted.",
+                category="capability_refusal",
+            )
+        argv = [self.executable, caps.print_flag, "--output-format", "stream-json"]
         if caps.workspace_selection:
             argv.extend(["--workspace", str(request.workspace)])
         if request.provider_session_id and caps.resume:
             argv.extend(["--resume", request.provider_session_id])
         argv.append(request.prompt)
-        return InvocationSpec(argv=argv, cwd=request.workspace)
+        return InvocationSpec(
+            argv=argv,
+            cwd=request.workspace,
+            env=allowed_environment(*self.authentication_environment),
+        )
 
     def parse_event(self, line: str) -> ProviderEvent | None:
         event = parse_json_line(line)

--- a/src/sovereign_agent/providers/cursor.py
+++ b/src/sovereign_agent/providers/cursor.py
@@ -53,6 +53,7 @@ class CursorProvider:
             streaming=has_flag(help_text, "--output-format") and "stream-json" in help_text,
             resume=has_flag(help_text, "--resume"),
             workspace_selection=has_flag(help_text, "--workspace"),
+            workspace_write=has_flag(help_text, "--force"),
             sandbox=False,
             evidence=evidence,
         )
@@ -75,6 +76,8 @@ class CursorProvider:
                 category="capability_refusal",
             )
         argv = [self.executable, caps.print_flag, "--output-format", "stream-json"]
+        if request.require_workspace_write:
+            argv.append("--force")
         if caps.workspace_selection:
             argv.extend(["--workspace", str(request.workspace)])
         if request.provider_session_id and caps.resume:

--- a/src/sovereign_agent/providers/cursor.py
+++ b/src/sovereign_agent/providers/cursor.py
@@ -1,0 +1,57 @@
+"""Cursor Agent CLI adapter. Equal in the registry, not a documentation bridge."""
+
+from __future__ import annotations
+
+from sovereign_agent.providers.base import (
+    InvocationRequest,
+    InvocationSpec,
+    ProviderCapabilities,
+    ProviderEvent,
+    capture,
+    look_up,
+    parse_json_line,
+    require_proven,
+)
+
+
+class CursorProvider:
+    name = "cursor"
+    executable = "agent"
+
+    def probe(self) -> ProviderCapabilities:
+        if look_up(self.executable) is None:
+            return ProviderCapabilities(available=False)
+        version = capture(self.executable, "--version").strip().splitlines()
+        help_text = capture(self.executable, "--help").lower()
+        return ProviderCapabilities(
+            available=True,
+            version=version[0] if version else "",
+            streaming="--output-format" in help_text and "stream-json" in help_text,
+            resume="--resume" in help_text,
+            sandbox="--workspace" in help_text,
+        )
+
+    def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
+        caps = self.probe()
+        require_proven(
+            caps,
+            request,
+            missing="agent (Cursor CLI)",
+            inspect="agent --help",
+            next_command="Install Cursor Agent CLI or bind the actor to scripted.",
+        )
+        argv = [
+            self.executable,
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--workspace",
+            str(request.workspace),
+        ]
+        if request.provider_session_id and caps.resume:
+            argv.extend(["--resume", request.provider_session_id])
+        argv.append(request.prompt)
+        return InvocationSpec(argv=argv, cwd=request.workspace)
+
+    def parse_event(self, line: str) -> ProviderEvent | None:
+        return parse_json_line(line)

--- a/src/sovereign_agent/providers/scripted.py
+++ b/src/sovereign_agent/providers/scripted.py
@@ -1,55 +1,40 @@
-"""Provider protocol and scripted adapter for offline lessons."""
+"""Deterministic fixture runner. No network."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
 
 from sovereign_agent.models import ActorReport
-
-
-@dataclass(frozen=True)
-class ProviderCapabilities:
-    available: bool
-    streaming: bool = False
-    resume: bool = False
-
-
-@dataclass(frozen=True)
-class InvocationSpec:
-    argv: list[str]
-    cwd: Path
-    env: dict[str, str] = field(default_factory=dict)
-
-
-class IntelligenceProvider(Protocol):
-    name: str
-
-    def probe(self) -> ProviderCapabilities: ...
-
-    def build_invocation(self, workspace: Path, output: Path, prompt: str) -> InvocationSpec: ...
+from sovereign_agent.providers.base import (
+    InvocationRequest,
+    InvocationSpec,
+    ProviderCapabilities,
+    ProviderEvent,
+    parse_json_line,
+)
 
 
 class ScriptedProvider:
-    """Deterministic fixture runner. No network. Invoked through subprocess argv."""
-
     name = "scripted"
+    executable = "python"
 
     def probe(self) -> ProviderCapabilities:
-        return ProviderCapabilities(available=True)
+        return ProviderCapabilities(available=True, streaming=True, structured_result=True)
 
-    def build_invocation(self, workspace: Path, output: Path, prompt: str) -> InvocationSpec:
+    def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
         return InvocationSpec(
             argv=[
                 "python",
                 "-m",
                 "sovereign_agent.providers.scripted",
-                str(output),
-                prompt,
+                str(request.output),
+                request.prompt,
             ],
-            cwd=workspace,
+            cwd=request.workspace,
         )
+
+    def parse_event(self, line: str) -> ProviderEvent | None:
+        return parse_json_line(line)
 
 
 def write_scripted_report(output: Path, prompt: str) -> ActorReport:

--- a/src/sovereign_agent/providers/scripted.py
+++ b/src/sovereign_agent/providers/scripted.py
@@ -51,7 +51,7 @@ def write_scripted_report(output: Path, prompt: str) -> ActorReport:
     try:
         envelope = json.loads(prompt)
         scope = str(envelope["statement_of_work"]["scope"])
-    except (json.JSONDecodeError, KeyError, TypeError):
+    except json.JSONDecodeError, KeyError, TypeError:
         scope = prompt
     report = ActorReport(
         status="completed" if "fail" not in scope.lower() else "failed",

--- a/src/sovereign_agent/providers/scripted.py
+++ b/src/sovereign_agent/providers/scripted.py
@@ -26,6 +26,7 @@ class ScriptedProvider:
             print_mode=True,
             streaming=True,
             structured_result=True,
+            workspace_write=True,
         )
 
     def build_invocation(self, request: InvocationRequest) -> InvocationSpec:

--- a/src/sovereign_agent/providers/scripted.py
+++ b/src/sovereign_agent/providers/scripted.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from sovereign_agent.models import ActorReport
@@ -17,9 +18,15 @@ from sovereign_agent.providers.base import (
 class ScriptedProvider:
     name = "scripted"
     executable = "python"
+    requires_terminal_event = False
 
     def probe(self) -> ProviderCapabilities:
-        return ProviderCapabilities(available=True, streaming=True, structured_result=True)
+        return ProviderCapabilities(
+            available=True,
+            print_mode=True,
+            streaming=True,
+            structured_result=True,
+        )
 
     def build_invocation(self, request: InvocationRequest) -> InvocationSpec:
         return InvocationSpec(
@@ -40,8 +47,13 @@ class ScriptedProvider:
 def write_scripted_report(output: Path, prompt: str) -> ActorReport:
     output.mkdir(parents=True, exist_ok=True)
     (output / "messages").mkdir(exist_ok=True)
+    try:
+        envelope = json.loads(prompt)
+        scope = str(envelope["statement_of_work"]["scope"])
+    except (json.JSONDecodeError, KeyError, TypeError):
+        scope = prompt
     report = ActorReport(
-        status="completed" if "fail" not in prompt.lower() else "failed",
+        status="completed" if "fail" not in scope.lower() else "failed",
         changed_artifacts=["inventory.md"],
         proposed_checks=["inventory_non_negative", "cash_reconciles"],
         questions=[],

--- a/tests/fixtures/providers/README.md
+++ b/tests/fixtures/providers/README.md
@@ -1,0 +1,26 @@
+# Provider fixture provenance
+
+These redacted JSONL fixtures reproduce the documented non-interactive stream
+shapes used by Unit 6. They contain no prompts, credentials, repository data,
+or provider-generated proprietary content.
+
+- `codex.exec-json.jsonl` follows OpenAI's Codex non-interactive JSONL example,
+  retrieved 2026-08-25. No Codex executable was installed on the capture host.
+  It includes `thread.started`, `turn.started`, `item.completed`, an unknown
+  valid event, and `turn.completed` with usage.
+- `claude.stream-json.jsonl` follows Claude Code 2.1.220 print-mode
+  `stream-json` output. Provenance: a redacted local protocol capture plus the
+  documented success terminal shape; volatile model, paths, ids, and message
+  text are replaced.
+- `cursor.stream-json.jsonl` follows Cursor Agent CLI `stream-json` output.
+  Provenance: Cursor's official output-format schema retrieved 2026-08-25; no
+  Cursor executable was installed on the capture host. Volatile model, paths,
+  ids, and message text are replaced.
+- `protocol-cases.json` records provider-neutral error cases used by the fake
+  executable integration suite: provider error, non-zero exit, malformed
+  stream, truncated stream, unknown valid event, and resume.
+
+Probe tests record the installed executable's version, command, exit status,
+stdout, stderr, and error. Golden fixtures intentionally do not claim that a
+future CLI version has the same protocol; opt-in live assignment smokes detect
+that drift.

--- a/tests/fixtures/providers/claude.stream-json.jsonl
+++ b/tests/fixtures/providers/claude.stream-json.jsonl
@@ -1,3 +1,3 @@
-{"type":"system","subtype":"init","session_id":"ses_offline"}
-{"type":"assistant","message":{"content":[{"type":"text","text":"replenish tea"}]}}
-{"type":"result","subtype":"success","result":"done"}
+{"type":"system","subtype":"init","cwd":"/redacted/workspace","session_id":"ses_offline","tools":["Read","Write"],"model":"redacted","permissionMode":"default","claude_code_version":"2.1.220"}
+{"type":"assistant","session_id":"ses_offline","message":{"role":"assistant","content":[{"type":"text","text":"replenish tea"}]}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":10,"num_turns":1,"result":"done","session_id":"ses_offline","usage":{"input_tokens":12,"output_tokens":4}}

--- a/tests/fixtures/providers/claude.stream-json.jsonl
+++ b/tests/fixtures/providers/claude.stream-json.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"ses_offline"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"replenish tea"}]}}
+{"type":"result","subtype":"success","result":"done"}

--- a/tests/fixtures/providers/codex.exec-json.jsonl
+++ b/tests/fixtures/providers/codex.exec-json.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"thread_offline"}
+{"type":"item.completed","item":{"type":"agent_message","text":"replenish tea"}}
+not valid json
+{"kind":"usage","input_tokens":12}

--- a/tests/fixtures/providers/codex.exec-json.jsonl
+++ b/tests/fixtures/providers/codex.exec-json.jsonl
@@ -1,4 +1,5 @@
 {"type":"thread.started","thread_id":"thread_offline"}
-{"type":"item.completed","item":{"type":"agent_message","text":"replenish tea"}}
-not valid json
-{"kind":"usage","input_tokens":12}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"replenish tea"}}
+{"type":"future.event","redacted":true}
+{"type":"turn.completed","usage":{"input_tokens":12,"cached_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":0}}

--- a/tests/fixtures/providers/cursor.stream-json.jsonl
+++ b/tests/fixtures/providers/cursor.stream-json.jsonl
@@ -1,3 +1,3 @@
-{"type":"system","subtype":"init","session_id":"cursor_offline"}
-{"type":"assistant","message":{"content":[{"type":"text","text":"replenish tea"}]}}
-{"type":"result","subtype":"success","result":"done"}
+{"type":"system","subtype":"init","cwd":"/redacted/workspace","session_id":"cursor_offline","model":"redacted","permission_mode":"default"}
+{"type":"assistant","session_id":"cursor_offline","message":{"role":"assistant","content":[{"type":"text","text":"replenish tea"}]}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":10,"num_turns":1,"result":"done","session_id":"cursor_offline","usage":{"input_tokens":10,"output_tokens":3}}

--- a/tests/fixtures/providers/cursor.stream-json.jsonl
+++ b/tests/fixtures/providers/cursor.stream-json.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"cursor_offline"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"replenish tea"}]}}
+{"type":"result","subtype":"success","result":"done"}

--- a/tests/fixtures/providers/protocol-cases.json
+++ b/tests/fixtures/providers/protocol-cases.json
@@ -1,0 +1,9 @@
+{
+  "malformed_stream": ["{\"type\":\"thread.started\",\"thread_id\":\"thread_1\"}", "not json"],
+  "missing_session": [{"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}}],
+  "nonzero_exit": 7,
+  "provider_error": [{"type": "turn.failed", "error": {"message": "redacted"}}],
+  "resume_session": "thread_resume",
+  "truncated_stream": [{"type": "thread.started", "thread_id": "thread_1"}],
+  "unknown_valid_event": [{"type": "future.event", "redacted": true}]
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,8 @@ def test_doctor_accepts_supported_environment(capsys) -> None:
     output = capsys.readouterr().out
     assert "Python:" in output
     assert "Pydantic:" in output
+    assert "Providers:" in output
+    assert "scripted" in output
     assert "Ready for the offline curriculum." in output
 
 

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -29,7 +29,13 @@ if name == "codex" and args == ["exec", "resume", "--help"]:
     print("Usage: codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]\n  --json\n  --sandbox")
     raise SystemExit(0)
 if args == ["--help"]:
-    print("-p --print --output-format stream-json --verbose --resume --workspace")
+    if name == "claude":
+        print(
+            "-p --print --output-format stream-json --verbose --resume "
+            "--permission-mode [default|acceptEdits]"
+        )
+    else:
+        print("-p --print --output-format stream-json --resume --workspace --force")
     raise SystemExit(0)
 
 envelope = json.loads(args[-1])
@@ -40,6 +46,14 @@ if name == "codex":
     if sandbox < 0 or args[sandbox + 1] != "workspace-write":
         print(json.dumps({"type": "turn.failed", "error": {"message": "read-only sandbox"}}))
         raise SystemExit(9)
+elif name == "claude":
+    permission = args.index("--permission-mode") if "--permission-mode" in args else -1
+    if permission < 0 or args[permission + 1] != "acceptEdits":
+        print(json.dumps({"type": "result", "subtype": "error", "is_error": True}))
+        raise SystemExit(9)
+elif "--force" not in args:
+    print(json.dumps({"type": "result", "subtype": "error", "is_error": True}))
+    raise SystemExit(9)
 output.mkdir(parents=True, exist_ok=True)
 (workspace / "observed-envelope.json").write_text(json.dumps(envelope, sort_keys=True))
 (workspace / "observed-argv.json").write_text(json.dumps(args[:-1]))
@@ -146,6 +160,10 @@ def test_fake_provider_reaches_review_with_truthful_receipt(
     observed_argv = json.loads((workspace / "observed-argv.json").read_text())
     if provider == "codex":
         assert observed_argv == ["exec", "--json", "--sandbox", "workspace-write"]
+    elif provider == "claude":
+        assert observed_argv[-2:] == ["--permission-mode", "acceptEdits"]
+    else:
+        assert "--force" in observed_argv
 
     receipt_text = (workspace / "receipt.json").read_text(encoding="utf-8")
     row = org.db.connection.execute("SELECT record FROM receipts").fetchone()

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from sovereign_agent.models import AssignmentState, Role, SowState
+from sovereign_agent.organization import Organization
+
+FAKE_CLI = r"""#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+name = Path(sys.argv[0]).name
+args = sys.argv[1:]
+if args == ["--version"]:
+    print(f"{name} 1.0.0-test")
+    raise SystemExit(0)
+if name == "codex" and args == ["exec", "--help"]:
+    print("Usage: codex exec [OPTIONS] [PROMPT]\n  --json\n  --sandbox")
+    raise SystemExit(0)
+if name == "codex" and args == ["exec", "resume", "--help"]:
+    print("Usage: codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]\n  --json")
+    raise SystemExit(0)
+if args == ["--help"]:
+    print("-p --print --output-format stream-json --verbose --resume --workspace")
+    raise SystemExit(0)
+
+envelope = json.loads(args[-1])
+workspace = Path(envelope["workspace"]["root"])
+output = Path(envelope["output"]["directory"])
+output.mkdir(parents=True, exist_ok=True)
+(workspace / "observed-envelope.json").write_text(json.dumps(envelope, sort_keys=True))
+(output / "messages").mkdir(exist_ok=True)
+(output / "report.json").write_text(json.dumps({
+    "schema_version": 1,
+    "status": "completed",
+    "changed_artifacts": [],
+    "proposed_checks": ["fixture_check"],
+    "questions": [],
+    "notes": "fake provider completed the governed envelope"
+}))
+
+scope = envelope["statement_of_work"]["scope"]
+scenario = scope.removeprefix("scenario:") if scope.startswith("scenario:") else "success"
+if name == "codex":
+    if scenario != "no_session":
+        print(json.dumps({"type": "thread.started", "thread_id": "thread_fake"}))
+    if scenario == "malformed":
+        print("not json")
+    if scenario == "unknown":
+        print(json.dumps({"type": "future.event", "redacted": True}))
+    if scenario == "provider_error":
+        print(json.dumps({"type": "turn.failed", "error": {"message": "redacted"}}))
+    elif scenario != "truncated":
+        print(json.dumps({"type": "turn.completed", "usage": {
+            "input_tokens": 10, "cached_input_tokens": 0, "output_tokens": 2,
+            "reasoning_output_tokens": 0
+        }}))
+else:
+    system = {"type": "system", "subtype": "init"}
+    if scenario != "no_session":
+        system["session_id"] = f"{name}_fake"
+    print(json.dumps(system))
+    if scenario == "malformed":
+        print("not json")
+    if scenario == "unknown":
+        print(json.dumps({"type": "future.event", "redacted": True}))
+    if scenario == "provider_error":
+        print(json.dumps({
+            "type": "result", "subtype": "error", "is_error": True,
+            "session_id": f"{name}_fake"
+        }))
+    elif scenario != "truncated":
+        print(json.dumps({
+            "type": "result", "subtype": "success", "is_error": False,
+            **({} if scenario == "no_session" else {"session_id": f"{name}_fake"}),
+            "usage": {"input_tokens": 10, "output_tokens": 2}
+        }))
+raise SystemExit(7 if scenario == "nonzero" else 0)
+"""
+
+
+def _install_fake_clis(path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path.mkdir()
+    for executable in ("claude", "codex", "agent"):
+        target = path / executable
+        target.write_text(FAKE_CLI, encoding="utf-8")
+        target.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{path}{os.pathsep}{os.environ['PATH']}")
+
+
+def _assignment(
+    root: Path, provider: str, scenario: str = "success"
+) -> tuple[Organization, str, str]:
+    org = Organization.init(root)
+    org.actors["operator-course"].provider = provider
+    outcome = org.create_outcome("fixture", "report exists", ["receipt valid"], "principal-human")
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(
+        outcome.id,
+        (
+            "Inspect the workspace and write the required report."
+            if scenario == "success"
+            else f"scenario:{scenario}"
+        ),
+        Role.OPERATOR,
+        "master-course",
+    )
+    org.ready_sow(sow.id)
+    assignment = org.assign(sow.id, "operator-course", "master-course")
+    return org, sow.id, assignment.id
+
+
+@pytest.mark.parametrize("provider", ["claude", "codex", "cursor"])
+def test_fake_provider_reaches_review_with_truthful_receipt(
+    provider: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_clis(tmp_path / "bin", monkeypatch)
+    org, sow_id, assignment_id = _assignment(tmp_path / "org", provider)
+    assignment = org.run_assignment(assignment_id)
+
+    assert assignment.state == AssignmentState.COMPLETED
+    assert org._sow(sow_id).state == SowState.REVIEW  # noqa: SLF001
+    workspace = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    envelope = json.loads((workspace / "observed-envelope.json").read_text())
+    assert envelope["actor"]["id"] == "operator-course"
+    assert envelope["actor"]["authority"] == org.actors["operator-course"].authority
+    assert envelope["statement_of_work"]["id"] == sow_id
+    assert envelope["output"]["report"].endswith(".sovereign-out/report.json")
+    assert envelope["report_contract"]["schema"]["title"] == "ActorReport"
+
+    receipt_text = (workspace / "receipt.json").read_text(encoding="utf-8")
+    row = org.db.connection.execute("SELECT record FROM receipts").fetchone()
+    assert row is not None and row["record"] == receipt_text
+    receipt = json.loads(receipt_text)
+    assert receipt["actor_id"] == "operator-course"
+    assert receipt["provider"] == provider
+    assert receipt["provider_session_ref"]
+    assert receipt["status"] == "completed"
+    digest = hashlib.sha256(receipt_text.encode()).hexdigest()
+    assert (workspace / "receipt.json.sha256").read_text().strip() == digest
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected"),
+    [
+        ("malformed", AssignmentState.FAILED),
+        ("truncated", AssignmentState.FAILED),
+        ("provider_error", AssignmentState.FAILED),
+        ("nonzero", AssignmentState.FAILED),
+        ("no_session", AssignmentState.FAILED),
+        ("unknown", AssignmentState.COMPLETED),
+    ],
+)
+@pytest.mark.parametrize("provider", ["claude", "codex", "cursor"])
+def test_protocol_failures_never_guess_success(
+    provider: str,
+    scenario: str,
+    expected: AssignmentState,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_clis(tmp_path / "bin", monkeypatch)
+    org, _, assignment_id = _assignment(tmp_path / "org", provider, scenario)
+    assignment = org.run_assignment(assignment_id)
+    assert assignment.state == expected

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from sovereign_agent.errors import Refusal
 from sovereign_agent.models import AssignmentState, Role, SowState
 from sovereign_agent.organization import Organization
 
@@ -25,7 +26,7 @@ if name == "codex" and args == ["exec", "--help"]:
     print("Usage: codex exec [OPTIONS] [PROMPT]\n  --json\n  --sandbox")
     raise SystemExit(0)
 if name == "codex" and args == ["exec", "resume", "--help"]:
-    print("Usage: codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]\n  --json")
+    print("Usage: codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]\n  --json\n  --sandbox")
     raise SystemExit(0)
 if args == ["--help"]:
     print("-p --print --output-format stream-json --verbose --resume --workspace")
@@ -34,8 +35,14 @@ if args == ["--help"]:
 envelope = json.loads(args[-1])
 workspace = Path(envelope["workspace"]["root"])
 output = Path(envelope["output"]["directory"])
+if name == "codex":
+    sandbox = args.index("--sandbox") if "--sandbox" in args else -1
+    if sandbox < 0 or args[sandbox + 1] != "workspace-write":
+        print(json.dumps({"type": "turn.failed", "error": {"message": "read-only sandbox"}}))
+        raise SystemExit(9)
 output.mkdir(parents=True, exist_ok=True)
 (workspace / "observed-envelope.json").write_text(json.dumps(envelope, sort_keys=True))
+(workspace / "observed-argv.json").write_text(json.dumps(args[:-1]))
 (output / "messages").mkdir(exist_ok=True)
 (output / "report.json").write_text(json.dumps({
     "schema_version": 1,
@@ -136,6 +143,9 @@ def test_fake_provider_reaches_review_with_truthful_receipt(
     assert envelope["statement_of_work"]["id"] == sow_id
     assert envelope["output"]["report"].endswith(".sovereign-out/report.json")
     assert envelope["report_contract"]["schema"]["title"] == "ActorReport"
+    observed_argv = json.loads((workspace / "observed-argv.json").read_text())
+    if provider == "codex":
+        assert observed_argv == ["exec", "--json", "--sandbox", "workspace-write"]
 
     receipt_text = (workspace / "receipt.json").read_text(encoding="utf-8")
     row = org.db.connection.execute("SELECT record FROM receipts").fetchone()
@@ -172,3 +182,48 @@ def test_protocol_failures_never_guess_success(
     org, _, assignment_id = _assignment(tmp_path / "org", provider, scenario)
     assignment = org.run_assignment(assignment_id)
     assert assignment.state == expected
+    if expected == AssignmentState.FAILED:
+        row = org.db.connection.execute("SELECT record FROM receipts").fetchone()
+        assert row is not None
+        assert json.loads(row["record"])["failure_category"]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        Refusal(
+            "Provider timed out.",
+            "The fixture simulated a timeout.",
+            "provider-raw",
+            "Retry.",
+            category="timeout",
+        ),
+        ValueError("programmer defect"),
+    ],
+)
+def test_escaped_failures_are_durable(
+    error: Exception,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_clis(tmp_path / "bin", monkeypatch)
+    org, sow_id, assignment_id = _assignment(tmp_path / "org", "claude")
+    created = org._assignment(assignment_id)  # noqa: SLF001
+
+    def fail(*args: object, **kwargs: object) -> object:
+        raise error
+
+    monkeypatch.setattr("sovereign_agent.organization.invoke_actor", fail)
+    with pytest.raises(type(error)):
+        org.run_assignment(assignment_id)
+
+    assert org._assignment(assignment_id).state == AssignmentState.FAILED  # noqa: SLF001
+    assert org._sow(sow_id).state == SowState.FAILED  # noqa: SLF001
+    workspace = org.root / ".sovereign" / "runs" / created.workspace_id
+    receipt_text = (workspace / "receipt.json").read_text(encoding="utf-8")
+    row = org.db.connection.execute("SELECT record FROM receipts").fetchone()
+    assert row is not None and row["record"] == receipt_text
+    receipt = json.loads(receipt_text)
+    assert receipt["status"] == "failed"
+    expected = "timeout" if isinstance(error, Refusal) else "internal_error"
+    assert receipt["failure_category"] == expected

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sovereign_agent.errors import Refusal
+from sovereign_agent.providers import PROVIDERS, get_provider
+from sovereign_agent.providers.base import InvocationRequest, ProviderCapabilities
+from sovereign_agent.providers.claude import ClaudeProvider
+from sovereign_agent.providers.codex import CodexProvider
+from sovereign_agent.providers.cursor import CursorProvider
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "providers"
+
+
+def _request(tmp_path: Path) -> InvocationRequest:
+    return InvocationRequest(
+        workspace=tmp_path,
+        output=tmp_path / "out",
+        prompt="replenish tea",
+    )
+
+
+def test_registry_names_are_equal_adapters() -> None:
+    assert list(PROVIDERS) == ["scripted", "claude", "codex", "cursor"]
+    with pytest.raises(Refusal, match="Unknown provider"):
+        get_provider("sonnet")
+
+
+def test_offline_fixtures_parse_without_executables() -> None:
+    claude_lines = (FIXTURES / "claude.stream-json.jsonl").read_text().splitlines()
+    codex_lines = (FIXTURES / "codex.exec-json.jsonl").read_text().splitlines()
+    cursor_lines = (FIXTURES / "cursor.stream-json.jsonl").read_text().splitlines()
+    claude = [ClaudeProvider().parse_event(line) for line in claude_lines]
+    codex = [CodexProvider().parse_event(line) for line in codex_lines]
+    cursor = [CursorProvider().parse_event(line) for line in cursor_lines]
+    assert claude[0] is not None and claude[0].kind == "system"
+    assert cursor[1] is not None and cursor[1].kind == "assistant"
+    assert codex[2] is not None and codex[2].kind == "raw"
+    assert codex[3] is not None and codex[3].kind == "usage"
+
+
+def test_chapter_imports_production_registry() -> None:
+    import importlib.util
+
+    path = Path(__file__).resolve().parent.parent / "book/ch03_actor_is_not_a_model/solution.py"
+    spec = importlib.util.spec_from_file_location("ch03_solution", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.PROVIDERS is PROVIDERS
+
+
+def test_missing_executable_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sovereign_agent.providers.claude.look_up", lambda _: None)
+    assert ClaudeProvider().probe().available is False
+
+
+def test_unproven_streaming_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = CursorProvider()
+    monkeypatch.setattr(
+        provider,
+        "probe",
+        lambda: ProviderCapabilities(available=True, streaming=False, resume=True),
+    )
+    with pytest.raises(Refusal, match="streaming"):
+        provider.build_invocation(_request(tmp_path))
+
+
+def test_unproven_resume_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = ClaudeProvider()
+    monkeypatch.setattr(
+        provider,
+        "probe",
+        lambda: ProviderCapabilities(available=True, streaming=True, resume=False),
+    )
+    request = InvocationRequest(
+        workspace=tmp_path,
+        output=tmp_path / "out",
+        prompt="hi",
+        require_resume=True,
+        provider_session_id="ses_1",
+    )
+    with pytest.raises(Refusal, match="resume"):
+        provider.build_invocation(request)
+
+
+def test_proven_flags_are_the_only_ones_on_argv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    claude = ClaudeProvider()
+    monkeypatch.setattr(
+        claude,
+        "probe",
+        lambda: ProviderCapabilities(available=True, streaming=True, resume=True),
+    )
+    spec = claude.build_invocation(_request(tmp_path))
+    assert spec.argv[:4] == ["claude", "-p", "--output-format", "stream-json"]
+    assert "--verbose" in spec.argv
+
+    cursor = CursorProvider()
+    monkeypatch.setattr(
+        cursor,
+        "probe",
+        lambda: ProviderCapabilities(available=True, streaming=True, sandbox=True),
+    )
+    spec = cursor.build_invocation(_request(tmp_path))
+    assert spec.argv[:6] == [
+        "agent",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--workspace",
+        str(tmp_path),
+    ]
+
+    codex = CodexProvider()
+    monkeypatch.setattr(
+        codex,
+        "probe",
+        lambda: ProviderCapabilities(available=True, streaming=True, sandbox=True),
+    )
+    spec = codex.build_invocation(_request(tmp_path))
+    assert spec.argv[:3] == ["codex", "exec", "--json"]
+    assert spec.argv[3:5] == ["--sandbox", "workspace-write"]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -6,9 +6,11 @@ from pathlib import Path
 import pytest
 
 from sovereign_agent.errors import Refusal
+from sovereign_agent.execution import run_spec
 from sovereign_agent.providers import PROVIDERS, get_provider
 from sovereign_agent.providers.base import (
     InvocationRequest,
+    InvocationSpec,
     ProbeEvidence,
     ProviderCapabilities,
     capture,
@@ -28,12 +30,15 @@ def _request(tmp_path: Path) -> InvocationRequest:
     )
 
 
-def _caps(**changes: bool) -> ProviderCapabilities:
+def _caps(**changes: object) -> ProviderCapabilities:
     values = {
         "available": True,
         "print_mode": True,
+        "print_flag": "-p",
         "streaming": True,
         "resume": True,
+        "resume_streaming": True,
+        "resume_sandbox": True,
         "verbose": True,
     }
     values.update(changes)
@@ -167,6 +172,18 @@ def test_proven_flags_are_the_only_ones_on_argv(
     assert spec.argv == ["codex", "exec", "--json", "replenish tea"]
 
 
+@pytest.mark.parametrize("provider", [ClaudeProvider(), CursorProvider()])
+def test_long_print_flag_is_emitted_when_it_is_the_only_proven_form(
+    provider: ClaudeProvider | CursorProvider,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider, "probe", lambda: _caps(print_flag="--print"))
+    spec = provider.build_invocation(_request(tmp_path))
+    assert spec.argv[1] == "--print"
+    assert "-p" not in spec.argv
+
+
 def test_cursor_workspace_flag_requires_exact_probe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -223,6 +240,42 @@ def test_codex_resume_has_subcommand_shape(
     ]
 
 
+def test_codex_resume_sandbox_uses_only_resume_probe_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = CodexProvider()
+    request = InvocationRequest(
+        workspace=tmp_path,
+        output=tmp_path / "out",
+        prompt="continue",
+        require_resume=True,
+        require_sandbox=True,
+        provider_session_id="thread_123",
+    )
+    monkeypatch.setattr(
+        provider,
+        "probe",
+        lambda: _caps(sandbox=True, resume_sandbox=False),
+    )
+    with pytest.raises(Refusal, match="resume cannot prove --sandbox"):
+        provider.build_invocation(request)
+    monkeypatch.setattr(
+        provider,
+        "probe",
+        lambda: _caps(sandbox=True, resume_sandbox=True),
+    )
+    assert provider.build_invocation(request).argv == [
+        "codex",
+        "exec",
+        "resume",
+        "--json",
+        "--sandbox",
+        "workspace-write",
+        "thread_123",
+        "continue",
+    ]
+
+
 def test_codex_probes_resume_subcommand_exactly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -235,7 +288,7 @@ def test_codex_probes_resume_subcommand_exactly(
         stdout = {
             ("--version",): "codex 1.0",
             ("exec", "--help"): "--json --sandbox",
-            ("exec", "resume", "--help"): "Usage: codex exec resume --json",
+            ("exec", "resume", "--help"): "Usage: codex exec resume --json --sandbox",
         }[args]
         return ProbeEvidence(command=command, exit_code=0, stdout=stdout)
 
@@ -243,7 +296,55 @@ def test_codex_probes_resume_subcommand_exactly(
     caps = CodexProvider().probe()
     assert calls[-1] == ("codex", "exec", "resume", "--help")
     assert caps.resume
+    assert caps.resume_streaming
+    assert caps.resume_sandbox
     assert caps.evidence[-1].command == calls[-1]
+
+
+def test_provider_auth_environment_is_allowlisted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "approved")
+    monkeypatch.setenv("DATABASE_URL", "must-not-leak")
+    provider = ClaudeProvider()
+    monkeypatch.setattr(provider, "probe", _caps)
+    spec = provider.build_invocation(_request(tmp_path))
+    assert spec.env == {"ANTHROPIC_API_KEY": "approved"}
+    assert "DATABASE_URL" not in spec.env
+
+
+def test_run_spec_forwards_approved_environment_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "must-not-leak")
+    observed: dict[str, str] = {}
+
+    def complete(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed.update(kwargs["env"])  # type: ignore[arg-type]
+        return subprocess.CompletedProcess(["tool"], 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", complete)
+    run_spec(
+        InvocationSpec(
+            argv=["tool"],
+            cwd=tmp_path,
+            env={"ANTHROPIC_API_KEY": "approved"},
+        )
+    )
+    assert observed["ANTHROPIC_API_KEY"] == "approved"
+    assert "DATABASE_URL" not in observed
+
+
+def test_run_spec_timeout_has_durable_failure_category(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def timeout(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(["tool"], 60)
+
+    monkeypatch.setattr(subprocess, "run", timeout)
+    with pytest.raises(Refusal) as raised:
+        run_spec(InvocationSpec(argv=["tool"], cwd=tmp_path))
+    assert raised.value.category == "timeout"
 
 
 def test_probe_timeout_is_degraded_not_an_exception(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -39,6 +39,7 @@ def _caps(**changes: object) -> ProviderCapabilities:
         "resume": True,
         "resume_streaming": True,
         "resume_sandbox": True,
+        "workspace_write": True,
         "verbose": True,
     }
     values.update(changes)
@@ -184,6 +185,34 @@ def test_long_print_flag_is_emitted_when_it_is_the_only_proven_form(
     assert "-p" not in spec.argv
 
 
+@pytest.mark.parametrize(
+    ("provider", "write_argv"),
+    [
+        (ClaudeProvider(), ["--permission-mode", "acceptEdits"]),
+        (CursorProvider(), ["--force"]),
+    ],
+)
+def test_write_authority_requires_provider_specific_mode(
+    provider: ClaudeProvider | CursorProvider,
+    write_argv: list[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = InvocationRequest(
+        workspace=tmp_path,
+        output=tmp_path / "out",
+        prompt="write report",
+        require_workspace_write=True,
+    )
+    monkeypatch.setattr(provider, "probe", lambda: _caps(workspace_write=False))
+    with pytest.raises(Refusal, match="workspace write"):
+        provider.build_invocation(request)
+    monkeypatch.setattr(provider, "probe", _caps)
+    argv = provider.build_invocation(request).argv
+    for index, value in enumerate(write_argv):
+        assert argv[argv.index(write_argv[0]) + index] == value
+
+
 def test_cursor_workspace_flag_requires_exact_probe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -301,15 +330,35 @@ def test_codex_probes_resume_subcommand_exactly(
     assert caps.evidence[-1].command == calls[-1]
 
 
+@pytest.mark.parametrize(
+    ("provider", "variable"),
+    [
+        (ClaudeProvider(), "ANTHROPIC_API_KEY"),
+        (CodexProvider(), "CODEX_API_KEY"),
+        (CursorProvider(), "CURSOR_API_KEY"),
+    ],
+)
 def test_provider_auth_environment_is_allowlisted(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    provider: ClaudeProvider | CodexProvider | CursorProvider,
+    variable: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "approved")
+    for name in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CODEX_API_KEY",
+        "CURSOR_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(variable, "approved")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-leak")
     monkeypatch.setenv("DATABASE_URL", "must-not-leak")
-    provider = ClaudeProvider()
     monkeypatch.setattr(provider, "probe", _caps)
     spec = provider.build_invocation(_request(tmp_path))
-    assert spec.env == {"ANTHROPIC_API_KEY": "approved"}
+    assert spec.env == {variable: "approved"}
+    assert "OPENAI_API_KEY" not in spec.env
     assert "DATABASE_URL" not in spec.env
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -223,9 +223,7 @@ def test_cursor_workspace_flag_requires_exact_probe(
     assert spec.cwd == tmp_path
 
 
-def test_requested_sandbox_must_be_proven(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_requested_sandbox_must_be_proven(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     provider = CodexProvider()
     request = InvocationRequest(
         workspace=tmp_path,
@@ -247,9 +245,7 @@ def test_requested_sandbox_must_be_proven(
     ]
 
 
-def test_codex_resume_has_subcommand_shape(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_codex_resume_has_subcommand_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     provider = CodexProvider()
     monkeypatch.setattr(provider, "probe", _caps)
     request = InvocationRequest(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from sovereign_agent.errors import Refusal
 from sovereign_agent.providers import PROVIDERS, get_provider
-from sovereign_agent.providers.base import InvocationRequest, ProviderCapabilities
+from sovereign_agent.providers.base import (
+    InvocationRequest,
+    ProbeEvidence,
+    ProviderCapabilities,
+    capture,
+)
 from sovereign_agent.providers.claude import ClaudeProvider
 from sovereign_agent.providers.codex import CodexProvider
 from sovereign_agent.providers.cursor import CursorProvider
@@ -22,26 +28,50 @@ def _request(tmp_path: Path) -> InvocationRequest:
     )
 
 
+def _caps(**changes: bool) -> ProviderCapabilities:
+    values = {
+        "available": True,
+        "print_mode": True,
+        "streaming": True,
+        "resume": True,
+        "verbose": True,
+    }
+    values.update(changes)
+    return ProviderCapabilities(**values)
+
+
 def test_registry_names_are_equal_adapters() -> None:
     assert list(PROVIDERS) == ["scripted", "claude", "codex", "cursor"]
     with pytest.raises(Refusal, match="Unknown provider"):
         get_provider("sonnet")
 
 
-def test_offline_fixtures_parse_without_executables() -> None:
+def test_offline_success_fixtures_capture_terminal_session_and_usage() -> None:
     claude_lines = (FIXTURES / "claude.stream-json.jsonl").read_text().splitlines()
     codex_lines = (FIXTURES / "codex.exec-json.jsonl").read_text().splitlines()
     cursor_lines = (FIXTURES / "cursor.stream-json.jsonl").read_text().splitlines()
     claude = [ClaudeProvider().parse_event(line) for line in claude_lines]
     codex = [CodexProvider().parse_event(line) for line in codex_lines]
     cursor = [CursorProvider().parse_event(line) for line in cursor_lines]
-    assert claude[0] is not None and claude[0].kind == "system"
-    assert cursor[1] is not None and cursor[1].kind == "assistant"
-    assert codex[2] is not None and codex[2].kind == "raw"
-    assert codex[3] is not None and codex[3].kind == "usage"
+    assert claude[0] is not None and claude[0].session_id == "ses_offline"
+    assert claude[-1] is not None and claude[-1].terminal and claude[-1].succeeded
+    assert cursor[0] is not None and cursor[0].session_id == "cursor_offline"
+    assert cursor[-1] is not None and cursor[-1].terminal and cursor[-1].succeeded
+    assert codex[0] is not None and codex[0].session_id == "thread_offline"
+    assert codex[-1] is not None and codex[-1].terminal and codex[-1].succeeded
+    assert codex[-1].usage["input_tokens"] == 12
 
 
-def test_chapter_imports_production_registry() -> None:
+def test_malformed_and_unknown_events_are_distinct() -> None:
+    malformed = CodexProvider().parse_event("not json")
+    unknown = CodexProvider().parse_event('{"type":"future.event","value":1}')
+    assert malformed is not None and malformed.malformed
+    assert malformed.kind == "malformed"
+    assert unknown is not None and not unknown.malformed
+    assert unknown.kind == "future.event"
+
+
+def test_chapter_exercise_preserves_actor_identity(tmp_path: Path) -> None:
     import importlib.util
 
     path = Path(__file__).resolve().parent.parent / "book/ch03_actor_is_not_a_model/solution.py"
@@ -49,7 +79,9 @@ def test_chapter_imports_production_registry() -> None:
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    assert module.PROVIDERS is PROVIDERS
+    result = module.run_exercise(tmp_path / "chapter", "scripted")
+    assert result["identity_unchanged"] is True
+    assert result["before"] == result["after"]
 
 
 def test_missing_executable_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -62,7 +94,7 @@ def test_unproven_streaming_is_refused(tmp_path: Path, monkeypatch: pytest.Monke
     monkeypatch.setattr(
         provider,
         "probe",
-        lambda: ProviderCapabilities(available=True, streaming=False, resume=True),
+        lambda: _caps(streaming=False),
     )
     with pytest.raises(Refusal, match="streaming"):
         provider.build_invocation(_request(tmp_path))
@@ -73,7 +105,7 @@ def test_unproven_resume_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(
         provider,
         "probe",
-        lambda: ProviderCapabilities(available=True, streaming=True, resume=False),
+        lambda: _caps(resume=False),
     )
     request = InvocationRequest(
         workspace=tmp_path,
@@ -86,6 +118,21 @@ def test_unproven_resume_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPa
         provider.build_invocation(request)
 
 
+def test_session_id_without_resume_intent_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = ClaudeProvider()
+    monkeypatch.setattr(provider, "probe", _caps)
+    request = InvocationRequest(
+        workspace=tmp_path,
+        output=tmp_path / "out",
+        prompt="hi",
+        provider_session_id="ses_1",
+    )
+    with pytest.raises(Refusal, match="without resume intent"):
+        provider.build_invocation(request)
+
+
 def test_proven_flags_are_the_only_ones_on_argv(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -93,7 +140,7 @@ def test_proven_flags_are_the_only_ones_on_argv(
     monkeypatch.setattr(
         claude,
         "probe",
-        lambda: ProviderCapabilities(available=True, streaming=True, resume=True),
+        _caps,
     )
     spec = claude.build_invocation(_request(tmp_path))
     assert spec.argv[:4] == ["claude", "-p", "--output-format", "stream-json"]
@@ -103,24 +150,111 @@ def test_proven_flags_are_the_only_ones_on_argv(
     monkeypatch.setattr(
         cursor,
         "probe",
-        lambda: ProviderCapabilities(available=True, streaming=True, sandbox=True),
+        _caps,
     )
     spec = cursor.build_invocation(_request(tmp_path))
-    assert spec.argv[:6] == [
-        "agent",
-        "-p",
-        "--output-format",
-        "stream-json",
-        "--workspace",
-        str(tmp_path),
-    ]
+    assert spec.argv == ["agent", "-p", "--output-format", "stream-json", "replenish tea"]
+    assert spec.cwd == tmp_path
+    assert cursor.probe().sandbox is False
 
     codex = CodexProvider()
     monkeypatch.setattr(
         codex,
         "probe",
-        lambda: ProviderCapabilities(available=True, streaming=True, sandbox=True),
+        lambda: _caps(sandbox=True),
     )
     spec = codex.build_invocation(_request(tmp_path))
-    assert spec.argv[:3] == ["codex", "exec", "--json"]
-    assert spec.argv[3:5] == ["--sandbox", "workspace-write"]
+    assert spec.argv == ["codex", "exec", "--json", "replenish tea"]
+
+
+def test_cursor_workspace_flag_requires_exact_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = CursorProvider()
+    monkeypatch.setattr(provider, "probe", lambda: _caps(workspace_selection=True))
+    spec = provider.build_invocation(_request(tmp_path))
+    assert spec.argv[-3:-1] == ["--workspace", str(tmp_path)]
+    assert spec.cwd == tmp_path
+
+
+def test_requested_sandbox_must_be_proven(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = CodexProvider()
+    request = InvocationRequest(
+        workspace=tmp_path,
+        output=tmp_path / "out",
+        prompt="bounded write",
+        require_sandbox=True,
+    )
+    monkeypatch.setattr(provider, "probe", lambda: _caps(sandbox=False))
+    with pytest.raises(Refusal, match="sandbox"):
+        provider.build_invocation(request)
+    monkeypatch.setattr(provider, "probe", lambda: _caps(sandbox=True))
+    assert provider.build_invocation(request).argv == [
+        "codex",
+        "exec",
+        "--json",
+        "--sandbox",
+        "workspace-write",
+        "bounded write",
+    ]
+
+
+def test_codex_resume_has_subcommand_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = CodexProvider()
+    monkeypatch.setattr(provider, "probe", _caps)
+    request = InvocationRequest(
+        workspace=tmp_path,
+        output=tmp_path / "out",
+        prompt="continue",
+        require_resume=True,
+        provider_session_id="thread_123",
+    )
+    assert provider.build_invocation(request).argv == [
+        "codex",
+        "exec",
+        "resume",
+        "--json",
+        "thread_123",
+        "continue",
+    ]
+
+
+def test_codex_probes_resume_subcommand_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr("sovereign_agent.providers.codex.look_up", lambda _: "/fake/codex")
+
+    def fake_capture(executable: str, *args: str) -> ProbeEvidence:
+        command = (executable, *args)
+        calls.append(command)
+        stdout = {
+            ("--version",): "codex 1.0",
+            ("exec", "--help"): "--json --sandbox",
+            ("exec", "resume", "--help"): "Usage: codex exec resume --json",
+        }[args]
+        return ProbeEvidence(command=command, exit_code=0, stdout=stdout)
+
+    monkeypatch.setattr("sovereign_agent.providers.codex.capture", fake_capture)
+    caps = CodexProvider().probe()
+    assert calls[-1] == ("codex", "exec", "resume", "--help")
+    assert caps.resume
+    assert caps.evidence[-1].command == calls[-1]
+
+
+def test_probe_timeout_is_degraded_not_an_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sovereign_agent.providers.base.look_up", lambda _: "/fake/claude")
+
+    def timeout(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(["claude", "--help"], 10)
+
+    monkeypatch.setattr(subprocess, "run", timeout)
+    evidence = capture("claude", "--help")
+    assert evidence.exit_code is None
+    assert evidence.error is not None

--- a/tests/test_providers_live.py
+++ b/tests/test_providers_live.py
@@ -1,9 +1,16 @@
-"""Opt-in live probes. Never submit prompts. Excluded from default pytest."""
+"""Opt-in live probes and assignments. Excluded from default pytest."""
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+from pathlib import Path
+
 import pytest
 
+from sovereign_agent.models import ActorReport, AssignmentState, Role, SowState
+from sovereign_agent.organization import Organization
 from sovereign_agent.providers import PROVIDERS
 
 pytestmark = pytest.mark.live
@@ -16,3 +23,91 @@ def test_installed_cli_probe_does_not_submit_work(name: str) -> None:
     if not caps.available:
         pytest.skip(f"{provider.executable} is not on PATH")
     assert caps.available
+    assert caps.evidence
+    assert all(item.exit_code == 0 for item in caps.evidence if item.error is None)
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _fixture_repo(root: Path) -> Organization:
+    org = Organization.init(root)
+    (root / "README.md").write_text("# Disposable provider smoke\n", encoding="utf-8")
+    (root / ".gitignore").write_text(
+        ".sovereign/\nartifacts/\ngovernance/\nsovereign.toml\n",
+        encoding="utf-8",
+    )
+    _git(root, "init", "-q")
+    _git(root, "add", ".")
+    _git(
+        root,
+        "-c",
+        "user.name=Sovereign Agent",
+        "-c",
+        "user.email=fixture@example.invalid",
+        "commit",
+        "-qm",
+        "fixture trunk",
+    )
+    return org
+
+
+@pytest.mark.parametrize("name", ["claude", "codex", "cursor"])
+@pytest.mark.parametrize("mode", ["read-only", "workspace-write"])
+def test_live_assignment_reaches_review_without_moving_trunk(
+    name: str,
+    mode: str,
+    tmp_path: Path,
+) -> None:
+    if os.environ.get("SOVEREIGN_AGENT_LIVE_ASSIGNMENTS") != "1":
+        pytest.skip("set SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1 (this submits a short prompt)")
+    provider = PROVIDERS[name]
+    if not provider.probe().available:
+        pytest.skip(f"{provider.executable} is not on PATH")
+
+    org = _fixture_repo(tmp_path / f"{name}-{mode}")
+    org.actors["operator-course"].provider = name
+    before_head = _git(org.root, "rev-parse", "HEAD")
+    scope = (
+        "Read README.md without changing tracked files, then write only the required report."
+        if mode == "read-only"
+        else (
+            "Create lesson.txt containing exactly 'actor is not provider\\n', "
+            "then write the required report."
+        )
+    )
+    outcome = org.create_outcome("live smoke", "truthful receipt", ["report"], "principal-human")
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, scope, Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    assignment = org.assign(sow.id, "operator-course", "master-course")
+    finished = org.run_assignment(assignment.id)
+
+    assert finished.state == AssignmentState.COMPLETED
+    assert org._sow(sow.id).state == SowState.REVIEW  # noqa: SLF001
+    assert _git(org.root, "rev-parse", "HEAD") == before_head
+    workspace = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    receipt = (workspace / "receipt.json").read_text(encoding="utf-8")
+    ActorReport.model_validate_json(
+        (workspace / ".sovereign-out" / "report.json").read_text(encoding="utf-8")
+    )
+    assert f'"provider":"{name}"' in receipt
+    assert '"provider_session_ref":null' not in receipt
+    assert '"status":"completed"' in receipt
+    normalized = [
+        json.loads(line)
+        for line in (workspace / "provider-raw" / "events.jsonl").read_text().splitlines()
+    ]
+    assert normalized[-1]["terminal"] is True
+    if mode == "read-only":
+        assert _git(org.root, "status", "--porcelain") == ""
+    else:
+        assert (workspace / "lesson.txt").read_text() == "actor is not provider\n"

--- a/tests/test_providers_live.py
+++ b/tests/test_providers_live.py
@@ -77,7 +77,7 @@ def test_live_assignment_reaches_review_without_moving_trunk(
     org.actors["operator-course"].provider = name
     before_head = _git(org.root, "rev-parse", "HEAD")
     scope = (
-        "Read README.md without changing tracked files, then write only the required report."
+        "Read fixture.txt without changing it, then write only the required report."
         if mode == "read-only"
         else (
             "Create lesson.txt containing exactly 'actor is not provider\\n', "
@@ -89,12 +89,17 @@ def test_live_assignment_reaches_review_without_moving_trunk(
     sow = org.create_sow(outcome.id, scope, Role.OPERATOR, "master-course")
     org.ready_sow(sow.id)
     assignment = org.assign(sow.id, "operator-course", "master-course")
+    workspace = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    workspace.mkdir(parents=True)
+    (workspace / "fixture.txt").write_text(
+        "actor identity is governed\n",
+        encoding="utf-8",
+    )
     finished = org.run_assignment(assignment.id)
 
     assert finished.state == AssignmentState.COMPLETED
     assert org._sow(sow.id).state == SowState.REVIEW  # noqa: SLF001
     assert _git(org.root, "rev-parse", "HEAD") == before_head
-    workspace = org.root / ".sovereign" / "runs" / assignment.workspace_id
     receipt = (workspace / "receipt.json").read_text(encoding="utf-8")
     ActorReport.model_validate_json(
         (workspace / ".sovereign-out" / "report.json").read_text(encoding="utf-8")
@@ -108,6 +113,7 @@ def test_live_assignment_reaches_review_without_moving_trunk(
     ]
     assert normalized[-1]["terminal"] is True
     if mode == "read-only":
+        assert (workspace / "fixture.txt").read_text() == "actor identity is governed\n"
         assert _git(org.root, "status", "--porcelain") == ""
     else:
         assert (workspace / "lesson.txt").read_text() == "actor is not provider\n"

--- a/tests/test_providers_live.py
+++ b/tests/test_providers_live.py
@@ -1,0 +1,18 @@
+"""Opt-in live probes. Never submit prompts. Excluded from default pytest."""
+
+from __future__ import annotations
+
+import pytest
+
+from sovereign_agent.providers import PROVIDERS
+
+pytestmark = pytest.mark.live
+
+
+@pytest.mark.parametrize("name", ["claude", "codex", "cursor"])
+def test_installed_cli_probe_does_not_submit_work(name: str) -> None:
+    provider = PROVIDERS[name]
+    caps = provider.probe()
+    if not caps.available:
+        pytest.skip(f"{provider.executable} is not on PATH")
+    assert caps.available


### PR DESCRIPTION
## Summary
- Add equal Claude, Codex, and Cursor adapters behind one `IntelligenceProvider` protocol, plus a provider-neutral assignment envelope with actor identity, authority, SOW, workspace bounds, output paths, and the exact `ActorReport` schema.
- Fail closed on unproven flags, Codex `exec resume` argv, Cursor `--workspace` as directory selection (not sandbox), truthful terminal/session/usage parsing, and canonical filesystem/database receipts with a SHA-256 sidecar.
- Fake-executable tests prove all three providers can reach REVIEW. Live assignment smokes remain opt-in (`SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1`) and excluded from default CI. Chapter 3 is a runnable actor-vs-provider exercise.

## Test plan
- [ ] `uv run pytest -q` (live tests deselected)
- [ ] `uv run python scripts/verify_runtime_dependencies.py` prints `pydantic`
- [ ] `uv run python scripts/verify_source_budget.py`
- [ ] `uv run ruff check src tests book` and `uv run mypy src`
- [ ] `sovereign-agent doctor` lists `scripted`, `claude`, `codex`, and `cursor`
- [ ] Optional: `uv run pytest -q -m live` (probes only)
- [ ] Optional: `SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1 uv run pytest -q -m live` on an authenticated CLI (consumes a short prompt)