### PR TITLE
Unit 6.5 — make the store demo's ACCEPTED mean the outcome is true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Install package and development tools
         run: python -m pip install -e . --group dev
       - name: Format
-        run: ruff format --check src tests scripts
+        run: ruff format --check src tests scripts book
       - name: Lint
-        run: ruff check src tests scripts
+        run: ruff check src tests scripts book
       - name: Type check
         run: mypy src/sovereign_agent
       - name: Test
@@ -29,11 +29,62 @@ jobs:
         run: python scripts/verify_runtime_dependencies.py
       - name: Verify source budgets
         run: python scripts/verify_source_budget.py
+      - name: Verify the curriculum is runnable
+        run: python scripts/verify_curriculum.py
       - name: Verify offline commands
         run: |
           sovereign-agent --help
           sovereign-agent doctor
           sovereign-agent demo store --mode simulated --root "$RUNNER_TEMP/store-demo"
+      - name: Verify the accepted outcome is actually TRUE
+        # The demo exiting 0 is not proof. The previous version of this pipeline
+        # ran the demo and stopped there, and the demo printed ACCEPTED while the
+        # shelf was empty. This asserts inventory, cash, events, evidence binding,
+        # staleness, receipts, actor separation, and that no Pulse was fabricated.
+        run: python scripts/verify_store_outcome.py "$RUNNER_TEMP/store-demo"
+      - name: Verify governance projections match the ledger
+        run: python scripts/verify_projections.py "$RUNNER_TEMP/store-demo"
+      - name: Verify a learner can reach a truthful outcome cold
+        run: python scripts/evaluate_andrea_alpha.py
+      - name: Prove acceptance still refuses a false claim
+        # A gate that only ever sees the happy path cannot tell you refusal works.
+        run: |
+          python - <<'CHECK'
+          import sqlite3, subprocess, sys, os
+          root = os.environ["RUNNER_TEMP"] + "/store-demo"
+          db = sqlite3.connect(root + "/.sovereign/organization.db")
+          db.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
+          db.commit(); db.close()
+          result = subprocess.run(
+              [sys.executable, "scripts/verify_store_outcome.py", root],
+              capture_output=True, text=True,
+          )
+          print(result.stdout)
+          if result.returncode == 0:
+              sys.exit("FAIL: the verifier passed an emptied shelf")
+          print("verifier correctly refused an emptied shelf")
+          CHECK
+      - name: Prove events are append-only from an outside connection
+        # recursive_triggers is per-connection. This deliberately uses its own
+        # connection, so it fails if enforcement moves back into application code.
+        run: |
+          python - <<'CHECK'
+          import sqlite3, os, sys
+          root = os.environ["RUNNER_TEMP"] + "/store-demo"
+          db = sqlite3.connect(root + "/.sovereign/organization.db")
+          event_id = db.execute("SELECT id FROM events LIMIT 1").fetchone()[0]
+          for statement in (
+              "INSERT OR REPLACE INTO events(id,kind,payload,created_at) VALUES (?,'HACKED','{}','t')",
+              "UPDATE events SET kind='HACKED' WHERE id=?",
+              "DELETE FROM events WHERE id=?",
+          ):
+              try:
+                  db.execute(statement, (event_id,)); db.commit()
+                  sys.exit(f"FAIL: append-only bypassed by: {statement}")
+              except sqlite3.IntegrityError as error:
+                  db.rollback()
+                  print(f"refused: {error}")
+          CHECK
       - name: Verify wheel metadata and clean install
         run: |
           python -m build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,31 @@ jobs:
         run: python scripts/verify_store_outcome.py "$RUNNER_TEMP/store-demo"
       - name: Verify governance projections match the ledger
         run: python scripts/verify_projections.py "$RUNNER_TEMP/store-demo"
+      - name: Prove projection verification reports drift without repairing it
+        # It previously called the projection WRITER to learn the expected bytes,
+        # so it silently repaired hand-edited files and reported success.
+        run: |
+          python - <<'CHECK'
+          import glob, json, os, subprocess, sys
+          root = os.environ["RUNNER_TEMP"] + "/store-demo"
+          path = glob.glob(root + "/governance/outcomes/*/sows/*.json")[0]
+          record = json.load(open(path)); record["scope"] = "HAND EDITED FALSE SCOPE"
+          tampered = json.dumps(record, indent=2)
+          open(path, "w").write(tampered)
+          result = subprocess.run(
+              [sys.executable, "scripts/verify_projections.py", root],
+              capture_output=True, text=True,
+          )
+          print(result.stdout)
+          if result.returncode == 0:
+              sys.exit("FAIL: drift was not reported")
+          if open(path).read() != tampered:
+              sys.exit("FAIL: verification rewrote the file it was checking")
+          subprocess.run(
+              [sys.executable, "scripts/verify_projections.py", root, "--reconcile"], check=True
+          )
+          print("drift reported, file untouched, --reconcile repaired it")
+          CHECK
       - name: Verify a learner can reach a truthful outcome cold
         run: python scripts/evaluate_andrea_alpha.py
       - name: Prove acceptance still refuses a false claim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,13 @@ jobs:
           org.run_assignment(
               org.assign(investigation.id, "operator-course", "master-course").id)
 
-          for sow_id in (effectful.id, investigation.id):
-              org.verify_sow(sow_id, "verifier-course")
+          # Verify the investigation FIRST, move the world with a legitimate
+          # sale, then verify the effectful SOW. Verifying both only after all
+          # business mutations cannot detect an ordering-dependent oracle,
+          # which is how a real disagreement shipped past this gate once.
+          org.verify_sow(investigation.id, "verifier-course")
+          record_sale(org.db, "SKU-TEA", 1, 400)
+          org.verify_sow(effectful.id, "verifier-course")
           for sow_id in (effectful.id, investigation.id):
               org.review(sow_id, "sparring-course")
           org.verify_outcome_condition(outcome.id, "verifier-course")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,65 @@ jobs:
           )
           print("drift reported, file untouched, --reconcile repaired it")
           CHECK
+      - name: Prove core and the truth verifier agree on a MULTI-SOW organization
+        # run_simulated builds exactly ONE SOW, so the oracle only ever ran
+        # against a single-SOW fixture: the gate was green because the fixture
+        # was narrower than the feature it gated. Both reviewers flagged that
+        # "true and ungated" is the state this defect was in when it broke.
+        run: |
+          python - <<'CHECK'
+          import pathlib, subprocess, sys, tempfile
+          sys.path.insert(0, "src")
+          from reference_organizations.store import (
+              RestockProposal, apply_restock, record_sale, seed,
+          )
+          from sovereign_agent.models import Role
+          from sovereign_agent.organization import Organization
+
+          root = pathlib.Path(tempfile.mkdtemp()) / "multi-sow"
+          org = Organization.init(root)
+          seed(org.db)
+          outcome = org.create_outcome(
+              "Keep the tea jar stocked",
+              "On-hand tea stays at or above the reorder point.",
+              ["inventory_at_or_above_reorder_point", "cash_reconciles",
+               "replenishment_event_exists"],
+              "principal-human", "SKU-TEA",
+          )
+          org.activate(outcome.id, "master-course")
+          signal = record_sale(org.db, "SKU-TEA", 2, 400)
+
+          effectful = org.create_sow(
+              outcome.id, "replenish", Role.OPERATOR, "master-course", "replenishment")
+          org.ready_sow(effectful.id)
+          worker = org.run_assignment(
+              org.assign(effectful.id, "operator-course", "master-course").id)
+          apply_restock(org.db, RestockProposal("SKU-TEA", 6), worker.id, signal.id)
+
+          investigation = org.create_sow(
+              outcome.id, "investigate", Role.OPERATOR, "master-course")
+          org.ready_sow(investigation.id)
+          org.run_assignment(
+              org.assign(investigation.id, "operator-course", "master-course").id)
+
+          for sow_id in (effectful.id, investigation.id):
+              org.verify_sow(sow_id, "verifier-course")
+          for sow_id in (effectful.id, investigation.id):
+              org.review(sow_id, "sparring-course")
+          org.verify_outcome_condition(outcome.id, "verifier-course")
+          org.accept(outcome.id, "principal-human")
+          org.db.close()
+          print("core: ACCEPTED")
+
+          result = subprocess.run(
+              [sys.executable, "scripts/verify_store_outcome.py", str(root)],
+              capture_output=True, text=True,
+          )
+          print(result.stdout)
+          if result.returncode != 0:
+              sys.exit("FAIL: core accepted what its own verifier rejects")
+          print("core and oracle agree on a multi-SOW organization")
+          CHECK
       - name: Verify a learner can reach a truthful outcome cold
         run: python scripts/evaluate_andrea_alpha.py
       - name: Prove acceptance still refuses a false claim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ Repository: [`zeroemployeeorg/sovereign-agent`](https://github.com/zeroemployeeo
 
 ## Unreleased
 
+### Cumulative conformance (Unit 6.5)
+
+The simulated store now performs a **real** replenishment. Previously the demo
+printed `ACCEPTED` while `SKU-TEA` sat at `on_hand=2` against a
+`reorder_point=3`, with no purchase and no replenishment event: the governance
+records were complete and the business claim was false.
+
+- The store gains a validated `apply_restock` effect. Inventory increase,
+  purchasing cash entry, signal resolution, and the `replenishment.committed`
+  event commit in one SQLite transaction, and are idempotent per assignment.
+  A provider may *propose* a bounded quantity; deterministic Python validates
+  it and reads the unit cost from the product record, never from the provider.
+- `verify_outcome` executes every declared acceptance check instead of only
+  advancing a status field. Unknown, malformed, and erroring checks fail closed.
+- Acceptance re-derives its own authority. It **re-executes** the declared
+  checks against current state, requires successful evidence for every declared
+  check bound to this outcome and execution, and refuses stale evidence. The
+  caller-supplied `performer_id` argument is **removed**: performers are derived
+  from assignments in the ledger, so separation cannot be satisfied by naming a
+  convenient stranger.
+- A small explicit check registry replaces the previous single evidence record
+  whose name (`inventory_non_negative`) described inventory while its value was
+  computed from cash. `cash_reconciles` now reconciles the purchase against the
+  replenishment event rather than testing solvency.
+- Events are append-only **at the database boundary**: triggers refuse `UPDATE`
+  and `DELETE`, and `PRAGMA recursive_triggers` closes the `INSERT OR REPLACE`
+  bypass. Evidence gains a foreign key, so a fabricated evidence id cannot be
+  inserted at all.
+- Migrations become forward-only and numbered. Migration 1 is unchanged;
+  migration 2 adds the guards and evidence binding. Fresh-database and
+  upgrade-from-v1 paths are both tested.
+- Chapters 1 and 2 are written, Chapters 0 and 3 gain the required structure,
+  and `scripts/verify_curriculum.py` detects missing sections, broken solution
+  imports, and references to scripts that do not exist.
+- New verification: `scripts/verify_store_outcome.py`,
+  `scripts/verify_projections.py`, `scripts/evaluate_andrea_alpha.py`.
+
+Tests grow from 59 to 98, including a falsification suite that proves acceptance
+is refused for missing, failed, unrelated, unbound, stale, and fabricated
+evidence, and a fault-injection suite that proves rollback after a partial write.
+
+**Not claimed:** the credentialed provider smokes for Claude, Codex, and Cursor
+have **not** been run. They remain a Unit 12 release gate. Installed is not
+authenticated.
+
+### Branch policy correction
+
+`main` became the 1.x educational integration line when Units 0–6 merged. The
+earlier holding that "`main` remains the 0.7 line" is superseded. Tag `v0.7.0`
+remains immutable at `be2a41bbee202c52a40b2e87c00215827be302a0`; pin
+`sovereign-agent<1` for the 0.x framework. No claim is made that 1.0 has met its
+release gates. See
+[docs/rulings/2026-08-25-main-is-the-1x-line.md](docs/rulings/2026-08-25-main-is-the-1x-line.md)
+and [docs/persistence-boundary.md](docs/persistence-boundary.md).
+
 ### Providers (Unit 6)
 
 Claude, Codex, and Cursor adapters implement `probe` / `build_invocation` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,20 @@ records were complete and the business claim was false.
   whose name (`inventory_non_negative`) described inventory while its value was
   computed from cash. `cash_reconciles` now reconciles the purchase against the
   replenishment event rather than testing solvency.
-- Events are append-only **at the database boundary**: triggers refuse `UPDATE`
-  and `DELETE`, and `PRAGMA recursive_triggers` closes the `INSERT OR REPLACE`
-  bypass. Evidence gains a foreign key, so a fabricated evidence id cannot be
-  inserted at all.
+- Events are append-only **at the database boundary, from any connection**:
+  triggers refuse `UPDATE`, `DELETE`, and an `INSERT` whose id already exists.
+  The first attempt closed the `INSERT OR REPLACE` bypass with
+  `PRAGMA recursive_triggers`, which is per-connection — so a plain `sqlite3`
+  shell, the tool Chapter 1 teaches, still silently overwrote events while the
+  verifier reported "ACCEPTED and true". Migration 3 replaces that with a
+  `BEFORE INSERT` guard needing no pragma, and a test that opens its own
+  connection proves it. Evidence gains a foreign key, so a fabricated evidence
+  id cannot be inserted at all.
+- Named limits rather than silent ones: `docs/persistence-boundary.md` records
+  that `outcomes` has no triggers, so an attacker with raw database write access
+  can retarget `outcome.subject` and make all three checks pass coherently. The
+  durable fix (binding subject into the evidence digest) is identified as the
+  next step, not claimed as done.
 - Migrations become forward-only and numbered. Migration 1 is unchanged;
   migration 2 adds the guards and evidence binding. Fresh-database and
   upgrade-from-v1 paths are both tested.

--- a/book/README.md
+++ b/book/README.md
@@ -3,8 +3,33 @@
 The book grows with the implementation. Each chapter uses the production
 package; it does not copy or fork it.
 
-- [Chapter 0: Andrea's first shift](ch00_first_shift/README.md) — runnable
-  simulated store shift (manually dispatched replenishment, no Pulse)
+Read them in order. Each one takes apart something the previous chapter asked
+you to take on faith.
+
+- [Chapter 0: Andrea's first shift](ch00_first_shift/README.md) — run one
+  complete piece of work and learn that `ACCEPTED` is a proved claim
+- [Chapter 1: The organization remembers](ch01_organization_remembers/README.md) —
+  SQLite, transactions, append-only events, and what is canonical versus derived
+- [Chapter 2: Work needs governance](ch02_work_needs_governance/README.md) —
+  outcomes, SOWs, evidence, verification, review, and no-self-approval
 - [Chapter 3: The actor is not a model](ch03_actor_is_not_a_model/README.md) —
   providers are probed CLIs; Cursor is equal to Claude and Codex
 
+## What is not here yet
+
+Pulse — the organization waking itself up — is Unit 9. Nothing in these chapters
+simulates a Pulse event, and the store demo is explicitly manually dispatched. A
+chapter that promised proactive behaviour before the code could do it would be
+the same kind of lie this book spends Chapter 2 teaching you to catch.
+
+## Every chapter contains
+
+- a concrete learning objective
+- a runnable exercise
+- expected observations
+- a learner verification command
+- an "explain it back" section
+- a `solution.py` that imports the production package
+
+Run `python scripts/verify_curriculum.py` to check that all of that is actually
+present and that the chapters' imports still work.

--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -1,31 +1,131 @@
 # Chapter 0 — Andrea's first shift
 
-## Status: runnable (manual replenishment, no Pulse)
+## Learning objective
 
-Complete the first shift without provider tokens:
+Run a Zero-Employee Organization through one complete piece of work, and learn
+that `ACCEPTED` is a **claim the system proved**, not a status string someone
+felt like printing.
+
+It is fine if this chapter feels like magic. Chapters 1 to 3 take the magic
+apart. What matters here is that you see the whole shape once.
+
+## The exercise
 
 ```bash
 sovereign-agent doctor
 sovereign-agent demo store --mode simulated --root /tmp/andrea-shift
 ```
 
-You should see `outcome ACCEPTED`.
+No API keys. No network. No provider subscription. `doctor` will tell you which
+provider CLIs you happen to have installed, and the demo does not need any of
+them: it uses the `scripted` provider, which is a deterministic fixture.
 
-The path is:
+## What the organization did
 
 ```text
-sale → inventory signal persisted → manually dispatched replenishment SOW
-→ Scripted Operator → evidence → Sparring → acceptance
+a customer buys 2 boxes of tea
+  → inventory drops to 2, below the reorder point of 3
+  → the organization records a durable signal: "stock is low"
+  → the Principal's outcome says: keep the tea jar stocked
+  → a Master writes a SOW and assigns it to an Operator actor
+  → the Operator's provider PROPOSES restocking 6 boxes
+  → deterministic Python VALIDATES the proposal and commits the purchase
+  → inventory, cash, and the event all commit together, or not at all
+  → a Verifier runs the acceptance checks and records evidence
+  → Sparring reviews the work (a different actor than the one who did it)
+  → the Principal accepts
 ```
 
-Pulse is not part of this chapter. The organization does not wake itself yet;
-the demo dispatches the replenishment SOW explicitly. Proactive wake behavior
-arrives in Chapter 7 / Unit 9.
+## Expected observations
 
-Inspect:
+You should see:
 
-- `governance/outcomes/*/outcome.json` and `README.md`
-- `.sovereign/organization.db`
-- `.sovereign/runs/*/.sovereign-out/report.json`
+```text
+out_...  ACCEPTED  Keep the tea jar stocked
+  sow_...  ACCEPTED  Manually dispatched replenishment after signal sig_...
+outcome ACCEPTED
+```
+
+Now confirm the organization is telling the truth.
+
+```bash
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "SELECT sku, on_hand, reorder_point FROM inventory;"
+```
+
+Expected: `SKU-TEA|8|3`. On-hand is **at or above** the reorder point. The tea
+jar is genuinely full.
+
+```bash
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "SELECT id, amount_cents FROM cash_entries;"
+```
+
+Expected: three rows — an opening balance of `10000`, a sale of `+800`, and a
+purchase of `-720`. Money left the organization to buy the stock. Six boxes at
+120 cents each is exactly 720.
+
+```bash
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "SELECT kind FROM events ORDER BY seq;"
+```
+
+Expected: a `replenishment.committed` event sitting between
+`assignment.finished` and `sow.reviewed`.
+
+## Learner verification command
+
+One command that checks all of it at once:
+
+```bash
+python scripts/verify_store_outcome.py /tmp/andrea-shift
+```
+
+It exits 0 only if the accepted outcome is actually true. Try breaking it:
+
+```bash
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA';"
+python scripts/verify_store_outcome.py /tmp/andrea-shift
+```
+
+Now it fails, and says why. The status field still reads `ACCEPTED`, because
+that is a historical record of a decision — but the verifier checks the *world*,
+and the world no longer matches. That gap is the whole subject of this book.
+
+## Why this is not a toy
+
+An earlier version of this exact demo printed `ACCEPTED` while the tea jar sat
+at 2 boxes against a reorder point of 3. Every governance record existed —
+outcome, SOW, assignment, review, acceptance — and the shelf was still empty.
+The paperwork was perfect and the claim was false.
+
+That is the failure this book is about. An organization that cannot tell you
+the difference between "we did the work" and "we filed the forms" will
+confidently tell you the forms are the work.
+
+## Explain it back
+
+Answer these in your own words before moving on. If you cannot, re-read the
+observations above — the answers are all visible in the database.
+
+1. The demo printed `ACCEPTED`. What would you check, and in what order, to
+   decide for yourself whether that word is earned?
+2. The provider asked for 6 boxes. Where did the *price* of those boxes come
+   from — the provider, or somewhere else? Why does that distinction matter?
+3. `sparring-course` reviewed the work and `principal-human` accepted it. Why
+   not let `operator-course`, who did the work, do either of those?
+4. Which of these is a fact about the world, and which is a fact about the
+   process: "inventory is at 8" versus "the SOW is in state ACCEPTED"?
+
+## Where to look next
+
+- `governance/outcomes/*/outcome.json` — the outcome, projected for reading
+- `governance/outcomes/*/README.md` — the same thing, generated for humans
+- `.sovereign/organization.db` — the authority for everything operational
+- `.sovereign/runs/*/.sovereign-out/report.json` — what the provider proposed
+- `.sovereign/runs/*/receipt.json` — what the organization recorded about the run
 
 `solution.py` imports the production demo rather than copying it.
+
+Next: [Chapter 1 — The organization remembers](../ch01_organization_remembers/README.md)

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -106,10 +106,21 @@ import tempfile, pathlib
 from unittest.mock import patch
 import reference_organizations.store as store
 from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.models import Role
 from sovereign_agent.organization import Organization
 
 org = Organization.init(pathlib.Path(tempfile.mkdtemp()))
 seed(org.db)
+
+# An effect needs a real completed assignment behind it. Chapter 2 explains why.
+outcome = org.create_outcome(
+    "Keep the tea jar stocked", "stocked",
+    ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA")
+org.activate(outcome.id, "master-course")
+sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
+org.ready_sow(sow.id)
+assignment = org.run_assignment(org.assign(sow.id, "operator-course", "master-course").id)
+
 signal = record_sale(org.db, "SKU-TEA", 2, 400)
 
 def state():
@@ -122,7 +133,7 @@ def state():
 print("before: ", state())
 with patch.object(store, "append_event", side_effect=RuntimeError("power cut")):
     try:
-        apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_demo", signal.id)
+        apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment.id, signal.id)
     except RuntimeError as error:
         print("failed: ", error)
 print("after:  ", state())

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -1,0 +1,175 @@
+# Chapter 1 — The organization remembers
+
+## Learning objective
+
+Understand where a Zero-Employee Organization keeps its memory, why some of that
+memory is allowed to change and some is not, and what a transaction actually
+buys you.
+
+By the end you should be able to say, for any piece of data in this system,
+**which file or table is the authority for it** — and defend the answer.
+
+## Why memory is the first hard problem
+
+An organization that forgets cannot be held to anything. If the tea order can
+vanish because a process died halfway through, then "we ordered the tea" is a
+hope, not a fact.
+
+So the first question is not "how does the AI decide" — it is "where does the
+truth live, and what happens when the power goes out mid-sentence".
+
+## Exercise 1: look at the operational state
+
+```bash
+sovereign-agent demo store --mode simulated --root /tmp/andrea-memory
+sqlite3 /tmp/andrea-memory/.sovereign/organization.db ".tables"
+```
+
+Expected: sixteen tables listed. The ones to care about now:
+
+| Table | Holds |
+| --- | --- |
+| `inventory` | how much stock exists, and the reorder point |
+| `cash_entries` | every movement of money, as signed amounts |
+| `events` | an append-only history of what happened |
+| `signals` | durable "something needs attention" facts |
+| `schema_migrations` | which schema versions have been applied |
+
+```bash
+sqlite3 -header -column /tmp/andrea-memory/.sovereign/organization.db \
+  "SELECT * FROM inventory; SELECT id, amount_cents FROM cash_entries;"
+```
+
+Cash is a **ledger of movements**, not a single balance field. The balance is
+`SUM(amount_cents)`: `10000` opening, `+800` from the sale, `-720` for the
+purchase. Nothing overwrites a balance, so nothing can quietly lose money.
+
+## Exercise 2: prove the events are append-only
+
+The event log is the organization's memory of what it did. Try to rewrite it.
+
+```bash
+sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+  "UPDATE events SET kind='NOTHING_HAPPENED' WHERE kind='sale.committed';"
+```
+
+Expected:
+
+```text
+Error: stepping, events are append-only: update refused (19)
+```
+
+Now try deleting:
+
+```bash
+sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+  "DELETE FROM events WHERE kind='replenishment.committed';"
+```
+
+Also refused. This is enforced by **database triggers**, not by Python being
+careful. That distinction matters: a rule enforced in application code protects
+you from bugs, but a rule enforced in the database protects you from *everything
+else that can reach the database* — including you, at 2am, with a REPL open.
+
+## Exercise 3: watch a transaction roll back
+
+A restock has to change three things: inventory goes up, cash goes down, and an
+event records it. If only some of those happen, the organization is lying to
+itself.
+
+```bash
+python - <<'PY'
+import tempfile, pathlib
+from unittest.mock import patch
+import reference_organizations.store as store
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.organization import Organization
+
+org = Organization.init(pathlib.Path(tempfile.mkdtemp()))
+seed(org.db)
+signal = record_sale(org.db, "SKU-TEA", 2, 400)
+
+def state():
+    on_hand = org.db.connection.execute(
+        "SELECT on_hand FROM inventory WHERE sku='SKU-TEA'").fetchone()["on_hand"]
+    cash = org.db.connection.execute(
+        "SELECT COUNT(*) c FROM cash_entries WHERE amount_cents<0").fetchone()["c"]
+    return f"on_hand={on_hand} purchase_entries={cash}"
+
+print("before: ", state())
+with patch.object(store, "append_event", side_effect=RuntimeError("power cut")):
+    try:
+        apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_demo", signal.id)
+    except RuntimeError as error:
+        print("failed: ", error)
+print("after:  ", state())
+PY
+```
+
+Expected: `before` and `after` are identical. The failure was injected *after*
+inventory had already been written — and the rollback took it back. Either all
+three changes happen, or none do.
+
+## Exercise 4: find the boundary between governance and operations
+
+```bash
+sovereign-agent demo store --mode simulated --root /tmp/andrea-boundary
+cat /tmp/andrea-boundary/sovereign.toml
+ls /tmp/andrea-boundary/governance/outcomes/*/
+```
+
+Two kinds of file, and they behave differently:
+
+- **`sovereign.toml`** is read every time the organization opens. Edit an actor's
+  `provider = ` line, reopen, and the change takes effect. It is *canonical*.
+- **`governance/outcomes/*/outcome.json` and `README.md`** are written and never
+  read back. Delete the whole `governance/` directory and the organization keeps
+  working perfectly. They are *projections*.
+
+Try it:
+
+```bash
+python -c "
+import shutil, sys; sys.path.insert(0,'src')
+shutil.rmtree('/tmp/andrea-boundary/governance')
+from sovereign_agent.organization import Organization
+o = Organization('/tmp/andrea-boundary')
+print(o.status_text(o.db.connection.execute('select id from outcomes').fetchone()['id']))
+"
+```
+
+It still prints the outcome. Nothing was lost, because SQLite held the truth.
+
+Markdown is one step further out: it is generated for *humans* and is never
+authoritative for anything. If it disagrees with the database, the database is
+right and the Markdown is stale.
+
+The full boundary — and the one thing this design cannot honestly promise — is
+written up in [docs/persistence-boundary.md](../../docs/persistence-boundary.md).
+Read the section titled "The limit you must not lie about".
+
+## Learner verification command
+
+```bash
+python -m pytest tests/test_persistence.py -q
+```
+
+Expected: all tests pass. They prove rollback, append-only enforcement,
+migrations applying in order, and a v1 database upgrading to v2 without losing
+its history.
+
+## Explain it back
+
+1. Cash is stored as a list of signed movements instead of one balance number.
+   Name one specific bug that choice makes impossible.
+2. The event triggers refuse `UPDATE` and `DELETE`. Why enforce that in SQLite
+   instead of just not writing such code?
+3. You delete `governance/` and nothing breaks. You delete
+   `.sovereign/organization.db` and everything is gone. Explain the difference
+   in one sentence.
+4. A restock fails after inventory is written but before the event. What does
+   the shelf look like afterwards, and why?
+5. The docs say SQLite and the filesystem cannot be updated in one transaction.
+   Describe a state the organization can end up in because of that.
+
+Next: [Chapter 2 — Work needs governance](../ch02_work_needs_governance/README.md)

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -66,10 +66,33 @@ sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
   "DELETE FROM events WHERE kind='replenishment.committed';"
 ```
 
-Also refused. This is enforced by **database triggers**, not by Python being
-careful. That distinction matters: a rule enforced in application code protects
-you from bugs, but a rule enforced in the database protects you from *everything
-else that can reach the database* — including you, at 2am, with a REPL open.
+Also refused. Now try the sneaky third variant — overwriting a row instead of
+editing it:
+
+```bash
+sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+  "INSERT OR REPLACE INTO events(id,kind,payload,created_at)
+   SELECT id,'NOTHING_HAPPENED',payload,created_at FROM events LIMIT 1;"
+```
+
+Also refused: `events are append-only: replace refused`.
+
+All three are enforced by **database triggers**, not by Python being careful.
+That distinction matters: a rule enforced in application code protects you from
+bugs, but a rule enforced in the database protects you from *everything else
+that can reach the database* — including you, at 2am, with a REPL open.
+
+That third case is worth dwelling on, because getting it right took two
+attempts. The first version of this guard relied on a SQLite setting called
+`recursive_triggers`, which the application switched on when it opened the
+database. It worked perfectly — from the application. From the `sqlite3` command
+above, the one this chapter just told you to use, the overwrite **succeeded
+silently** and the row count did not change. The lesson claimed the database
+enforced the rule while the guarantee actually lived in Python.
+
+The fix is the guard you just triggered: a `BEFORE INSERT` trigger that refuses
+an id which already exists. It needs no setting, so it holds from any client.
+Enforcement now matches the claim — which is the entire subject of Chapter 2.
 
 ## Exercise 3: watch a transaction roll back
 

--- a/book/ch01_organization_remembers/solution.py
+++ b/book/ch01_organization_remembers/solution.py
@@ -1,0 +1,88 @@
+"""Chapter 1: where the organization keeps its memory.
+
+Imports the production package. Nothing here reimplements storage — the point of
+the exercise is to observe the real ledger, not a teaching replica of one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import reference_organizations.store as store
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.organization import Organization
+
+
+def observe_memory(root: Path) -> dict[str, Any]:
+    """Show operational state, then prove a failed restock leaves no trace."""
+    org = Organization.init(root)
+    seed(org.db)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+
+    def snapshot() -> dict[str, int]:
+        inventory = org.db.connection.execute(
+            "SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'"
+        ).fetchone()
+        purchases = org.db.connection.execute(
+            "SELECT COUNT(*) AS c FROM cash_entries WHERE amount_cents < 0"
+        ).fetchone()
+        events = org.db.connection.execute(
+            "SELECT COUNT(*) AS c FROM events WHERE kind = 'replenishment.committed'"
+        ).fetchone()
+        return {
+            "on_hand": int(inventory["on_hand"]),
+            "purchase_entries": int(purchases["c"]),
+            "replenishment_events": int(events["c"]),
+        }
+
+    before = snapshot()
+    rollback_error = ""
+    with patch.object(store, "append_event", side_effect=RuntimeError("injected power cut")):
+        try:
+            apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_ch1", signal.id)
+        except RuntimeError as error:
+            rollback_error = str(error)
+    after_rollback = snapshot()
+
+    committed = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_ch1", signal.id)
+    after_success = snapshot()
+
+    append_only: dict[str, str] = {}
+    for label, statement in (
+        ("update", "UPDATE events SET kind = 'TAMPERED'"),
+        ("delete", "DELETE FROM events"),
+    ):
+        try:
+            org.db.connection.execute(statement)
+            append_only[label] = "ALLOWED (this would be a bug)"
+        except Exception as error:  # noqa: BLE001 - we are demonstrating the refusal
+            org.db.connection.rollback()
+            append_only[label] = f"refused: {error}"
+
+    return {
+        "before_failed_restock": before,
+        "rollback_error": rollback_error,
+        "after_rollback": after_rollback,
+        "nothing_survived_rollback": before == after_rollback,
+        "after_successful_restock": after_success,
+        "cash_balance_cents": store.cash_balance_cents(org.db),
+        "purchase_total_cents": committed["total_cost_cents"],
+        "append_only_enforcement": append_only,
+        "schema_versions": sorted(org.db.applied_versions()),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+    print(json.dumps(observe_memory(args.root), indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/book/ch01_organization_remembers/solution.py
+++ b/book/ch01_organization_remembers/solution.py
@@ -14,13 +14,28 @@ from unittest.mock import patch
 
 import reference_organizations.store as store
 from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.models import Role
 from sovereign_agent.organization import Organization
 
 
 def observe_memory(root: Path) -> dict[str, Any]:
     """Show operational state, then prove a failed restock leaves no trace."""
+    # An effect needs a real, completed, authorized assignment behind it: the
+    # organization refuses to change the world on the say-so of an id nobody
+    # issued. Chapter 2 explains why; here we just need a legitimate one.
     org = Organization.init(root)
     seed(org.db)
+    outcome = org.create_outcome(
+        "Keep the tea jar stocked",
+        "On-hand tea stays at or above the reorder point.",
+        ["inventory_at_or_above_reorder_point"],
+        "principal-human",
+        "SKU-TEA",
+    )
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    assignment = org.run_assignment(org.assign(sow.id, "operator-course", "master-course").id)
     signal = record_sale(org.db, "SKU-TEA", 2, 400)
 
     def snapshot() -> dict[str, int]:
@@ -43,12 +58,12 @@ def observe_memory(root: Path) -> dict[str, Any]:
     rollback_error = ""
     with patch.object(store, "append_event", side_effect=RuntimeError("injected power cut")):
         try:
-            apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_ch1", signal.id)
+            apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment.id, signal.id)
         except RuntimeError as error:
             rollback_error = str(error)
     after_rollback = snapshot()
 
-    committed = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_ch1", signal.id)
+    committed = apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment.id, signal.id)
     after_success = snapshot()
 
     append_only: dict[str, str] = {}

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -168,7 +168,32 @@ status field and run no checks at all — a verification step that verified
 nothing. Now it executes every declared check, and an unknown or crashing check
 **fails closed** rather than being skipped.
 
-## Exercise 6: being refused is not the end
+## Exercise 6: the proof itself cannot be rewritten
+
+Chapter 1 showed that `events` refuses `UPDATE` and `DELETE`. The same guarantee
+now covers every table acceptance reads as proof — `effects`, `verifications`,
+`reviews`, `evidence`:
+
+```bash
+sqlite3 /tmp/andrea-gov/.sovereign/organization.db \
+  "UPDATE evidence SET success = 1;"
+```
+
+Expected: `Error: stepping, evidence are append-only: update refused`.
+
+This was not always true, and the story is worth knowing. Append-only was added
+to `events` because acceptance rested on events. Then acceptance came to rest on
+evidence, reviews, verifications and effects — and the guards stayed where they
+were. For a while the tables carrying the proof were the ones with no
+protection, while the table they replaced was still immune. A reviewer put it
+exactly: *the guarantee stayed put while the load moved.*
+
+One thing append-only cannot do is stop a forged **append**: inserting is
+precisely what it permits. So an effect must also be corroborated by the event
+committed alongside it. An effect with no matching event is not a record of
+anything that happened.
+
+## Exercise 7: being refused is not the end
 
 Chapter 2 has spent five exercises showing the organization refusing things. A
 fair question: what happens to work that gets refused? Is it dead?
@@ -230,6 +255,10 @@ above, and that authority cannot be self-granted.
    an execution; the other describes a fact about the world. Which is which?
 6. Recovery from `changes_requested` creates a *new* assignment rather than
    reusing the failed one. What would you lose if it reused it?
+7. `events` was append-only long before `evidence` was. Explain, in terms of
+   where the proof lives, why protecting only `events` stopped being enough.
+8. Append-only refuses rewriting a row but permits adding one. Why does that
+   make corroboration necessary, and what corroborates an effect?
 7. Acceptance requires a review of the **exact** verification batch it is
    accepting on. Describe the lie that would be possible if it accepted any
    review of the outcome instead.

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -76,7 +76,7 @@ org.db.connection.execute(
 org.db.connection.commit()
 
 try:
-    org.accept(outcome_id, "principal-human", "SKU-TEA")
+    org.accept(outcome_id, "principal-human")
     print("ACCEPTED  <-- this would be a bug")
 except Refusal as refusal:
     print("REFUSED:", str(refusal).splitlines()[0])

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -168,10 +168,49 @@ status field and run no checks at all — a verification step that verified
 nothing. Now it executes every declared check, and an unknown or crashing check
 **fails closed** rather than being skipped.
 
+## Exercise 6: being refused is not the end
+
+Chapter 2 has spent five exercises showing the organization refusing things. A
+fair question: what happens to work that gets refused? Is it dead?
+
+```bash
+python -m pytest tests/test_recovery.py -v
+```
+
+Read the test names. The cycle they prove is:
+
+```text
+verification fails
+  -> Sparring requests changes           (SOW state: CHANGES_REQUESTED)
+  -> the world is repaired
+  -> a NEW assignment is created         (SOW state: ASSIGNED)
+  -> verification runs again             (a new batch)
+  -> Sparring reviews the new batch      (accepted)
+  -> the Principal accepts
+```
+
+Two details worth pausing on.
+
+**Recovery creates a new assignment.** Repaired work is new work, and the ledger
+says so. The failed execution is not overwritten or reused — you can still read
+what went wrong the first time.
+
+**Nothing is deleted.** After recovery the database holds two verifications and
+two reviews, including the `changes_requested` one. The organization remembers
+being wrong. That is the difference between a system that learns and a system
+that launders its history.
+
+This path did not exist while this chapter was first written. `changes_requested`
+was terminal: the only way forward from a refusal was to delete the organization
+and start over. A book that teaches "refusal is the system working" while
+shipping a refusal you cannot recover from is teaching the opposite of what it
+says.
+
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_acceptance_falsification.py tests/test_actors_and_mailbox.py -q
+python -m pytest tests/test_acceptance_falsification.py tests/test_actors_and_mailbox.py \
+  tests/test_recovery.py -q
 ```
 
 Expected: all pass. Together they prove that acceptance refuses every lie listed
@@ -189,5 +228,10 @@ above, and that authority cannot be self-granted.
    one back would quietly disable no-self-approval.
 5. What is the difference between a **receipt** and **evidence**? One describes
    an execution; the other describes a fact about the world. Which is which?
+6. Recovery from `changes_requested` creates a *new* assignment rather than
+   reusing the failed one. What would you lose if it reused it?
+7. Acceptance requires a review of the **exact** verification batch it is
+   accepting on. Describe the lie that would be possible if it accepted any
+   review of the outcome instead.
 
 Next: [Chapter 3 — The actor is not a model](../ch03_actor_is_not_a_model/README.md)

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -1,0 +1,193 @@
+# Chapter 2 — Work needs governance
+
+## Learning objective
+
+Understand how a piece of work travels from "somebody wants this" to "this is
+done", and why every step in that journey exists. By the end you should be able
+to explain what makes `ACCEPTED` mean something — and to break it on purpose.
+
+Chapter 1 was about memory. This chapter is about **judgement**: who is allowed
+to decide what, and what has to be true before a decision sticks.
+
+## The vocabulary, in the order the work moves
+
+| Word | What it is |
+| --- | --- |
+| **Outcome** | The state of the world someone wants. "The tea jar stays stocked." |
+| **Acceptance check** | A deterministic question that decides whether the outcome is true. |
+| **SOW** | A statement of work: scope, non-goals, deliverables, done-when. |
+| **Assignment** | One actor bound to one SOW, with a workspace. |
+| **Receipt** | The durable record of an execution: who ran, how it ended. |
+| **Evidence** | The record of a check having been run, bound to what it proves. |
+| **Verification** | Actually executing the declared checks. |
+| **Review** | A different actor reading the work. |
+| **Acceptance** | The Principal declaring the outcome true — if it survives proof. |
+| **Ruling** | A recorded decision that changes the rules. |
+
+## Exercise 1: follow one outcome through the whole chain
+
+```bash
+sovereign-agent demo store --mode simulated --root /tmp/andrea-gov
+DB=/tmp/andrea-gov/.sovereign/organization.db
+
+sqlite3 -header -column "$DB" \
+  "SELECT json_extract(record,'$.title') AS title,
+          json_extract(record,'$.state') AS state,
+          json_extract(record,'$.acceptance_checks') AS checks
+   FROM outcomes;"
+```
+
+The outcome declares **three** acceptance checks. Note that the outcome declares
+them — not the provider, and not the operator who does the work. The thing being
+judged does not get to choose its own judges.
+
+```bash
+sqlite3 -header -column "$DB" \
+  "SELECT check_id, success, substr(outcome_id,1,20) AS outcome,
+          substr(assignment_id,1,20) AS execution
+   FROM evidence;"
+```
+
+Three evidence rows, one per declared check. Each one records *which question*
+was asked, *about which outcome*, and *during which execution*. That binding is
+the difference between evidence and a filename.
+
+## Exercise 2: try to accept something that is not true
+
+This is the important exercise. Governance is only real if it refuses.
+
+```bash
+python - <<'PY'
+import pathlib, tempfile
+from reference_organizations.store.demo import run_simulated
+from sovereign_agent.organization import Organization
+from sovereign_agent.errors import Refusal
+
+root = pathlib.Path(tempfile.mkdtemp())
+run_simulated(root)
+org = Organization(root)
+outcome_id = org.db.connection.execute("SELECT id FROM outcomes").fetchone()["id"]
+
+# Empty the shelf, then re-open the outcome and try to accept it again.
+org.db.connection.execute("UPDATE inventory SET on_hand=0 WHERE sku='SKU-TEA'")
+org.db.connection.execute(
+    "UPDATE outcomes SET record=json_set(record,'$.state','VERIFYING') WHERE id=?",
+    (outcome_id,))
+org.db.connection.commit()
+
+try:
+    org.accept(outcome_id, "principal-human", "SKU-TEA")
+    print("ACCEPTED  <-- this would be a bug")
+except Refusal as refusal:
+    print("REFUSED:", str(refusal).splitlines()[0])
+PY
+```
+
+Expected: a refusal naming `inventory_at_or_above_reorder_point`. Acceptance
+**re-runs the checks against the world at the moment of acceptance**. It does
+not trust that they passed earlier.
+
+That last sentence is the entire lesson of this chapter, and it was learned the
+hard way: an earlier version of this system accepted an outcome by checking that
+someone had handed it a non-empty list of evidence IDs. The IDs were never
+looked up. You could accept with `["evd_i_just_made_this_up"]`.
+
+## Exercise 3: try the other ways of lying
+
+Each of these is refused for a different reason. Run the suite that proves it:
+
+```bash
+python -m pytest tests/test_acceptance_falsification.py -v
+```
+
+Read the test names. They are the list of lies this system knows how to catch:
+
+- evidence that does not exist (refused by a **foreign key**, in the database)
+- evidence that reports failure
+- evidence for a different outcome
+- evidence from a different execution
+- evidence that is **stale** — true when written, but the world moved since
+- a declared check with no evidence at all
+- an outcome with no SOW
+- the operator trying to accept its own work
+- a malformed provider report
+- a proposal outside its allowed bounds
+
+## Exercise 4: no self-approval
+
+```bash
+python -c "
+from sovereign_agent.policy import forbid_self_approval
+from sovereign_agent.errors import Refusal
+try:
+    forbid_self_approval('operator-course','operator-course')
+except Refusal as r:
+    print('REFUSED:', str(r).splitlines()[0])
+"
+```
+
+Three different actors touch the store outcome, and none of them can do another's
+job:
+
+- `operator-course` does the work.
+- `sparring-course` reviews it.
+- `principal-human` accepts it.
+
+`accept()` does not take a "who performed this" argument. It **derives** the
+performers from the assignments in the ledger, then refuses if the accepter is
+among them. If the caller could name the performer, the caller could name a
+convenient stranger, and the separation would be decoration.
+
+## Exercise 5: watch verification actually run
+
+```bash
+python -c "
+import tempfile, pathlib
+from reference_organizations.store.demo import run_simulated
+from sovereign_agent.organization import Organization
+from sovereign_agent.checks import run_check
+root = pathlib.Path(tempfile.mkdtemp()); run_simulated(root)
+org = Organization(root)
+oid = org.db.connection.execute('SELECT id FROM outcomes').fetchone()['id']
+for check_id in org._outcome(oid).acceptance_checks:
+    r = run_check(org.db, check_id, 'SKU-TEA')
+    print(f'{r.check_id}: {\"PASS\" if r.success else \"FAIL\"} - {r.detail}')
+"
+```
+
+Expected:
+
+```text
+inventory_at_or_above_reorder_point: PASS - on_hand=8 vs reorder_point=3
+cash_reconciles: PASS - 1 purchase entr(y/ies) reconcile
+replenishment_event_exists: PASS - 1 replenishment event(s) for SKU-TEA
+```
+
+Each check reports the facts it observed. `verify_outcome` used to change a
+status field and run no checks at all — a verification step that verified
+nothing. Now it executes every declared check, and an unknown or crashing check
+**fails closed** rather than being skipped.
+
+## Learner verification command
+
+```bash
+python -m pytest tests/test_acceptance_falsification.py tests/test_actors_and_mailbox.py -q
+```
+
+Expected: all pass. Together they prove that acceptance refuses every lie listed
+above, and that authority cannot be self-granted.
+
+## Explain it back
+
+1. An outcome declares its acceptance checks. Why is it dangerous to let the
+   actor doing the work declare them instead?
+2. Evidence records a check id, an outcome id, and an execution id. Remove any
+   one of those three. What lie becomes possible?
+3. "Stale evidence" is refused even when the check would still pass today.
+   Why bother refusing something that is still true?
+4. `accept()` deliberately has no `performer_id` parameter. Explain why adding
+   one back would quietly disable no-self-approval.
+5. What is the difference between a **receipt** and **evidence**? One describes
+   an execution; the other describes a fact about the world. Which is which?
+
+Next: [Chapter 3 — The actor is not a model](../ch03_actor_is_not_a_model/README.md)

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -189,9 +189,28 @@ protection, while the table they replaced was still immune. A reviewer put it
 exactly: *the guarantee stayed put while the load moved.*
 
 One thing append-only cannot do is stop a forged **append**: inserting is
-precisely what it permits. So an effect must also be corroborated by the event
-committed alongside it. An effect with no matching event is not a record of
-anything that happened.
+precisely what it permits. An effect is therefore cross-checked against the
+event committed alongside it, and an effect with no matching event is an
+incomplete record.
+
+Now the part that matters more, because it is where most systems overclaim.
+That cross-check detects **inconsistency**. It does not prove **authenticity**.
+Someone who can write arbitrary rows can append an effect *and* its matching
+event — two rows that agree with each other and are both invented. The
+organization will accept them.
+
+That is not a hole to be plugged with a third table. Every check you can write
+inside the database constrains what the *code* does, and an attacker with a
+database handle is not the code. Proving authenticity needs something the
+database does not hold — a signature key kept outside it — which is a different
+subject and out of scope here.
+
+So the honest statement, which
+[the ruling](../../docs/rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md)
+records: **anyone who can write arbitrary rows can rewrite the organization's
+memory.** Everything in this chapter protects the ledger from mistakes and
+ordinary tools. Knowing exactly which door is open is worth more than believing
+they are all shut.
 
 ## Exercise 7: being refused is not the end
 

--- a/book/ch02_work_needs_governance/solution.py
+++ b/book/ch02_work_needs_governance/solution.py
@@ -1,0 +1,112 @@
+"""Chapter 2: what makes ACCEPTED mean something.
+
+Runs the production governed loop, then attempts to accept several false claims
+and records how each one is refused. Imports the production package throughout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from reference_organizations.store.demo import run_simulated
+from sovereign_agent.checks import run_check
+from sovereign_agent.errors import Refusal
+from sovereign_agent.organization import Organization
+
+SKU = "SKU-TEA"
+
+
+def _reopen(org: Organization, outcome_id: str) -> None:
+    org.db.connection.execute(
+        "UPDATE outcomes SET record = json_set(record, '$.state', 'VERIFYING') WHERE id = ?",
+        (outcome_id,),
+    )
+    org.db.connection.commit()
+
+
+def _attempt(org: Organization, outcome_id: str, accepter: str = "principal-human") -> str:
+    _reopen(org, outcome_id)
+    try:
+        org.accept(outcome_id, accepter, SKU)
+    except Refusal as refusal:
+        return f"refused: {str(refusal).splitlines()[0]}"
+    return "ACCEPTED (this would be a bug)"
+
+
+def explore_governance(root: Path) -> dict[str, Any]:
+    run_simulated(root)
+    org = Organization(root)
+    outcome_id = str(org.db.connection.execute("SELECT id FROM outcomes").fetchone()["id"])
+    outcome = org._outcome(outcome_id)  # noqa: SLF001
+
+    checks_now = {
+        check_id: run_check(org.db, check_id, SKU).detail for check_id in outcome.acceptance_checks
+    }
+    evidence = [
+        {
+            "check_id": row["check_id"],
+            "success": bool(row["success"]),
+            "bound_to_outcome": str(row["outcome_id"]) == outcome_id,
+        }
+        for row in org.db.connection.execute(
+            "SELECT check_id, success, outcome_id FROM evidence WHERE outcome_id = ?",
+            (outcome_id,),
+        )
+    ]
+
+    refusals: dict[str, str] = {}
+
+    # The operator who did the work cannot accept it.
+    refusals["operator_self_approval"] = _attempt(org, outcome_id, "operator-course")
+
+    # Evidence that reports failure is a record of a problem, not a permission.
+    org.db.connection.execute("UPDATE evidence SET success = 0")
+    org.db.connection.commit()
+    refusals["failed_evidence"] = _attempt(org, outcome_id)
+    org.db.connection.execute("UPDATE evidence SET success = 1")
+    org.db.connection.commit()
+
+    # A declared check with no evidence at all.
+    removed = org.db.connection.execute(
+        "SELECT id, assignment_id, record, outcome_id, check_id, success, state_digest "
+        "FROM evidence WHERE check_id = 'cash_reconciles'"
+    ).fetchall()
+    org.db.connection.execute("DELETE FROM evidence WHERE check_id = 'cash_reconciles'")
+    org.db.connection.commit()
+    refusals["missing_evidence"] = _attempt(org, outcome_id)
+    for row in removed:
+        org.db.connection.execute(
+            "INSERT INTO evidence(id, assignment_id, record, outcome_id, check_id, "
+            "success, state_digest) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            tuple(row),
+        )
+    org.db.connection.commit()
+
+    # The world moves after verification: the claim itself becomes false.
+    org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = ?", (SKU,))
+    org.db.connection.commit()
+    refusals["outcome_no_longer_true"] = _attempt(org, outcome_id)
+
+    return {
+        "outcome": outcome.title,
+        "declared_checks": outcome.acceptance_checks,
+        "checks_when_accepted": checks_now,
+        "evidence": evidence,
+        "performers_derived_from_ledger": sorted(org.performers_for(outcome_id)),
+        "refusals": refusals,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+    print(json.dumps(explore_governance(args.root), indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/book/ch02_work_needs_governance/solution.py
+++ b/book/ch02_work_needs_governance/solution.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -62,28 +63,21 @@ def explore_governance(root: Path) -> dict[str, Any]:
     # The operator who did the work cannot accept it.
     refusals["operator_self_approval"] = _attempt(org, outcome_id, "operator-course")
 
-    # Evidence that reports failure is a record of a problem, not a permission.
-    org.db.connection.execute("UPDATE evidence SET success = 0")
-    org.db.connection.commit()
-    refusals["failed_evidence"] = _attempt(org, outcome_id)
-    org.db.connection.execute("UPDATE evidence SET success = 1")
-    org.db.connection.commit()
-
-    # A declared check with no evidence at all.
-    removed = org.db.connection.execute(
-        "SELECT id, assignment_id, record, outcome_id, check_id, success, state_digest "
-        "FROM evidence WHERE check_id = 'cash_reconciles'"
-    ).fetchall()
-    org.db.connection.execute("DELETE FROM evidence WHERE check_id = 'cash_reconciles'")
-    org.db.connection.commit()
-    refusals["missing_evidence"] = _attempt(org, outcome_id)
-    for row in removed:
-        org.db.connection.execute(
-            "INSERT INTO evidence(id, assignment_id, record, outcome_id, check_id, "
-            "success, state_digest) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            tuple(row),
-        )
-    org.db.connection.commit()
+    # Evidence cannot be rewritten at all: proof-bearing tables are append-only
+    # at the database boundary, so the tamper is refused before acceptance is
+    # ever consulted. That is a stronger guarantee than "acceptance notices".
+    for statement in (
+        "UPDATE evidence SET success = 0",
+        "DELETE FROM evidence WHERE check_id = 'cash_reconciles'",
+        "UPDATE reviews SET decision = 'changes_requested'",
+    ):
+        try:
+            org.db.connection.execute(statement)
+            org.db.connection.commit()
+            refusals[statement.split()[1].lower()] = "ALLOWED (this would be a bug)"
+        except sqlite3.IntegrityError as error:
+            org.db.connection.rollback()
+            refusals[f"tamper_{statement.split()[1].lower()}"] = f"refused: {error}"
 
     # The world moves after verification: the claim itself becomes false.
     org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = ?", (SKU,))

--- a/book/ch02_work_needs_governance/solution.py
+++ b/book/ch02_work_needs_governance/solution.py
@@ -30,7 +30,7 @@ def _reopen(org: Organization, outcome_id: str) -> None:
 def _attempt(org: Organization, outcome_id: str, accepter: str = "principal-human") -> str:
     _reopen(org, outcome_id)
     try:
-        org.accept(outcome_id, accepter, SKU)
+        org.accept(outcome_id, accepter)
     except Refusal as refusal:
         return f"refused: {str(refusal).splitlines()[0]}"
     return "ACCEPTED (this would be a bug)"

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -1,6 +1,9 @@
 # Chapter 3 — The actor is not a model
 
-## Andrea's goal
+## Learning objective
+
+Understand why swapping the intelligence behind an actor does not change who is
+accountable — and why a provider therefore cannot approve its own work.
 
 An **actor** is a governed identity with a role and authority. A **provider**
 is an external intelligence CLI: `scripted`, `claude`, `codex`, or `cursor`.
@@ -32,6 +35,52 @@ The provider receives one production-built assignment envelope containing the
 actor, authority, SOW, disposable workspace boundary, output paths, and exact
 `ActorReport` schema. The adapter only translates that envelope into its CLI.
 
+## Expected observations
+
+Running the exercise prints a JSON summary. The line that matters:
+
+```text
+"identity_unchanged": true
+```
+
+Before and after the rebind, `operator-course` keeps the same id, the same
+role, and the same authority list. Only `provider` changes — from `scripted`
+to `claude`, `codex`, or `cursor`.
+
+Confirm the governed record of the change:
+
+```bash
+sqlite3 /tmp/andrea-ch03/.sovereign/organization.db \
+  "SELECT kind FROM events WHERE kind = 'actor.provider_rebound';"
+```
+
+Expected: one row. Rebinding is an act the organization records, performed by an
+actor with ruling authority — not a config edit that happens quietly.
+
+If a live CLI is missing or cannot prove its required flags, you will see a
+refusal instead of a run. That is the correct outcome: capability claims come
+from probing the installed CLI, and an unprovable capability fails closed.
+
+## Why a provider cannot approve its own work
+
+The provider that proposed the restock in Chapter 0 runs *behind*
+`operator-course`. Acceptance is refused for every actor that performed work,
+and performers are derived from the assignments in the ledger — not supplied by
+the caller. So the intelligence that did the work cannot become the authority
+that blesses it, no matter which model is bound to the actor.
+
+Swap `claude` for `codex` and the governance does not move. That is the point.
+
+## Learner verification command
+
+```bash
+python -m pytest tests/test_actors_and_mailbox.py tests/test_providers.py -q
+```
+
+Expected: all pass. These prove actor identity survives a provider rebind, that
+authority cannot be self-granted, and that adapters build argument arrays rather
+than shell strings.
+
 ## Isolation warning
 
 `--workspace` selects a directory; it is not a sandbox. Cursor's CLI has file
@@ -50,7 +99,7 @@ The same authority becomes Claude `--permission-mode acceptEdits` and Cursor
 CLI's help output. These flags authorize writes inside the disposable run
 workspace; they do not expand the actor's organizational authority.
 
-## Reflection
+## Explain it back
 
 1. Which fields stayed constant after rebinding the provider?
 2. Why is a provider session id evidence about continuity but not actor
@@ -60,6 +109,10 @@ workspace; they do not expand the actor's organizational authority.
 4. Why may an unknown valid event be retained while malformed JSON must fail
    the receipt?
 5. In your own words: what is the difference between an actor and a provider?
+6. `operator-course` is rebound from `scripted` to `claude`. Who is accountable
+   for the work afterwards, and how would you show that from the ledger?
+7. Why does deriving the performer from assignments — rather than accepting it
+   as an argument — matter for keeping a provider from approving itself?
 
 ## Production correspondence
 

--- a/docs/andrea-alpha-evaluation.md
+++ b/docs/andrea-alpha-evaluation.md
@@ -1,0 +1,184 @@
+# Andrea Alpha evaluation (Units 0–6.5)
+
+## Who Andrea is
+
+A master's student. Knows some Python. Has written scripts and notebooks, not
+production systems. Wants a path into data science or AI engineering. Has not
+run a service, debugged a transaction, or argued about governance.
+
+Andrea is not a proxy for "a beginner". Andrea is the specific person this book
+is written for, and a change that makes the system more elegant for an expert
+while making it opaque for Andrea is a regression.
+
+## What this evaluation scores
+
+**Truth and understanding — not memorization.** A session that can recite
+"evidence must be bound to an outcome" but cannot say *what breaks without it*
+has failed. A session that says "I think it's so you can't reuse a check from a
+different job" in imperfect words has passed.
+
+Score each task 0–2:
+
+- **2** — did it, and can explain why it matters
+- **1** — did it, explanation is shaky or partly wrong
+- **0** — could not complete, or the explanation is confidently wrong
+
+A confidently wrong answer scores below a hesitant right one. This book is about
+not believing your own paperwork.
+
+## Setup (evaluator, before the session)
+
+Use a machine with Python 3.14 and no Sovereign Agent state:
+
+```console
+python --version          # expect 3.14.x
+uv sync --all-groups
+```
+
+Do **not** pre-run the demo. Andrea should see a cold start.
+
+## Timing
+
+The commands themselves take about **1.3 seconds** of machine time end to end.
+The ten-minute budget is entirely Andrea's reading, typing, and thinking time.
+If Andrea exceeds ten minutes to a truthful accepted outcome, the blocker is the
+writing, not the software — record where the time went.
+
+## The tasks
+
+### 1. Enter the environment (target: 2 min)
+
+```console
+uv sync --all-groups
+sovereign-agent doctor
+```
+
+Pass: `doctor` reports Python and Pydantic OK, and lists which providers are
+installed. Andrea should notice that **no provider is required**.
+
+### 2. Reach a truthful accepted outcome (target: 3 min)
+
+```console
+sovereign-agent demo store --mode simulated --root /tmp/andrea-shift
+python scripts/verify_store_outcome.py /tmp/andrea-shift
+```
+
+Pass: `outcome ACCEPTED`, then `ACCEPTED and true: ...`.
+
+Ask: *"The demo said ACCEPTED. The second command said it was true. Why are
+those two different questions?"*
+
+Score 2 if Andrea says something like: the first is what the system recorded,
+the second checks the world.
+
+### 3. Locate the eight artifacts (target: 3 min)
+
+Andrea must find and say what each one is:
+
+| Artifact | Where |
+| --- | --- |
+| outcome | `governance/outcomes/*/outcome.json`, or the `outcomes` table |
+| SOW | `governance/outcomes/*/sows/*.json`, or the `sows` table |
+| assignment | `assignments` table |
+| receipt | `.sovereign/runs/*/receipt.json` |
+| evidence | `evidence` table |
+| inventory | `inventory` table |
+| cash entry | `cash_entries` table |
+| event history | `events` table |
+
+Score 2 only if Andrea can say **what each is for**, not just where it lives.
+
+### 4. Explain the four ideas (target: 4 min)
+
+Ask each. Record the answer verbatim; do not coach.
+
+1. *Why is an actor not a provider?*
+   Looking for: the actor is the accountable identity; the provider is
+   swappable intelligence. Rebinding the provider changes who does the thinking,
+   not who is answerable.
+
+2. *Why can the operator not approve its own work?*
+   Looking for: an actor that checks itself provides no independent evidence.
+   Bonus: `accept()` derives the performer from the ledger, so a caller cannot
+   nominate a convenient stranger.
+
+3. *Why is evidence more than a filename or an ID?*
+   Looking for: it must say which check, about which outcome, during which
+   execution, with what result, over what state. Bonus: an earlier version
+   accepted a made-up ID.
+
+4. *Which data is governance and which is operational?*
+   Looking for: `sovereign.toml` and rulings are committed governance and are
+   read back; inventory, cash, events, and execution state live in SQLite;
+   Markdown is generated and never authoritative.
+
+### 5. Change a reorder point and predict (target: 2 min)
+
+Before running anything, Andrea predicts what will happen:
+
+```console
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "UPDATE inventory SET reorder_point = 99 WHERE sku = 'SKU-TEA';"
+python scripts/verify_store_outcome.py /tmp/andrea-shift
+```
+
+Pass: Andrea predicts the verifier will now fail, and can say why — the world
+did not change, but the *standard* did, and the claim is judged against the
+standard as it is now.
+
+Score 2 if the prediction was made **before** running the command and was right.
+
+### 6. Diagnose a malformed provider report (target: 3 min)
+
+```console
+python -c "
+import pathlib, tempfile
+from reference_organizations.store.demo import propose_restock_from_report
+from sovereign_agent.errors import Refusal
+bad = pathlib.Path(tempfile.mkdtemp())/'report.json'
+bad.write_text('{not json')
+try:
+    propose_restock_from_report(bad, 'SKU-TEA')
+except Refusal as r:
+    print(r)
+"
+```
+
+Pass: Andrea reads the refusal and explains that a malformed report becomes a
+failure, never a guessed success. Ask the follow-up: *"What would be the
+dangerous alternative?"* Looking for: assuming the provider meant something
+reasonable and proceeding.
+
+### 7. Explain why the organization is still passive (target: 1 min)
+
+Ask: *"You ran a command and work happened. What has to be true for this to run
+without you?"*
+
+Pass: Andrea says the organization does not wake itself — something must call
+it. Proactive waking is Pulse, and Pulse does not exist yet (Unit 9). Score 0 if
+Andrea believes the system is already autonomous; that would mean the book
+oversold it.
+
+## Scoring
+
+Maximum 14 (seven tasks × 2).
+
+- **12–14** — Alpha passes. Andrea can reach and explain a truthful outcome.
+- **9–11** — Alpha passes with named gaps. Record which task scored low; that
+  chapter needs work.
+- **≤8** — Alpha fails. The book is not yet teaching what the code does.
+
+Record every wrong answer verbatim. A wrong answer is a bug report about the
+writing, not about Andrea.
+
+## Automated pre-check
+
+Before spending a human session, confirm the machine-checkable parts:
+
+```console
+python scripts/evaluate_andrea_alpha.py
+```
+
+It runs the cold-start path end to end and reports which tasks are
+machine-verifiable. It cannot score understanding — tasks 4 and 7 need a human
+reading the answers.

--- a/docs/persistence-boundary.md
+++ b/docs/persistence-boundary.md
@@ -148,6 +148,23 @@ introduced. It is the same statement in a different key: everything here
 protects the ledger from *mistakes and ordinary tools*, not from an actor with
 arbitrary write access to the database file.
 
+## Append-only guards reach the databases that ran their migration
+
+`APPEND_ONLY_TABLES` is a maintained list, not a discovery mechanism, and its
+guards arrive through migrations like any other schema change. That has one
+consequence worth stating rather than leaving to be discovered:
+
+**Adding a table to the list does not retro-guard existing databases.** A new
+proof-bearing table needs a NEW migration version. Editing an applied
+migration's body would guard fresh installs and silently skip every database
+that had already stamped that version — the same shape as every other defect on
+this line: a guarantee staying put while the load moves.
+
+`test_migration_12_content_is_frozen` enforces it, so the rule does not depend
+on anyone remembering it. `receipts` is deliberately outside the list —
+`put_serialized` rewrites a receipt in place while an assignment runs — and is
+guarded instead by requiring its canonical record and indexed columns to agree.
+
 ## How to see the drift for yourself
 
 ```console

--- a/docs/persistence-boundary.md
+++ b/docs/persistence-boundary.md
@@ -90,55 +90,63 @@ than disguised.
 
 ## A second limit: the ledger is inside the trust boundary
 
-Append-only protection covers `events`. It does not cover every table, and it
-cannot. `outcomes` has no triggers, and `outcome.subject` — the field that says
-which SKU the acceptance checks are about — is a value inside that row's JSON.
+`outcomes` has no triggers, and `outcome.subject` — the field naming what the
+acceptance checks are about — is a value inside that row's JSON. Anyone who can
+write to the database can change it.
 
-Sparring demonstrated the consequence. Rewriting that single field to point at a
-different, well-stocked product makes all three checks pass **coherently**, and
-the outcome accepts while the real shelf is empty:
+**What that does and does not buy an attacker**, re-derived against the current
+code rather than carried forward from an earlier commit:
+
+Retargeting the subject *on its own* is refused, and refused early. Acceptance
+re-executes every declared check against the **new** subject before it looks at
+any stored evidence, so a subject pointing at a product with no stock and no
+replenishment fails immediately:
 
 ```text
-UPDATE outcomes SET record = <subject: "SKU-TEA" -> "SKU-DECOY"> WHERE id = ...
--> all three checks PASS, ACCEPTED, while SKU-TEA on_hand=2 < reorder_point=3
+subject retargeted to SKU-DECOY, real SKU-TEA on_hand=0
+-> REFUSED: Checks failing at acceptance time: cash_reconciles,
+   inventory_at_or_above_reorder_point, replenishment_event_exists
 ```
 
-This is worth naming precisely, because it is the *exception* to how the check
-registry normally protects you. Tamper with inventory directly and you are
-caught: `cash_reconciles` and `replenishment_event_exists` cross-check inventory
-against the event log, so a single edit puts the checks in contradiction with
-each other. Subject tampering is the one single-field write that moves all three
-checks together onto a world where they are genuinely true — so the mutual
-cross-checking that provides the real guarantee is bypassed rather than tripped.
+If the decoy is stocked first so those checks would pass, the stored evidence
+still does not transfer: each check digests its own observation, and every store
+check's observation includes the SKU it ran against, so evidence written about
+tea is refused as stale rather than read as evidence about the decoy. The
+verifier reports the same, naming the missing decoy inventory.
+
+What still succeeds is retargeting **and then re-running verification**:
+
+```text
+retarget subject -> SKU-DECOY, seed and restock the decoy, re-verify, accept
+-> ACCEPTED, while the real SKU-TEA sits at on_hand=0 against reorder_point=3
+```
+
+That is not a hole in the digest. Fresh evidence about the decoy is genuinely
+fresh and genuinely consistent; the checks answer the question they were asked
+truthfully. The question itself was changed. **No digest of a check's own reads
+can detect the question changing underneath it** — the digest covers the answer,
+and the tampering happened to the prompt.
+
+Closing it means making the outcome record tamper-evident: signing or
+hash-chaining governance rows so a rewritten `subject` is detectable as a break
+in the chain rather than as an ordinary update. That is a real mechanism and a
+larger change than Unit 6.5 should carry, so it is named here as the honest next
+step and **not** claimed as taken.
 
 It requires raw write access to the database, and doctrine already places SQLite
 inside the trust boundary: anyone who can write arbitrary rows can rewrite the
-organization's memory. But "ACCEPTED means the outcome is true now" is exactly
-the claim this falsifies, so it is recorded here rather than left for a reader
-to discover.
+organization's memory. This section exists because "ACCEPTED means the outcome
+is true now" is exactly the claim it qualifies, and a reader deserves to know
+which door is which.
 
 A related property, verified rather than assumed: `DROP TRIGGER` succeeds from
 an outside connection, and reopening does not restore the trigger, because the
 migration that created it is already stamped as applied. This is true of the
 migration-2 guards as much as the migration-3 one, so it is a pre-existing
 property of the trust boundary rather than something the append-only work
-introduced. It is the same statement as above in a different key: everything
-here protects the ledger from *mistakes and ordinary tools*, not from an actor
-with arbitrary write access to the database file.
-
-**What the digest does and does not cover.** Each check now digests its own
-observation, and every store check's observation includes the `sku` it was run
-against — so evidence written about one SKU cannot be read as evidence about
-another. What the digest cannot see is a change to `outcome.subject` itself:
-retargeting the outcome makes verification *re-run* against the new subject and
-produce fresh, internally consistent evidence. The gap is not a missing field in
-the digest; it is that `outcomes` rows are mutable by anyone with database write
-access, and no digest of a check's own reads can detect the question changing
-underneath it.
-
-Closing it needs the outcome record itself to be tamper-evident — signing or
-hash-chaining governance rows — which is a larger change than Unit 6.5 should
-carry. Named here as the honest next step rather than implied to be taken.
+introduced. It is the same statement in a different key: everything here
+protects the ledger from *mistakes and ordinary tools*, not from an actor with
+arbitrary write access to the database file.
 
 ## How to see the drift for yourself
 

--- a/docs/persistence-boundary.md
+++ b/docs/persistence-boundary.md
@@ -86,6 +86,42 @@ A stronger property (an outbox, replayed on next open) is buildable, and is
 deliberately out of scope for Unit 6.5. The honest half-door is labelled rather
 than disguised.
 
+
+## A second limit: the ledger is inside the trust boundary
+
+Append-only protection covers `events`. It does not cover every table, and it
+cannot. `outcomes` has no triggers, and `outcome.subject` — the field that says
+which SKU the acceptance checks are about — is a value inside that row's JSON.
+
+Sparring demonstrated the consequence. Rewriting that single field to point at a
+different, well-stocked product makes all three checks pass **coherently**, and
+the outcome accepts while the real shelf is empty:
+
+```text
+UPDATE outcomes SET record = <subject: "SKU-TEA" -> "SKU-DECOY"> WHERE id = ...
+-> all three checks PASS, ACCEPTED, while SKU-TEA on_hand=2 < reorder_point=3
+```
+
+This is worth naming precisely, because it is the *exception* to how the check
+registry normally protects you. Tamper with inventory directly and you are
+caught: `cash_reconciles` and `replenishment_event_exists` cross-check inventory
+against the event log, so a single edit puts the checks in contradiction with
+each other. Subject tampering is the one single-field write that moves all three
+checks together onto a world where they are genuinely true — so the mutual
+cross-checking that provides the real guarantee is bypassed rather than tripped.
+
+It requires raw write access to the database, and doctrine already places SQLite
+inside the trust boundary: anyone who can write arbitrary rows can rewrite the
+organization's memory. But "ACCEPTED means the outcome is true now" is exactly
+the claim this falsifies, so it is recorded here rather than left for a reader
+to discover.
+
+The durable fix — binding `subject` into the evidence `state_digest`, so that a
+post-verification subject swap presents as staleness — is deliberately **not**
+done in Unit 6.5. It changes the digest contract, and this unit has already
+changed enough. It is named here as the next honest step rather than implied to
+be already taken.
+
 ## How to see the drift for yourself
 
 ```console

--- a/docs/persistence-boundary.md
+++ b/docs/persistence-boundary.md
@@ -1,0 +1,98 @@
+# The persistence boundary: what is canonical, what is derived
+
+The 1.x educational-reset ruling states the doctrine in one line:
+
+> JSON/TOML is canonical for committed governance; SQLite is canonical for
+> operational state; Markdown is generated.
+
+That line is nearly right, and reading it literally would teach you something
+false about this codebase. This note records the refined boundary and the
+experiment that forced the refinement, as an amendment to the doctrine rather
+than a quiet re-reading of it.
+
+## What the code actually does
+
+Two claims, each checkable in under a minute.
+
+**Claim 1 — deleting `governance/` does not harm the organization.**
+
+```console
+sovereign-agent demo store --mode simulated --root /tmp/store
+rm -rf /tmp/store/governance
+python -c "from sovereign_agent.organization import Organization; \
+o=Organization('/tmp/store'); \
+print(o.status_text(o.db.connection.execute('select id from outcomes').fetchone()['id']))"
+```
+
+The status still prints. Outcomes and SOWs are read from SQLite
+(`Organization._outcome`, `Organization.sows_for`). Nothing in the codebase ever
+reads `governance/outcomes/**/outcome.json` back. It is written and never
+consulted.
+
+**Claim 2 — editing `sovereign.toml` does change behaviour.**
+
+Change a `provider = ` line and reopen the organization; the actor comes back
+with the new provider. `load_actors` parses that file on every open.
+
+## The refined boundary
+
+| Data | Canonical home | Why |
+| --- | --- | --- |
+| Actor definitions, roles, providers | `sovereign.toml` | Read on every open. Editing it changes behaviour. Committed, reviewable, diffable. |
+| Rulings | `docs/rulings/*.md` + `governance/rulings/` | Human decisions belong in version control, where they can be argued with. |
+| Outcomes, SOWs, assignments, evidence, acceptance | **SQLite** | Read on every operation. These carry mutable execution state. |
+| Inventory, cash, events, signals, leases | **SQLite** | Operational state by definition. |
+| `governance/**/*.json` | **derived projection** | Written for inspection and diffing. Never read back. |
+| `governance/**/*.md`, chapter output | **generated** | Never authoritative. Regenerate freely. |
+
+So the doctrine is refined, not overturned:
+
+- *Committed governance definitions* — the actors and rulings a human writes and
+  reviews — are canonical in TOML/Markdown, and they are genuinely read back.
+- *Governance execution records* — the state of a particular outcome as work
+  moves through it — are canonical in SQLite, because they change while the
+  organization runs.
+- The JSON under `governance/outcomes/` is the **inspectable projection** of
+  those records, not their source.
+
+The original line collapsed those two senses of "governance". Splitting them is
+the amendment.
+
+## The limit you must not lie about
+
+SQLite gives you one transaction across many tables. It does **not** give you a
+transaction across SQLite *and* the filesystem.
+
+`Organization.accept` commits the ledger, and only then calls `project_outcome`
+to write files. If the process dies in between — or the disk fills — the ledger
+says `ACCEPTED` and the files on disk do not. That is a real, reachable state,
+and it is why the code carries this comment:
+
+```python
+# NOT part of the transaction above: see docs/persistence-boundary.md.
+project_outcome(self.root, outcome, sows)
+```
+
+`atomic_write` (in `files.py`) makes each individual file appear atomically, via
+write-temp-then-rename. That is per-file atomicity, and it is worth having. It
+is not cross-resource atomicity, and calling it that would be the same species
+of lie as an `ACCEPTED` outcome with an empty shelf.
+
+**The rule that follows:** SQLite is the authority. Files are rebuildable from
+it. When they disagree, the database wins and the projection is regenerated —
+never the reverse. Drift detection therefore reconciles *toward* the database.
+
+A stronger property (an outbox, replayed on next open) is buildable, and is
+deliberately out of scope for Unit 6.5. The honest half-door is labelled rather
+than disguised.
+
+## How to see the drift for yourself
+
+```console
+sovereign-agent demo store --mode simulated --root /tmp/store
+echo "hand-edited nonsense" >> /tmp/store/governance/outcomes/*/README.md
+python scripts/verify_projections.py /tmp/store
+```
+
+The verifier reports the stale projection and exits non-zero. Regenerating from
+the ledger fixes it.

--- a/docs/persistence-boundary.md
+++ b/docs/persistence-boundary.md
@@ -116,6 +116,15 @@ organization's memory. But "ACCEPTED means the outcome is true now" is exactly
 the claim this falsifies, so it is recorded here rather than left for a reader
 to discover.
 
+A related property, verified rather than assumed: `DROP TRIGGER` succeeds from
+an outside connection, and reopening does not restore the trigger, because the
+migration that created it is already stamped as applied. This is true of the
+migration-2 guards as much as the migration-3 one, so it is a pre-existing
+property of the trust boundary rather than something the append-only work
+introduced. It is the same statement as above in a different key: everything
+here protects the ledger from *mistakes and ordinary tools*, not from an actor
+with arbitrary write access to the database file.
+
 The durable fix — binding `subject` into the evidence `state_digest`, so that a
 post-verification subject swap presents as staleness — is deliberately **not**
 done in Unit 6.5. It changes the digest contract, and this unit has already

--- a/docs/persistence-boundary.md
+++ b/docs/persistence-boundary.md
@@ -39,7 +39,8 @@ with the new provider. `load_actors` parses that file on every open.
 | Data | Canonical home | Why |
 | --- | --- | --- |
 | Actor definitions, roles, providers | `sovereign.toml` | Read on every open. Editing it changes behaviour. Committed, reviewable, diffable. |
-| Rulings | `docs/rulings/*.md` + `governance/rulings/` | Human decisions belong in version control, where they can be argued with. |
+| Repository product rulings | `docs/rulings/*.md` | Human decisions, committed and reviewed. Canonical in files. |
+| Runtime organization rulings | **SQLite** (`rulings`), projected to `governance/rulings/` | `Organization.rule()` records a decision made by an actor inside a running organization. Operational state; the files are a projection. |
 | Outcomes, SOWs, assignments, evidence, acceptance | **SQLite** | Read on every operation. These carry mutable execution state. |
 | Inventory, cash, events, signals, leases | **SQLite** | Operational state by definition. |
 | `governance/**/*.json` | **derived projection** | Written for inspection and diffing. Never read back. |
@@ -125,11 +126,19 @@ introduced. It is the same statement as above in a different key: everything
 here protects the ledger from *mistakes and ordinary tools*, not from an actor
 with arbitrary write access to the database file.
 
-The durable fix — binding `subject` into the evidence `state_digest`, so that a
-post-verification subject swap presents as staleness — is deliberately **not**
-done in Unit 6.5. It changes the digest contract, and this unit has already
-changed enough. It is named here as the next honest step rather than implied to
-be already taken.
+**What the digest does and does not cover.** Each check now digests its own
+observation, and every store check's observation includes the `sku` it was run
+against — so evidence written about one SKU cannot be read as evidence about
+another. What the digest cannot see is a change to `outcome.subject` itself:
+retargeting the outcome makes verification *re-run* against the new subject and
+produce fresh, internally consistent evidence. The gap is not a missing field in
+the digest; it is that `outcomes` rows are mutable by anyone with database write
+access, and no digest of a check's own reads can detect the question changing
+underneath it.
+
+Closing it needs the outcome record itself to be tamper-evident — signing or
+hash-chaining governance rows — which is a larger change than Unit 6.5 should
+carry. Named here as the honest next step rather than implied to be taken.
 
 ## How to see the drift for yourself
 

--- a/docs/rulings/2026-08-25-main-is-the-1x-line.md
+++ b/docs/rulings/2026-08-25-main-is-the-1x-line.md
@@ -43,8 +43,10 @@ original file.
 
 ## What did not change
 
-- The persistence doctrine of the original ruling stands, refined by
-  [the persistence boundary note](../persistence-boundary.md).
+- The persistence doctrine of the original ruling is refined **separately**, by
+  [its own ruling](2026-08-26-persistence-boundary-refinement.md). This
+  amendment decides branch policy and nothing else: two unrelated decisions
+  should not share one authority record.
 - Holdings 1 through 7 of the educational-reset ruling remain in force.
 - The production destination remains Zero Employee in Go. This package is the
   didactic reference.

--- a/docs/rulings/2026-08-25-main-is-the-1x-line.md
+++ b/docs/rulings/2026-08-25-main-is-the-1x-line.md
@@ -1,0 +1,62 @@
+# Ruling amendment: `main` is the 1.x educational integration line
+
+- **id:** `ruling-2026-08-25-main-is-the-1x-line`
+- **decided:** 2026-08-25
+- **authority:** principal
+- **applies_to:** Sovereign Agent 1.x branch policy and release expectations
+- **status:** ACTIVE
+- **amends:** [`ruling-2026-08-25-educational-reset`](2026-08-25-educational-reset.md)
+
+## Why this amendment exists
+
+The educational-reset ruling recorded, under *Consequences in this repository*:
+
+> Implementation proceeds on `v1-educational`. `main` remains the 0.7 line
+> until the 1.0 definition of done is met.
+
+That holding no longer describes reality. Units 0 through 6 were reviewed,
+approved, and merged into `main` (PRs #20, #21, #22, #23). `main` today
+contains the Python 3.14 educational skeleton, not the 0.7 framework.
+
+A ruling that contradicts the repository is worse than no ruling: it teaches a
+learner to distrust the governance records. The correction is an amendment on
+the record, **not** a rewrite of Git history and **not** a quiet edit of the
+original file.
+
+## Holdings
+
+1. **`v0.7.0` remains immutable.** The tag stays at commit
+   `be2a41bbee202c52a40b2e87c00215827be302a0`. It is not moved, retagged, or
+   deleted. The 0.x line remains installable exactly as released.
+2. **`main` is the 1.x educational integration line.** As of the Unit 0 merge,
+   `main` carries the 1.x executable textbook. The earlier holding that "`main`
+   remains the 0.7 line until the 1.0 definition of done is met" is
+   **superseded** in full.
+3. **Users who need the 0.x framework pin `sovereign-agent<1`.** This is
+   unchanged by this amendment and is the supported migration answer.
+4. **No release-gate claim is made.** Nothing in this amendment asserts that
+   1.0 has met its definition of done. `main` carries `1.0.0.dev1`, a
+   pre-release. Outstanding gates include the credentialed provider smokes
+   (Unit 12), which have **not** been run.
+5. **History is not rewritten.** The merges that produced this state stand as
+   the durable record of how the line moved.
+
+## What did not change
+
+- The persistence doctrine of the original ruling stands, refined by
+  [the persistence boundary note](../persistence-boundary.md).
+- Holdings 1 through 7 of the educational-reset ruling remain in force.
+- The production destination remains Zero Employee in Go. This package is the
+  didactic reference.
+
+## How to verify this amendment against the repository
+
+```console
+git log --oneline --first-parent main | head
+git tag --list 'v0.7.0' --format='%(objectname) %(refname:short)'
+python -c "import sovereign_agent; print(sovereign_agent.__version__)"
+```
+
+The first command shows the merged 1.x units on `main`. The second shows the
+`v0.7.0` tag still present. The third prints a `.dev` version, which is the
+package stating plainly that it is not a finished 1.0.

--- a/docs/rulings/2026-08-26-amendment-conditional-effects.md
+++ b/docs/rulings/2026-08-26-amendment-conditional-effects.md
@@ -1,0 +1,75 @@
+# Ruling amendment: effects are required where a SOW declares them
+
+- **id:** `ruling-2026-08-26-amendment-conditional-effects`
+- **decided:** 2026-08-26
+- **authority:** principal
+- **applies_to:** Sovereign Agent 1.x acceptance semantics
+- **status:** ACTIVE
+- **amends:** [`ruling-2026-08-26-outcomes-are-conditions-sows-are-work`](2026-08-26-outcomes-are-conditions-sows-are-work.md)
+
+## Why this amendment exists
+
+The amended ruling holds, in its acceptance requirements:
+
+> **(b) the bound execution contributed** — the assignment being accepted on
+> actually produced an effect
+
+and rules out "deleting the governance records for outcomes that need no work",
+saying the right answer is "a refusal that says so".
+
+The implementation then introduced `StatementOfWork.required_effect_kind`, under
+which a SOW with no declared effect completes without changing the world — and a
+test pins that behaviour. **The code overturned a holding without changing the
+holding.**
+
+Raised in review of PR #24. The reviewer was right twice: the conditional model
+is better, *and* changing the code instead of the ruling is the wrong way round.
+A ruling the code contradicts is worse than no ruling, because it teaches a
+learner that the governance records are decoration — the exact failure the Unit 0
+branch amendment exists to correct, reproduced inside Unit 6.5.
+
+## What was wrong with the original holding
+
+It assumed every SOW is effectful. Investigations, reports and reviews are
+legitimate units of work that deliver without moving inventory. Requiring a
+world-changing effect from all of them would either forbid such SOWs or invite
+fake effects to satisfy the check — and a system that rewards manufacturing an
+effect to pass a gate has learned the wrong lesson from this unit.
+
+## Amended holdings
+
+Acceptance of an **outcome** requires all of the following, checked separately:
+
+1. **Every SOW has a completed execution** with a successful receipt whose
+   canonical record and indexed columns agree.
+2. **Every SOW produced its declared deliverables.** For a non-effectful SOW the
+   deliverable *is* the proof: outcome-level store checks say nothing about
+   whether a report was written. Judging an investigation by an inventory check
+   would be a check named for one fact measuring another — this unit's signature
+   defect, one scope up.
+3. **Every SOW has an independent review of its own current verification**,
+   bound relationally: `verification.sow_id → assignment.sow_id → the reviewed
+   SOW`.
+4. **Only a SOW declaring `required_effect_kind` must have changed the world**,
+   and then its own execution must have produced an effect of exactly that kind.
+   Supersedes holding (b) of the amended ruling, which required this of every
+   SOW.
+5. **The outcome's condition holds now**, re-executed at acceptance time.
+   Unchanged.
+
+## What is unchanged
+
+- An outcome is still a standing condition; a SOW is still a unit of work.
+- `ACCEPTED` still means the outcome is true *now*.
+- "No work was required" still refuses — but the refusal is now precise: a SOW
+  that declares an effect and produces none is refused for that, while a SOW
+  that never claimed to change the world is judged on its deliverable instead.
+
+## Verification
+
+- `test_a_sow_with_no_declared_effect_need_not_change_the_world` — holding 4.
+- `test_condition_true_but_no_effects_exist_at_all_is_refused` — an effectful
+  SOW that changed nothing is still refused.
+- `Organization._require_deliverables` and its refusal — holding 2.
+- `test_core_and_the_truth_verifier_agree_on_a_multi_sow_organization` — the
+  core and the release oracle enforce the same amended model.

--- a/docs/rulings/2026-08-26-one-process-per-actor.md
+++ b/docs/rulings/2026-08-26-one-process-per-actor.md
@@ -1,0 +1,39 @@
+# Ruling: one process per actor in 1.x; lease fencing is Unit 8
+
+- **id:** `ruling-2026-08-26-one-process-per-actor`
+- **decided:** 2026-08-26
+- **authority:** principal
+- **applies_to:** Sovereign Agent 1.x mailbox claims and actor hosting
+- **status:** ACTIVE
+
+## The question
+
+`claim()` is an atomic compare-and-set, so two *different* actors contending for
+one message produce exactly one winner. But a second connection using the **same
+actor id** is granted the claim, because a claim already held by that actor short
+circuits and returns it.
+
+Two processes hosting one actor can therefore both believe they may proceed.
+
+## Holdings
+
+1. **The mailbox provides actor-level idempotency, not process-level
+   exclusivity.** Re-claiming a message you already hold is deliberately safe;
+   it is what makes a retried worker harmless.
+2. **One process may host an actor.** Running the same actor id in two processes
+   concurrently is outside the 1.x contract and is not defended against.
+3. **Lease fencing is deferred to Unit 8.** A fencing token — a distinct
+   lease/attempt id required at completion, so a resumed worker cannot commit
+   under a lease it no longer holds — belongs with the supervisor that owns
+   process lifecycle. It is not built in 6.5.
+4. **The property must not be described as "exactly one worker."** Documentation
+   and test names say what is proved: one winner among *distinct contenders*.
+
+## Why this is a ruling and not a code change
+
+Adding fencing now would mean inventing process lifecycle in a unit that has no
+supervisor to own it. The honest move is to state the boundary, name where it
+gets closed, and stop any text from implying a guarantee that does not exist.
+
+Verified by `test_the_same_actor_from_two_processes_is_idempotent_not_exclusive`,
+which asserts the current behaviour so a future change to it is visible.

--- a/docs/rulings/2026-08-26-outcomes-are-conditions-sows-are-work.md
+++ b/docs/rulings/2026-08-26-outcomes-are-conditions-sows-are-work.md
@@ -1,0 +1,87 @@
+# Ruling: an outcome is a standing condition; a SOW is a unit of work
+
+- **id:** `ruling-2026-08-26-outcomes-are-conditions-sows-are-work`
+- **decided:** 2026-08-26
+- **authority:** principal
+- **applies_to:** Sovereign Agent 1.x acceptance semantics
+- **status:** ACTIVE
+
+## The question
+
+Raised by Sparring on PR #24 as a design fork deserving a ruling rather than a
+patch. Reproduced in full:
+
+```text
+Week 1: real work, real restock, accepted legitimately.
+Week 2: an assignment runs and does NOTHING. Inventory is still stocked
+        from week 1. *** WEEK 2 ACCEPTED ***
+```
+
+Is week 2 correct or incorrect?
+
+- If "keep the tea jar stocked" is a **standing condition**, week 2 is correctly
+  accepted — the jar is stocked — and the SOW, assignment and receipt merely
+  imply work that was not required.
+- If it is a **unit of work**, week 2 must refuse, and the checks need an
+  execution-scoped question beside the world-fact one.
+
+Sparring observed that `checks.py` takes the first position while every
+governance record takes the second.
+
+## Holding
+
+**Both readings are correct, about different objects.** The records say so, and
+were consulted rather than reasoned about:
+
+| Object | Field | Shape |
+| --- | --- | --- |
+| `Outcome.desired_state` | "On-hand tea is at or above the reorder point…" | a state of the world — **condition** |
+| `StatementOfWork.deliverables` | `["report.json"]` | a thing produced — **work** |
+| `StatementOfWork.done_when` | "Evidence exists and a different actor has reviewed it." | a completion test — **work** |
+
+1. **An outcome is a standing condition.** It names how the world should be. It
+   can be true without anyone doing anything, and it can stop being true without
+   anyone doing anything.
+2. **A SOW is a unit of work.** It names a deliverable and the test for having
+   delivered it. It is done or not done; it does not "remain true".
+3. **Acceptance asserts both, separately.** To accept an outcome the system must
+   establish:
+   - **(a) the condition holds now** — the deterministic world-fact checks,
+     re-executed at acceptance time; and
+   - **(b) the bound execution contributed** — the assignment being accepted on
+     actually produced an effect, read from the structured `effects` table.
+4. **Neither implies the other, and the failure of each is reported
+   differently.** (a) failing means *the world is wrong*. (b) failing means *this
+   work did nothing*. Collapsing them is the defect this ruling exists to fix:
+   week 2 satisfied (a) and failed (b), and was accepted anyway while presenting
+   a SOW, an assignment, a receipt and a review as though they evidenced the work
+   that produced the stocked shelf.
+5. **`ACCEPTED` continues to mean the outcome is true now.** This ruling does
+   not weaken that; it adds a second, independent requirement. An outcome whose
+   condition holds but whose execution did nothing is not accepted — not because
+   the world is wrong, but because the record would misattribute it.
+
+## What this rules out
+
+- Making the world-fact checks execution-scoped. That would lose the property
+  Unit 6.5 exists to establish: that `ACCEPTED` means the claim is *currently*
+  true, not that it was true once when a check happened to run.
+- Deleting the governance records for outcomes that need no work. The right
+  answer to "no work was required" is a refusal that says so, not a SOW quietly
+  taking credit.
+
+## Consequences in this repository
+
+- `effects` carries `outcome_id` as a structured foreign key, so the effect edge
+  can be followed relationally rather than inferred from world state.
+- Acceptance follows that edge and refuses when the bound execution contributed
+  no effect, with a message naming the real reason.
+- Proof selection stops using "the newest assignment row" as an implicit rule.
+  That was never a proof; it was an ordering accident, and it cannot model an
+  outcome with several SOWs.
+
+## Verification
+
+`tests/test_causal_binding.py` reproduces the week-1/week-2 sequence and asserts
+week 2 is refused while the condition still holds — proving the two requirements
+are genuinely independent rather than one dressed as two.

--- a/docs/rulings/2026-08-26-persistence-boundary-refinement.md
+++ b/docs/rulings/2026-08-26-persistence-boundary-refinement.md
@@ -1,0 +1,63 @@
+# Ruling: the persistence boundary, refined
+
+- **id:** `ruling-2026-08-26-persistence-boundary-refinement`
+- **decided:** 2026-08-26
+- **authority:** principal
+- **applies_to:** Sovereign Agent 1.x persistence and the governance/operational split
+- **status:** ACTIVE
+- **amends:** [`ruling-2026-08-25-educational-reset`](2026-08-25-educational-reset.md)
+
+## Why this is its own ruling
+
+This refinement was first recorded inside the amendment that moved `main` to the
+1.x line. Those are two unrelated decisions — a branch policy and a data
+doctrine — and folding them into one authority record makes it impossible to
+cite, supersede, or argue with either separately. Raised in review of PR #24 and
+corrected here.
+
+## The holding being refined
+
+The educational-reset ruling states:
+
+> JSON/TOML is canonical for committed governance; SQLite is canonical for
+> operational state; Markdown is generated.
+
+Read literally, that is false of this codebase. Deleting the entire
+`governance/` directory leaves the organization fully working, because outcomes
+and SOWs are read from SQLite and the JSON is never read back.
+
+## Holdings
+
+1. **"Governance" names two different things**, and the original line collapsed
+   them:
+   - *Committed governance definitions* — actors in `sovereign.toml`, rulings in
+     `docs/rulings/` — are canonical in files and are genuinely read back.
+     Editing `sovereign.toml` changes behaviour on the next open.
+   - *Governance execution records* — the state of an outcome as work moves
+     through it — are canonical in **SQLite**, because they change while the
+     organization runs.
+2. **`governance/**/*.json` is a derived projection**, not a source. It is
+   written for inspection and diffing and never read back.
+3. **Markdown is generated** and never authoritative.
+4. **Runtime rulings are operational records.** `Organization.rule()` stores a
+   ruling in SQLite and projects files from it. That is a *runtime organization
+   ruling* — a governed decision made by an actor inside a running
+   organization — and it is distinct from the *repository product rulings* in
+   `docs/rulings/`, which humans write, review, and commit. Both are called
+   "ruling"; only the second is canonical in files. The teaching text must keep
+   these apart.
+5. **No cross-resource atomicity is claimed.** SQLite and the filesystem cannot
+   be written in one transaction. The ledger is the authority; projections are
+   rebuildable from it and reconcile *toward* it.
+6. **Verification of projections must be pure.** Detecting drift and repairing
+   it are separate acts. A verifier that repairs while checking reports success
+   about a state it created.
+
+## Consequences
+
+- `docs/persistence-boundary.md` is the explanatory text for this ruling.
+- `scripts/verify_projections.py` checks by default and repairs only under
+  `--reconcile`.
+- Trust boundary, stated plainly: everything here protects the ledger from
+  mistakes and ordinary tools, not from an actor with arbitrary write access to
+  the database file.

--- a/docs/rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md
+++ b/docs/rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md
@@ -1,0 +1,75 @@
+# Ruling: SQLite writers are inside the trust boundary
+
+- **id:** `ruling-2026-08-26-sqlite-writers-are-inside-the-boundary`
+- **decided:** 2026-08-26
+- **authority:** principal
+- **applies_to:** Sovereign Agent 1.x append-only guarantees and effect corroboration
+- **status:** ACTIVE
+
+## Why this exists
+
+`docs/persistence-boundary.md` already says it plainly:
+
+> anyone who can write arbitrary rows can rewrite the organization's memory
+
+and
+
+> everything here protects the ledger from *mistakes and ordinary tools*, not
+> from an actor with arbitrary write access to the database file.
+
+Then a fix for a forged-effect finding described cross-table corroboration as
+putting "the proof back on the table where a forged append is detectable", and
+Chapter 2 repeated it. **The code and the book claimed a guarantee the project
+had already documented that it does not have.**
+
+Both reviewers demonstrated the same thing from different directions. Two
+coordinated fresh appends — an effect and its witnessing event — are mutually
+consistent and equally forged, and acceptance takes them:
+
+```text
+three fresh appends (cash, event, effect) — no trigger fires
+*** ACCEPTED — the execution did no work ***
+```
+
+Sparring, which had previously reported the corroboration as four layers deep,
+retracted: it had found one *ordering* in which the attack failed and reported
+it as depth.
+
+## Holdings
+
+1. **SQLite writers are inside the trust boundary.** An actor with arbitrary
+   write access to the database file can rewrite the organization's memory. This
+   is not a defect to be fixed in 1.x; it is the boundary, stated.
+2. **Append-only triggers are mutation safety.** They prevent rewriting and
+   replacement by ordinary tools and honest mistakes. They do not prevent
+   appending, and appending is how a forgery gets in.
+3. **Effect/event corroboration detects incomplete or inconsistent records.** An
+   effect with no witnessing event is a half-written state or a hand-added row.
+   Corroboration establishes consistency between two claims; it authenticates
+   neither.
+4. **Two coordinated fresh appends remain a documented limitation.** Not a bug
+   to be closed by a third cross-table check.
+5. **Authenticating against an arbitrary writer requires a trust root outside
+   the database** — signatures or keyed MACs whose key the database never holds
+   — and a precise attacker model. Deliberately out of scope for an educational
+   release.
+
+## Why not fix it
+
+Because the fix would be the mistake, one table over. Each of the last three
+rounds added a mechanism to shore up the previous mechanism, and each new
+mechanism inherited the same property: it constrains what the *code* writes, and
+an arbitrary writer is not the code. A learner who understands why cross-table
+checks cannot authenticate has learned more than one who believes they can.
+
+The honest teaching is the boundary, drawn where it actually falls.
+
+## Consequences
+
+- `Organization.effect_kinds_for_execution` documents detection, not
+  authentication.
+- `book/ch02_work_needs_governance` teaches the limitation rather than past it.
+- `APPEND_ONLY_TABLES` (formerly `PROOF_TABLES`) is named for what it does, and
+  is a maintained list rather than a claim of exhaustiveness.
+- `test_corroboration_detects_inconsistency_but_does_not_authenticate` records
+  the limitation as an asserted fact, so nobody re-derives it as a bug.

--- a/scripts/evaluate_andrea_alpha.py
+++ b/scripts/evaluate_andrea_alpha.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Run the machine-checkable half of the Andrea Alpha evaluation.
+
+Stdlib only. Executes the cold-start learner path exactly as the guide writes
+it, and reports what a fresh Andrea-profile session would actually see.
+
+It scores REACHABILITY, not understanding. Tasks 4 and 7 of
+docs/andrea-alpha-evaluation.md require a human reading Andrea's answers; this
+script says so rather than inventing a score for them.
+
+Exits 0 when every machine-checkable task passes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+
+def run(argv: list[str]) -> tuple[int, str]:
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        argv, capture_output=True, text=True, cwd=REPO_ROOT
+    )
+    return result.returncode, (result.stdout + result.stderr)
+
+
+def main() -> int:
+    python = sys.executable
+    results: list[tuple[str, bool, str]] = []
+    started = time.monotonic()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "andrea-shift"
+
+        # Task 1: enter the environment.
+        code, output = run([python, "-m", "sovereign_agent", "doctor"])
+        ok = code == 0 and "Python:" in output
+        results.append(
+            (
+                "1. doctor runs on a cold start",
+                ok,
+                output.strip().splitlines()[0] if output.strip() else "",
+            )
+        )
+
+        # Task 2: reach a truthful accepted outcome.
+        code, output = run(
+            [
+                python,
+                "-m",
+                "sovereign_agent",
+                "demo",
+                "store",
+                "--mode",
+                "simulated",
+                "--root",
+                str(root),
+            ]
+        )
+        accepted = code == 0 and "ACCEPTED" in output
+        results.append(
+            (
+                "2a. demo reaches ACCEPTED",
+                accepted,
+                output.strip().splitlines()[-1] if output.strip() else "",
+            )
+        )
+
+        code, output = run(
+            [python, str(REPO_ROOT / "scripts" / "verify_store_outcome.py"), str(root)]
+        )
+        truthful = code == 0
+        results.append(
+            (
+                "2b. the accepted outcome is TRUE",
+                truthful,
+                output.strip().splitlines()[-1] if output.strip() else "",
+            )
+        )
+
+        # Task 3: the eight artifacts are locatable.
+        from sovereign_agent.organization import Organization
+
+        org = Organization(root)
+        tables = {
+            "outcome": "SELECT COUNT(*) c FROM outcomes",
+            "SOW": "SELECT COUNT(*) c FROM sows",
+            "assignment": "SELECT COUNT(*) c FROM assignments",
+            "evidence": "SELECT COUNT(*) c FROM evidence",
+            "inventory": "SELECT COUNT(*) c FROM inventory",
+            "cash entry": "SELECT COUNT(*) c FROM cash_entries",
+            "event history": "SELECT COUNT(*) c FROM events",
+            "receipt": "SELECT COUNT(*) c FROM receipts",
+        }
+        missing = [
+            name
+            for name, query in tables.items()
+            if int(org.db.connection.execute(query).fetchone()["c"]) == 0
+        ]
+        found_files = list((root / ".sovereign" / "runs").glob("*/receipt.json"))
+        ok = not missing and bool(found_files)
+        results.append(
+            (
+                "3. all eight artifacts exist and are locatable",
+                ok,
+                "all present" if ok else f"missing: {missing}",
+            )
+        )
+
+        # Task 5: changing the reorder point changes the verdict.
+        org.db.connection.execute("UPDATE inventory SET reorder_point = 99 WHERE sku = 'SKU-TEA'")
+        org.db.connection.commit()
+        org.db.close()
+        code, output = run(
+            [python, str(REPO_ROOT / "scripts" / "verify_store_outcome.py"), str(root)]
+        )
+        ok = code == 1
+        results.append(
+            (
+                "5. raising the reorder point makes the claim fail",
+                ok,
+                "verifier correctly refuses" if ok else "verifier still passed",
+            )
+        )
+
+        # Task 6: a malformed provider report is refused.
+        bad = Path(tmp) / "report.json"
+        bad.write_text("{not json", encoding="utf-8")
+        from reference_organizations.store.demo import propose_restock_from_report
+        from sovereign_agent.errors import Refusal
+
+        try:
+            propose_restock_from_report(bad, "SKU-TEA")
+            ok, detail = False, "malformed report was accepted"
+        except Refusal as refusal:
+            ok, detail = True, str(refusal).splitlines()[0]
+        results.append(("6. malformed provider report is refused", ok, detail))
+
+        # Task 7 (partial): no Pulse event was fabricated.
+        org = Organization(root)
+        kinds = [
+            str(row["kind"])
+            for row in org.db.connection.execute("SELECT kind FROM events").fetchall()
+        ]
+        ok = not any(kind.startswith("pulse.") for kind in kinds)
+        results.append(
+            (
+                "7. no Pulse event fabricated before Unit 9",
+                ok,
+                "no pulse events" if ok else "PULSE EVENT FOUND",
+            )
+        )
+
+    elapsed = time.monotonic() - started
+
+    print("Andrea Alpha — machine-checkable tasks\n")
+    failures = 0
+    for label, ok, detail in results:
+        mark = "PASS" if ok else "FAIL"
+        if not ok:
+            failures += 1
+        print(f"  [{mark}] {label}")
+        if detail:
+            print(f"         {detail}")
+
+    print(f"\nmachine execution time: {elapsed:.1f}s")
+    print("(The ten-minute budget is learner reading time, not machine time.)")
+    print("\nNOT machine-checkable — a human must read Andrea's answers:")
+    print("  4. why an actor is not a provider; why the operator cannot self-approve;")
+    print("     why evidence is more than an ID; governance versus operational data")
+    print("  7. why the organization is still passive before Pulse (Unit 9)")
+
+    if failures:
+        print(f"\n{failures} machine-checkable task(s) failed.")
+        return 1
+    print("\nAll machine-checkable tasks pass. Schedule the human session.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_curriculum.py
+++ b/scripts/verify_curriculum.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import importlib.util
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -29,6 +30,13 @@ REQUIRED_CHAPTERS = (
     "ch02_work_needs_governance",
     "ch03_actor_is_not_a_model",
 )
+
+# Chapter solutions that take a root path and run the exercise end to end.
+RUNNABLE = {
+    "ch00_first_shift": "run_simulated",
+    "ch01_organization_remembers": "observe_memory",
+    "ch02_work_needs_governance": "explore_governance",
+}
 
 REQUIRED_SECTIONS = (
     ("learning objective", ("## Learning objective",)),
@@ -87,6 +95,25 @@ def check_chapter(name: str) -> list[str]:
             problems.append(
                 f"{name}: solution.py failed to import: {type(error).__name__}: {error}"
             )
+            return problems
+
+        # Importing proves the file parses. RUNNING it proves the chapter still
+        # works: an exercise rots when the API moves underneath it, and an
+        # import-only check never notices. Each runs against a fresh root.
+        entry_point = RUNNABLE.get(name)
+        if entry_point is not None:
+            function = getattr(module, entry_point, None)
+            if function is None:
+                problems.append(f"{name}: solution.py has no {entry_point}()")
+            else:
+                with tempfile.TemporaryDirectory() as scratch:
+                    try:
+                        function(Path(scratch) / "root")
+                    except Exception as error:  # noqa: BLE001 - broken exercise, broken chapter
+                        problems.append(
+                            f"{name}: {entry_point}() failed to run: "
+                            f"{type(error).__name__}: {error}"
+                        )
 
     # Every local link and referenced script must exist.
     for target in re.findall(r"\]\(([^)]+)\)", text):
@@ -120,7 +147,10 @@ def main() -> int:
     if problems:
         print(f"\n{len(problems)} curriculum problem(s).")
         return 1
-    print(f"curriculum sound: {len(REQUIRED_CHAPTERS)} chapters, all imports and links resolve")
+    print(
+        f"curriculum sound: {len(REQUIRED_CHAPTERS)} chapters, "
+        f"{len(RUNNABLE)} exercises executed, all links resolve"
+    )
     return 0
 
 

--- a/scripts/verify_curriculum.py
+++ b/scripts/verify_curriculum.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Check that the book is a real, runnable learning path.
+
+Catches the ways a curriculum rots:
+
+- a chapter that lost a required section
+- a `solution.py` that no longer imports
+- a solution that copies implementation instead of importing the package
+- a chapter promising behaviour the code does not have (e.g. Pulse before Unit 9)
+- a referenced script or chapter that does not exist
+
+Exits 0 when the curriculum is sound, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOOK = REPO_ROOT / "book"
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+REQUIRED_CHAPTERS = (
+    "ch00_first_shift",
+    "ch01_organization_remembers",
+    "ch02_work_needs_governance",
+    "ch03_actor_is_not_a_model",
+)
+
+REQUIRED_SECTIONS = (
+    ("learning objective", ("## Learning objective",)),
+    ("runnable exercise", ("## The exercise", "## Exercise 1", "## Exercise")),
+    ("expected observations", ("Expected", "## Expected observations")),
+    ("learner verification command", ("## Learner verification command",)),
+    ("explain it back", ("## Explain it back",)),
+)
+
+# Pulse arrives in Unit 9. A chapter must not claim the organization wakes itself.
+FORBIDDEN_CLAIMS = (
+    re.compile(r"\bpulse\b\s+(?:event\s+)?(?:fires|fired|wakes|woke)", re.IGNORECASE),
+    re.compile(r"organization wakes itself (?:up )?(?:now|today)", re.IGNORECASE),
+)
+
+
+def check_chapter(name: str) -> list[str]:
+    problems: list[str] = []
+    directory = BOOK / name
+    if not directory.is_dir():
+        return [f"{name}: chapter directory is missing"]
+
+    readme = directory / "README.md"
+    if not readme.is_file():
+        problems.append(f"{name}: README.md is missing")
+        return problems
+    text = readme.read_text(encoding="utf-8")
+
+    for label, markers in REQUIRED_SECTIONS:
+        if not any(marker in text for marker in markers):
+            problems.append(f"{name}: no {label} section")
+
+    for pattern in FORBIDDEN_CLAIMS:
+        if pattern.search(text):
+            problems.append(f"{name}: claims Pulse behaviour that does not exist until Unit 9")
+
+    solution = directory / "solution.py"
+    if not solution.is_file():
+        problems.append(f"{name}: solution.py is missing")
+        return problems
+
+    source = solution.read_text(encoding="utf-8")
+    if not re.search(r"^from (sovereign_agent|reference_organizations)", source, re.MULTILINE):
+        problems.append(f"{name}: solution.py does not import the production package")
+    if "class Database" in source or "CREATE TABLE" in source:
+        problems.append(f"{name}: solution.py appears to copy implementation code")
+
+    spec = importlib.util.spec_from_file_location(f"book_{name}_solution", solution)
+    if spec is None or spec.loader is None:
+        problems.append(f"{name}: solution.py could not be loaded")
+    else:
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception as error:  # noqa: BLE001 - any import failure is a curriculum failure
+            problems.append(
+                f"{name}: solution.py failed to import: {type(error).__name__}: {error}"
+            )
+
+    # Every local link and referenced script must exist.
+    for target in re.findall(r"\]\(([^)]+)\)", text):
+        if target.startswith(("http://", "https://", "#")):
+            continue
+        if not (directory / target).resolve().exists():
+            problems.append(f"{name}: broken link to {target}")
+    for script in re.findall(r"(scripts/[\w_]+\.py)", text):
+        if not (REPO_ROOT / script).is_file():
+            problems.append(f"{name}: references missing script {script}")
+    return problems
+
+
+def main() -> int:
+    problems: list[str] = []
+
+    index = BOOK / "README.md"
+    if not index.is_file():
+        problems.append("book/README.md is missing")
+    else:
+        index_text = index.read_text(encoding="utf-8")
+        for name in REQUIRED_CHAPTERS:
+            if name not in index_text:
+                problems.append(f"book/README.md does not link {name}")
+
+    for name in REQUIRED_CHAPTERS:
+        problems.extend(check_chapter(name))
+
+    for problem in problems:
+        print(f"CURRICULUM: {problem}")
+    if problems:
+        print(f"\n{len(problems)} curriculum problem(s).")
+        return 1
+    print(f"curriculum sound: {len(REQUIRED_CHAPTERS)} chapters, all imports and links resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_projections.py
+++ b/scripts/verify_projections.py
@@ -3,30 +3,36 @@
 
 Markdown and JSON under `governance/` are projections. They are never read back,
 which means nothing else will ever notice if they go stale or are hand-edited.
-This script notices.
+This script notices — and does NOT fix.
 
-Drift is always resolved TOWARD the database: the ledger is the authority and
-the projection is regenerated. See docs/persistence-boundary.md.
+Verification is PURE. An earlier version called the projection writer to learn
+what the files should contain, which silently repaired hand-edited SOWs and then
+reported "projections match the ledger". A verifier that edits reality until it
+agrees with itself is worse than no verifier, because it reports success.
 
-    python scripts/verify_projections.py <organization-root>
+Repair lives behind an explicit flag:
 
+    python scripts/verify_projections.py <organization-root>            # check only
+    python scripts/verify_projections.py <organization-root> --reconcile  # rewrite
+
+Drift is always resolved TOWARD the database. See docs/persistence-boundary.md.
 Exits 0 when every projection matches the ledger, 1 otherwise.
 """
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from sovereign_agent.governance import project_outcome  # noqa: E402
+from sovereign_agent.governance import project_outcome, render_outcome  # noqa: E402
 from sovereign_agent.organization import Organization  # noqa: E402
 
 
 def check(root: Path) -> list[str]:
+    """Compare every projected file against expected bytes. Never writes."""
     problems: list[str] = []
     org = Organization(root)
     rows = org.db.connection.execute("SELECT id FROM outcomes").fetchall()
@@ -38,52 +44,56 @@ def check(root: Path) -> list[str]:
         outcome = org._outcome(outcome_id)  # noqa: SLF001
         sows = org.sows_for(outcome_id)
         directory = root / "governance" / "outcomes" / outcome_id
+        expected = render_outcome(outcome, sows)
 
-        json_path = directory / "outcome.json"
-        if not json_path.is_file():
-            problems.append(f"{outcome_id}: outcome.json is missing")
-        else:
-            on_disk = json.loads(json_path.read_text(encoding="utf-8"))
-            expected = json.loads(json.dumps(outcome.model_dump(mode="json"), default=str))
-            if on_disk != expected:
-                differing = sorted(
-                    key
-                    for key in set(on_disk) | set(expected)
-                    if on_disk.get(key) != expected.get(key)
-                )
-                problems.append(
-                    f"{outcome_id}: outcome.json differs from the ledger "
-                    f"(fields: {', '.join(differing) or 'unknown'})"
-                )
+        for name, data in expected.items():
+            path = directory / name
+            if not path.is_file():
+                problems.append(f"{outcome_id}: {name} is missing")
+                continue
+            if path.read_bytes() != data:
+                problems.append(f"{outcome_id}: {name} does not match the ledger")
 
-        readme = directory / "README.md"
-        if not readme.is_file():
-            problems.append(f"{outcome_id}: README.md is missing")
-        else:
-            before = readme.read_text(encoding="utf-8")
-            project_outcome(root, outcome, sows)
-            after = readme.read_text(encoding="utf-8")
-            if before != after:
-                problems.append(
-                    f"{outcome_id}: README.md was stale or hand-edited "
-                    "(regenerated from the ledger)"
-                )
+        # Extra SOW projections are drift too: a deleted SOW must not linger.
+        sows_directory = directory / "sows"
+        if sows_directory.is_dir():
+            expected_sows = {name.split("/", 1)[1] for name in expected if name.startswith("sows/")}
+            for path in sorted(sows_directory.glob("*.json")):
+                if path.name not in expected_sows:
+                    problems.append(f"{outcome_id}: sows/{path.name} is not in the ledger")
     return problems
 
 
+def reconcile(root: Path) -> int:
+    """Rewrite projections from the ledger. Explicit, never a side effect of checking."""
+    org = Organization(root)
+    count = 0
+    for row in org.db.connection.execute("SELECT id FROM outcomes").fetchall():
+        outcome_id = str(row["id"])
+        project_outcome(root, org._outcome(outcome_id), org.sows_for(outcome_id))  # noqa: SLF001
+        count += 1
+    print(f"reconciled {count} outcome projection(s) from the ledger")
+    return 0
+
+
 def main(argv: list[str]) -> int:
-    if len(argv) != 2:
+    arguments = [item for item in argv[1:] if not item.startswith("--")]
+    if len(arguments) != 1:
         print(__doc__)
         return 2
-    root = Path(argv[1]).resolve()
+    root = Path(arguments[0]).resolve()
     if not (root / ".sovereign" / "organization.db").is_file():
         print(f"no organization at {root}")
         return 2
+    if "--reconcile" in argv:
+        return reconcile(root)
+
     problems = check(root)
     for problem in problems:
         print(f"DRIFT: {problem}")
     if problems:
         print(f"\n{len(problems)} projection problem(s). The ledger is the authority.")
+        print("Rewrite them with: verify_projections.py <root> --reconcile")
         return 1
     print("projections match the ledger")
     return 0

--- a/scripts/verify_projections.py
+++ b/scripts/verify_projections.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Detect drift between the SQLite ledger and the generated governance files.
+
+Markdown and JSON under `governance/` are projections. They are never read back,
+which means nothing else will ever notice if they go stale or are hand-edited.
+This script notices.
+
+Drift is always resolved TOWARD the database: the ledger is the authority and
+the projection is regenerated. See docs/persistence-boundary.md.
+
+    python scripts/verify_projections.py <organization-root>
+
+Exits 0 when every projection matches the ledger, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from sovereign_agent.governance import project_outcome  # noqa: E402
+from sovereign_agent.organization import Organization  # noqa: E402
+
+
+def check(root: Path) -> list[str]:
+    problems: list[str] = []
+    org = Organization(root)
+    rows = org.db.connection.execute("SELECT id FROM outcomes").fetchall()
+    if not rows:
+        return ["no outcomes in the ledger: nothing to project"]
+
+    for row in rows:
+        outcome_id = str(row["id"])
+        outcome = org._outcome(outcome_id)  # noqa: SLF001
+        sows = org.sows_for(outcome_id)
+        directory = root / "governance" / "outcomes" / outcome_id
+
+        json_path = directory / "outcome.json"
+        if not json_path.is_file():
+            problems.append(f"{outcome_id}: outcome.json is missing")
+        else:
+            on_disk = json.loads(json_path.read_text(encoding="utf-8"))
+            expected = json.loads(json.dumps(outcome.model_dump(mode="json"), default=str))
+            if on_disk != expected:
+                differing = sorted(
+                    key
+                    for key in set(on_disk) | set(expected)
+                    if on_disk.get(key) != expected.get(key)
+                )
+                problems.append(
+                    f"{outcome_id}: outcome.json differs from the ledger "
+                    f"(fields: {', '.join(differing) or 'unknown'})"
+                )
+
+        readme = directory / "README.md"
+        if not readme.is_file():
+            problems.append(f"{outcome_id}: README.md is missing")
+        else:
+            before = readme.read_text(encoding="utf-8")
+            project_outcome(root, outcome, sows)
+            after = readme.read_text(encoding="utf-8")
+            if before != after:
+                problems.append(
+                    f"{outcome_id}: README.md was stale or hand-edited "
+                    "(regenerated from the ledger)"
+                )
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__)
+        return 2
+    root = Path(argv[1]).resolve()
+    if not (root / ".sovereign" / "organization.db").is_file():
+        print(f"no organization at {root}")
+        return 2
+    problems = check(root)
+    for problem in problems:
+        print(f"DRIFT: {problem}")
+    if problems:
+        print(f"\n{len(problems)} projection problem(s). The ledger is the authority.")
+        return 1
+    print("projections match the ledger")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/verify_store_outcome.py
+++ b/scripts/verify_store_outcome.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Assert that an accepted store outcome is ACTUALLY TRUE.
+
+Run this after `sovereign-agent demo store`. It reads the ledger and checks the
+world, rather than trusting the status field — because the whole point of this
+unit is that a status field can lie.
+
+    python scripts/verify_store_outcome.py <organization-root>
+
+Exits 0 only when every claim below holds.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from sovereign_agent.checks import run_check  # noqa: E402
+from sovereign_agent.organization import Organization  # noqa: E402
+
+SKU = "SKU-TEA"
+
+
+def verify(root: Path) -> list[str]:
+    failures: list[str] = []
+    org = Organization(root)
+    db = org.db
+
+    row = db.connection.execute("SELECT id FROM outcomes").fetchone()
+    if row is None:
+        return ["no outcome exists"]
+    outcome_id = str(row["id"])
+    outcome = org._outcome(outcome_id)  # noqa: SLF001
+
+    def fail(message: str) -> None:
+        failures.append(message)
+
+    # 1. The outcome says ACCEPTED.
+    if outcome.state.value != "ACCEPTED":
+        fail(f"outcome state is {outcome.state.value}, expected ACCEPTED")
+
+    # 2. Every declared check passes RIGHT NOW, re-executed against live state.
+    for check_id in outcome.acceptance_checks:
+        result = run_check(db, check_id, SKU)
+        if not result.success:
+            fail(f"check '{check_id}' does not hold now: {result.detail}")
+
+    # 3. Inventory is at or above the reorder point.
+    inventory = db.connection.execute(
+        "SELECT on_hand, reorder_point FROM inventory WHERE sku = ?", (SKU,)
+    ).fetchone()
+    if inventory is None:
+        fail(f"no inventory row for {SKU}")
+    elif int(inventory["on_hand"]) < int(inventory["reorder_point"]):
+        fail(
+            f"inventory {inventory['on_hand']} is below reorder point {inventory['reorder_point']}"
+        )
+
+    # 4. A purchasing cash entry exists, and cash reconciles.
+    purchases = db.connection.execute(
+        "SELECT id, amount_cents, record FROM cash_entries WHERE amount_cents < 0"
+    ).fetchall()
+    if not purchases:
+        fail("no purchasing cash entry")
+
+    # 5. A real replenishment event exists.
+    events = db.connection.execute("SELECT kind, payload FROM events ORDER BY seq").fetchall()
+    kinds = [str(event["kind"]) for event in events]
+    if "replenishment.committed" not in kinds:
+        fail("no replenishment.committed event")
+
+    # 6. No Pulse was fabricated. Pulse is Unit 9.
+    fabricated = [kind for kind in kinds if kind.startswith("pulse.")]
+    if fabricated:
+        fail(f"pulse events before Unit 9: {fabricated}")
+
+    # 7. Every declared check has successful evidence bound to this outcome
+    #    and to the execution that acceptance used.
+    evidence = db.connection.execute(
+        "SELECT check_id, success, assignment_id, state_digest FROM evidence WHERE outcome_id = ?",
+        (outcome_id,),
+    ).fetchall()
+    passing = {str(row["check_id"]) for row in evidence if int(row["success"]) == 1}
+    missing = set(outcome.acceptance_checks) - passing
+    if missing:
+        fail(f"declared checks without successful bound evidence: {sorted(missing)}")
+
+    execution_id = org._latest_assignment_id(outcome_id)  # noqa: SLF001
+    for row in evidence:
+        if str(row["assignment_id"]) != execution_id:
+            fail(f"evidence for '{row['check_id']}' is bound to another execution")
+
+    # 8. Evidence is not stale relative to current state.
+    for check_id in outcome.acceptance_checks:
+        current = run_check(db, check_id, SKU)
+        digests = {str(row["state_digest"]) for row in evidence if str(row["check_id"]) == check_id}
+        if digests and current.state_digest not in digests:
+            fail(f"evidence for '{check_id}' is stale relative to current state")
+
+    # 9. The receipt is successful and digest-bound.
+    receipts = db.connection.execute("SELECT record FROM receipts").fetchall()
+    if not receipts:
+        fail("no receipt recorded")
+    for row in receipts:
+        receipt = json.loads(row["record"])
+        if receipt.get("status") != "completed":
+            fail(f"receipt {receipt.get('id')} status is {receipt.get('status')}")
+    for digest_file in (root / ".sovereign" / "runs").glob("*/receipt.json.sha256"):
+        import hashlib
+
+        receipt_json = (digest_file.parent / "receipt.json").read_text(encoding="utf-8")
+        expected = hashlib.sha256(receipt_json.encode()).hexdigest()
+        if digest_file.read_text(encoding="utf-8").strip() != expected:
+            fail(f"receipt digest mismatch at {digest_file}")
+
+    # 10. Operator, reviewer, and Principal are distinct governed actors.
+    acceptance_row = db.connection.execute(
+        "SELECT record FROM acceptance WHERE outcome_id = ?", (outcome_id,)
+    ).fetchone()
+    if acceptance_row is None:
+        fail("no acceptance record")
+    else:
+        accepted_by = json.loads(acceptance_row["record"])["accepted_by"]
+        performers = org.performers_for(outcome_id)
+        if accepted_by in performers:
+            fail(f"{accepted_by} accepted work it performed")
+        if org.actor(accepted_by).role.value != "principal":
+            fail(f"{accepted_by} is not the Principal")
+        for performer in performers:
+            if org.actor(performer).role.value != "operator":
+                fail(f"performer {performer} is not an operator")
+
+    # 11. Governance projections agree with the ledger.
+    projection = root / "governance" / "outcomes" / outcome_id / "outcome.json"
+    if not projection.is_file():
+        fail("governance projection missing")
+    else:
+        on_disk = json.loads(projection.read_text(encoding="utf-8"))
+        if on_disk.get("state") != outcome.state.value:
+            fail(f"projection says {on_disk.get('state')}, ledger says {outcome.state.value}")
+
+    return failures
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__)
+        return 2
+    root = Path(argv[1]).resolve()
+    if not (root / ".sovereign" / "organization.db").is_file():
+        print(f"no organization at {root}")
+        return 2
+    failures = verify(root)
+    for failure in failures:
+        print(f"FAIL: {failure}")
+    if failures:
+        print(f"\n{len(failures)} problem(s): this outcome is NOT truthfully accepted.")
+        return 1
+    print("ACCEPTED and true: inventory, cash, events, evidence, and actors all check out.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/verify_store_outcome.py
+++ b/scripts/verify_store_outcome.py
@@ -86,54 +86,98 @@ def verify(root: Path) -> list[str]:
     if fabricated:
         fail(f"pulse events before Unit 9: {fabricated}")
 
-    # 7. Every declared check has successful evidence bound to this outcome
-    #    and to the execution that acceptance used.
-    evidence = db.connection.execute(
-        "SELECT check_id, success, assignment_id, state_digest FROM evidence WHERE outcome_id = ?",
-        (outcome_id,),
-    ).fetchall()
-    passing = {str(row["check_id"]) for row in evidence if int(row["success"]) == 1}
-    missing = set(outcome.acceptance_checks) - passing
-    if missing:
-        fail(f"declared checks without successful bound evidence: {sorted(missing)}")
+    # 7. EVERY SOW's proof chain, validated separately. The core permits
+    #    per-SOW executions, so an oracle that assumes one latest execution owns
+    #    all evidence will call a legitimate multi-SOW organization false. Both
+    #    must agree, or the control plane can mint a state its own gate rejects.
+    sows = org.sows_for(outcome_id)
+    if not sows:
+        fail("no SOW for this outcome")
+    newest_verification = None
+    for sow in sows:
+        if sow.state.value != "ACCEPTED":
+            fail(f"SOW {sow.id} is {sow.state.value}, not ACCEPTED")
+            continue
+        execution = org.completed_assignment_for_sow(sow.id)
+        if not execution:
+            fail(f"SOW {sow.id} has no completed execution")
+            continue
 
-    execution_id = org._latest_assignment_id(outcome_id)  # noqa: SLF001
-    for row in evidence:
-        if str(row["assignment_id"]) != execution_id:
-            fail(f"evidence for '{row['check_id']}' is bound to another execution")
+        verification = org.verification_for_sow(sow.id)
+        if verification is None:
+            fail(f"SOW {sow.id} has no verification")
+            continue
+        if verification.assignment_id != execution or verification.sow_id != sow.id:
+            fail(f"verification {verification.id} is not bound to SOW {sow.id}'s execution")
+        newest_verification = verification
 
-    # 8. Evidence is not stale relative to current state.
-    for check_id in outcome.acceptance_checks:
-        current = run_check(db, check_id, subject)
-        digests = {str(row["state_digest"]) for row in evidence if str(row["check_id"]) == check_id}
-        if digests and current.state_digest not in digests:
-            fail(f"evidence for '{check_id}' is stale relative to current state")
+        rows = db.connection.execute(
+            "SELECT check_id, success, assignment_id FROM evidence WHERE verification_id = ?",
+            (verification.id,),
+        ).fetchall()
+        passing = {str(row["check_id"]) for row in rows if int(row["success"]) == 1}
+        missing = set(outcome.acceptance_checks) - passing
+        if missing:
+            fail(f"SOW {sow.id}: checks without successful evidence: {sorted(missing)}")
+        for row in rows:
+            if str(row["assignment_id"]) != execution:
+                fail(f"SOW {sow.id}: evidence for '{row['check_id']}' is bound elsewhere")
 
-    # 9. EXACTLY the receipt for the accepted execution, successful, digest-bound.
-    execution_id = org._latest_assignment_id(outcome_id)  # noqa: SLF001
-    if not execution_id:
-        fail("no execution recorded for this outcome")
-    receipt_rows = db.connection.execute(
-        "SELECT record, status FROM receipts WHERE assignment_id = ?", (execution_id,)
-    ).fetchall()
-    if not receipt_rows:
-        fail(f"no receipt bound to execution {execution_id}")
-    for row in receipt_rows:
-        receipt = json.loads(row["record"])
-        # The indexed column and the canonical record are two sources for one
-        # fact. Requiring agreement means neither can be edited alone.
-        if str(row["status"]) != str(receipt.get("status")):
-            fail(
-                f"receipt {receipt.get('id')} column says {row['status']}, "
-                f"record says {receipt.get('status')}"
-            )
-        if receipt.get("status") != "completed" or str(row["status"]) != "completed":
-            fail(f"receipt {receipt.get('id')} status is {row['status']}")
-        if receipt.get("assignment_id") != execution_id:
-            fail(f"receipt {receipt.get('id')} is not bound to {execution_id}")
+        review_rows = db.connection.execute(
+            "SELECT reviewer_actor_id, decision FROM reviews "
+            "WHERE sow_id = ? AND verification_id = ?",
+            (sow.id, verification.id),
+        ).fetchall()
+        if not review_rows:
+            fail(f"SOW {sow.id} has no review of its current verification")
+        for row in review_rows:
+            if str(row["decision"]) != "accepted":
+                fail(f"SOW {sow.id}: review decision is {row['decision']}")
+            reviewer = str(row["reviewer_actor_id"])
+            if reviewer == json.loads(
+                db.connection.execute(
+                    "SELECT record FROM assignments WHERE id = ?", (execution,)
+                ).fetchone()["record"]
+            ).get("actor_id"):
+                fail(f"SOW {sow.id}: reviewer {reviewer} also performed the work")
 
-    # The sidecar must EXIST and match. Checking it only when present meant
-    # deleting it was not a failure.
+        receipt_rows = db.connection.execute(
+            "SELECT record, status FROM receipts WHERE assignment_id = ?", (execution,)
+        ).fetchall()
+        if not receipt_rows:
+            fail(f"SOW {sow.id}: no receipt bound to execution {execution}")
+        for row in receipt_rows:
+            receipt = json.loads(row["record"])
+            if str(row["status"]) != str(receipt.get("status")):
+                fail(f"SOW {sow.id}: receipt column and record disagree")
+            elif receipt.get("status") != "completed":
+                fail(f"SOW {sow.id}: receipt status is {receipt.get('status')}")
+
+        # Only SOWs that DECLARE a required effect must have changed the world.
+        if sow.required_effect_kind is not None:
+            kinds = org.effect_kinds_for_execution(execution)
+            if sow.required_effect_kind not in kinds:
+                fail(
+                    f"SOW {sow.id} declares {sow.required_effect_kind} but its "
+                    f"execution produced none"
+                )
+
+    # 8. Freshness is checked once, against the verification describing the world
+    #    as acceptance saw it.
+    if newest_verification is not None:
+        for check_id in outcome.acceptance_checks:
+            current = run_check(db, check_id, subject)
+            digests = {
+                str(row["state_digest"])
+                for row in db.connection.execute(
+                    "SELECT state_digest FROM evidence WHERE verification_id = ? AND check_id = ?",
+                    (newest_verification.id, check_id),
+                ).fetchall()
+            }
+            if digests and current.state_digest not in digests:
+                fail(f"evidence for '{check_id}' is stale relative to current state")
+
+    # 9. The receipt sidecars on disk must exist and match.
     workspaces = list((root / ".sovereign" / "runs").glob("*"))
     if not workspaces:
         fail("no run workspace on disk")
@@ -149,23 +193,6 @@ def verify(root: Path) -> list[str]:
         expected = hashlib.sha256(receipt_path.read_text(encoding="utf-8").encode()).hexdigest()
         if digest_path.read_text(encoding="utf-8").strip() != expected:
             fail(f"{workspace.name}: receipt digest does not match receipt.json")
-
-    # 9b. An independent review must exist, have accepted, and name a reviewer
-    #     who is neither a performer nor the accepter.
-    review_rows = db.connection.execute(
-        "SELECT record, decision, reviewer_actor_id FROM reviews WHERE outcome_id = ?",
-        (outcome_id,),
-    ).fetchall()
-    if not review_rows:
-        fail("no review record for this outcome")
-    for row in review_rows:
-        if str(row["decision"]) != "accepted":
-            fail(f"review decision is {row['decision']}")
-        reviewer = str(row["reviewer_actor_id"])
-        if reviewer in org.performers_for(outcome_id):
-            fail(f"reviewer {reviewer} also performed the work")
-        if org.actor(reviewer).role.value not in {"sparring", "verifier", "master"}:
-            fail(f"reviewer {reviewer} does not hold a reviewing role")
 
     # 10. Operator, reviewer, and Principal are distinct governed actors.
     acceptance_row = db.connection.execute(

--- a/scripts/verify_store_outcome.py
+++ b/scripts/verify_store_outcome.py
@@ -93,7 +93,6 @@ def verify(root: Path) -> list[str]:
     sows = org.sows_for(outcome_id)
     if not sows:
         fail("no SOW for this outcome")
-    newest_verification = None
     for sow in sows:
         if sow.state.value != "ACCEPTED":
             fail(f"SOW {sow.id} is {sow.state.value}, not ACCEPTED")
@@ -109,7 +108,6 @@ def verify(root: Path) -> list[str]:
             continue
         if verification.assignment_id != execution or verification.sow_id != sow.id:
             fail(f"verification {verification.id} is not bound to SOW {sow.id}'s execution")
-        newest_verification = verification
 
         rows = db.connection.execute(
             "SELECT check_id, success, assignment_id FROM evidence WHERE verification_id = ?",
@@ -162,16 +160,22 @@ def verify(root: Path) -> list[str]:
                     f"execution produced none"
                 )
 
-    # 8. Freshness is checked once, against the verification describing the world
-    #    as acceptance saw it.
-    if newest_verification is not None:
+    # 8. Freshness is checked once, against the OUTCOME-LEVEL observation --
+    #    selected explicitly, exactly as `Organization.accept()` selects it.
+    #    This used to keep whichever SOW was iterated last, so review order
+    #    changed which batch the oracle called final and the release gate
+    #    rejected organizations the core had legitimately accepted.
+    outcome_observation = org.outcome_verification(outcome_id)
+    if outcome_observation is None:
+        fail("the outcome condition has not been verified")
+    else:
         for check_id in outcome.acceptance_checks:
             current = run_check(db, check_id, subject)
             digests = {
                 str(row["state_digest"])
                 for row in db.connection.execute(
                     "SELECT state_digest FROM evidence WHERE verification_id = ? AND check_id = ?",
-                    (newest_verification.id, check_id),
+                    (outcome_observation.id, check_id),
                 ).fetchall()
             }
             if digests and current.state_digest not in digests:

--- a/scripts/verify_store_outcome.py
+++ b/scripts/verify_store_outcome.py
@@ -19,7 +19,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
+import hashlib  # noqa: E402
+
 from sovereign_agent.checks import run_check  # noqa: E402
+from sovereign_agent.governance import render_outcome  # noqa: E402
 from sovereign_agent.organization import Organization  # noqa: E402
 
 SKU = "SKU-TEA"
@@ -35,7 +38,11 @@ def verify(root: Path) -> list[str]:
         return ["no outcome exists"]
     outcome_id = str(row["id"])
     outcome = org._outcome(outcome_id)  # noqa: SLF001
-    subject = outcome.subject or SKU
+    subject = outcome.subject
+    if not subject:
+        # `outcome.subject or SKU` silently re-pointed a subjectless outcome at
+        # tea and reported "ACCEPTED and true". Reported on PR #24.
+        return [f"outcome {outcome_id} declares no subject: nothing to check it against"]
 
     def fail(message: str) -> None:
         failures.append(message)
@@ -102,21 +109,63 @@ def verify(root: Path) -> list[str]:
         if digests and current.state_digest not in digests:
             fail(f"evidence for '{check_id}' is stale relative to current state")
 
-    # 9. The receipt is successful and digest-bound.
-    receipts = db.connection.execute("SELECT record FROM receipts").fetchall()
-    if not receipts:
-        fail("no receipt recorded")
-    for row in receipts:
+    # 9. EXACTLY the receipt for the accepted execution, successful, digest-bound.
+    execution_id = org._latest_assignment_id(outcome_id)  # noqa: SLF001
+    if not execution_id:
+        fail("no execution recorded for this outcome")
+    receipt_rows = db.connection.execute(
+        "SELECT record, status FROM receipts WHERE assignment_id = ?", (execution_id,)
+    ).fetchall()
+    if not receipt_rows:
+        fail(f"no receipt bound to execution {execution_id}")
+    for row in receipt_rows:
         receipt = json.loads(row["record"])
-        if receipt.get("status") != "completed":
-            fail(f"receipt {receipt.get('id')} status is {receipt.get('status')}")
-    for digest_file in (root / ".sovereign" / "runs").glob("*/receipt.json.sha256"):
-        import hashlib
+        # The indexed column and the canonical record are two sources for one
+        # fact. Requiring agreement means neither can be edited alone.
+        if str(row["status"]) != str(receipt.get("status")):
+            fail(
+                f"receipt {receipt.get('id')} column says {row['status']}, "
+                f"record says {receipt.get('status')}"
+            )
+        if receipt.get("status") != "completed" or str(row["status"]) != "completed":
+            fail(f"receipt {receipt.get('id')} status is {row['status']}")
+        if receipt.get("assignment_id") != execution_id:
+            fail(f"receipt {receipt.get('id')} is not bound to {execution_id}")
 
-        receipt_json = (digest_file.parent / "receipt.json").read_text(encoding="utf-8")
-        expected = hashlib.sha256(receipt_json.encode()).hexdigest()
-        if digest_file.read_text(encoding="utf-8").strip() != expected:
-            fail(f"receipt digest mismatch at {digest_file}")
+    # The sidecar must EXIST and match. Checking it only when present meant
+    # deleting it was not a failure.
+    workspaces = list((root / ".sovereign" / "runs").glob("*"))
+    if not workspaces:
+        fail("no run workspace on disk")
+    for workspace in workspaces:
+        receipt_path = workspace / "receipt.json"
+        digest_path = workspace / "receipt.json.sha256"
+        if not receipt_path.is_file():
+            fail(f"{workspace.name}: receipt.json is missing")
+            continue
+        if not digest_path.is_file():
+            fail(f"{workspace.name}: receipt.json.sha256 is missing")
+            continue
+        expected = hashlib.sha256(receipt_path.read_text(encoding="utf-8").encode()).hexdigest()
+        if digest_path.read_text(encoding="utf-8").strip() != expected:
+            fail(f"{workspace.name}: receipt digest does not match receipt.json")
+
+    # 9b. An independent review must exist, have accepted, and name a reviewer
+    #     who is neither a performer nor the accepter.
+    review_rows = db.connection.execute(
+        "SELECT record, decision, reviewer_actor_id FROM reviews WHERE outcome_id = ?",
+        (outcome_id,),
+    ).fetchall()
+    if not review_rows:
+        fail("no review record for this outcome")
+    for row in review_rows:
+        if str(row["decision"]) != "accepted":
+            fail(f"review decision is {row['decision']}")
+        reviewer = str(row["reviewer_actor_id"])
+        if reviewer in org.performers_for(outcome_id):
+            fail(f"reviewer {reviewer} also performed the work")
+        if org.actor(reviewer).role.value not in {"sparring", "verifier", "master"}:
+            fail(f"reviewer {reviewer} does not hold a reviewing role")
 
     # 10. Operator, reviewer, and Principal are distinct governed actors.
     acceptance_row = db.connection.execute(
@@ -131,18 +180,21 @@ def verify(root: Path) -> list[str]:
             fail(f"{accepted_by} accepted work it performed")
         if org.actor(accepted_by).role.value != "principal":
             fail(f"{accepted_by} is not the Principal")
+        for row in review_rows:
+            if str(row["reviewer_actor_id"]) == accepted_by:
+                fail(f"{accepted_by} both reviewed and accepted")
         for performer in performers:
             if org.actor(performer).role.value != "operator":
                 fail(f"performer {performer} is not an operator")
 
-    # 11. Governance projections agree with the ledger.
-    projection = root / "governance" / "outcomes" / outcome_id / "outcome.json"
-    if not projection.is_file():
-        fail("governance projection missing")
-    else:
-        on_disk = json.loads(projection.read_text(encoding="utf-8"))
-        if on_disk.get("state") != outcome.state.value:
-            fail(f"projection says {on_disk.get('state')}, ledger says {outcome.state.value}")
+    # 11. EVERY projected file matches the ledger byte for byte, not just `state`.
+    directory = root / "governance" / "outcomes" / outcome_id
+    for name, data in render_outcome(outcome, org.sows_for(outcome_id)).items():
+        path = directory / name
+        if not path.is_file():
+            fail(f"projection {name} is missing")
+        elif path.read_bytes() != data:
+            fail(f"projection {name} does not match the ledger")
 
     return failures
 

--- a/scripts/verify_store_outcome.py
+++ b/scripts/verify_store_outcome.py
@@ -35,6 +35,7 @@ def verify(root: Path) -> list[str]:
         return ["no outcome exists"]
     outcome_id = str(row["id"])
     outcome = org._outcome(outcome_id)  # noqa: SLF001
+    subject = outcome.subject or SKU
 
     def fail(message: str) -> None:
         failures.append(message)
@@ -45,16 +46,16 @@ def verify(root: Path) -> list[str]:
 
     # 2. Every declared check passes RIGHT NOW, re-executed against live state.
     for check_id in outcome.acceptance_checks:
-        result = run_check(db, check_id, SKU)
+        result = run_check(db, check_id, subject)
         if not result.success:
             fail(f"check '{check_id}' does not hold now: {result.detail}")
 
     # 3. Inventory is at or above the reorder point.
     inventory = db.connection.execute(
-        "SELECT on_hand, reorder_point FROM inventory WHERE sku = ?", (SKU,)
+        "SELECT on_hand, reorder_point FROM inventory WHERE sku = ?", (subject,)
     ).fetchone()
     if inventory is None:
-        fail(f"no inventory row for {SKU}")
+        fail(f"no inventory row for {subject}")
     elif int(inventory["on_hand"]) < int(inventory["reorder_point"]):
         fail(
             f"inventory {inventory['on_hand']} is below reorder point {inventory['reorder_point']}"
@@ -96,7 +97,7 @@ def verify(root: Path) -> list[str]:
 
     # 8. Evidence is not stale relative to current state.
     for check_id in outcome.acceptance_checks:
-        current = run_check(db, check_id, SKU)
+        current = run_check(db, check_id, subject)
         digests = {str(row["state_digest"]) for row in evidence if str(row["check_id"]) == check_id}
         if digests and current.state_digest not in digests:
             fail(f"evidence for '{check_id}' is stale relative to current state")

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from dataclasses import dataclass
 
 from sovereign_agent.database import Database
@@ -49,40 +50,48 @@ def seed(db: Database) -> None:
 
 
 def record_sale(db: Database, sku: str, quantity: int, unit_price_cents: int) -> Signal:
-    """Mutate inventory and cash in the same transaction as the recording event."""
-    row = db.connection.execute(
-        "SELECT on_hand, reorder_point FROM inventory WHERE sku = ?", (sku,)
-    ).fetchone()
-    if row is None:
-        raise Refusal(
-            "Unknown SKU.", "Actors cannot invent inventory.", "inventory list", "Seed the catalog."
+    """Mutate inventory and cash in the same transaction as the recording event.
+
+    The read of current stock happens INSIDE the immediate transaction. Reading
+    first and writing later lets two concurrent sales both see enough stock and
+    both sell it.
+    """
+    with db.immediate() as connection:
+        row = connection.execute(
+            "SELECT on_hand, reorder_point FROM inventory WHERE sku = ?", (sku,)
+        ).fetchone()
+        if row is None:
+            raise Refusal(
+                "Unknown SKU.",
+                "Actors cannot invent inventory.",
+                "inventory list",
+                "Seed the catalog.",
+            )
+        on_hand = int(row["on_hand"]) - quantity
+        if on_hand < 0:
+            raise Refusal(
+                "Sale would go negative.",
+                "The ledger refuses unrecorded stock.",
+                "status",
+                "Restock first.",
+            )
+        cash_id = new_id("cash")
+        signal = Signal(
+            id=new_id("sig"),
+            kind="inventory.changed",
+            source="sale",
+            subject_ref=sku,
+            severity="warning" if on_hand <= int(row["reorder_point"]) else "info",
+            observed_at=utc_now(),
+            payload_digest=sku,
+            dedupe_key=f"inventory:{sku}:{on_hand}",
         )
-    on_hand = int(row["on_hand"]) - quantity
-    if on_hand < 0:
-        raise Refusal(
-            "Sale would go negative.",
-            "The ledger refuses unrecorded stock.",
-            "status",
-            "Restock first.",
-        )
-    cash_id = new_id("cash")
-    signal = Signal(
-        id=new_id("sig"),
-        kind="inventory.changed",
-        source="sale",
-        subject_ref=sku,
-        severity="warning" if on_hand <= int(row["reorder_point"]) else "info",
-        observed_at=utc_now(),
-        payload_digest=sku,
-        dedupe_key=f"inventory:{sku}:{on_hand}",
-    )
-    with db.transaction():
-        db.connection.execute("UPDATE inventory SET on_hand = ? WHERE sku = ?", (on_hand, sku))
-        db.connection.execute(
+        connection.execute("UPDATE inventory SET on_hand = ? WHERE sku = ?", (on_hand, sku))
+        connection.execute(
             "INSERT INTO cash_entries(id, amount_cents, record) VALUES (?, ?, ?)",
             (cash_id, quantity * unit_price_cents, json.dumps({"sku": sku, "qty": quantity})),
         )
-        db.connection.execute(
+        connection.execute(
             "INSERT OR REPLACE INTO signals(id, dedupe_key, record) VALUES (?, ?, ?)",
             (signal.id, signal.dedupe_key, signal.model_dump_json()),
         )
@@ -151,7 +160,9 @@ def _state_digest(db: Database, sku: str) -> str:
     return digest_payload(facts)
 
 
-def validate_restock(db: Database, proposal: RestockProposal) -> tuple[int, int]:
+def _validate_restock_locked(
+    connection: sqlite3.Connection, proposal: RestockProposal
+) -> tuple[int, int]:
     """Refuse an unsound proposal. Returns (unit_cost_cents, total_cost_cents).
 
     This is the trusted boundary. It runs in Python, reads authoritative rows,
@@ -171,7 +182,7 @@ def validate_restock(db: Database, proposal: RestockProposal) -> tuple[int, int]
             "sovereign-agent status",
             f"Propose at most {MAX_RESTOCK_UNITS} units.",
         )
-    product = db.connection.execute(
+    product = connection.execute(
         "SELECT record FROM products WHERE sku = ?", (proposal.sku,)
     ).fetchone()
     if product is None:
@@ -182,7 +193,7 @@ def validate_restock(db: Database, proposal: RestockProposal) -> tuple[int, int]
             "Propose a SKU that exists in the catalog.",
         )
     if (
-        db.connection.execute("SELECT 1 FROM inventory WHERE sku = ?", (proposal.sku,)).fetchone()
+        connection.execute("SELECT 1 FROM inventory WHERE sku = ?", (proposal.sku,)).fetchone()
         is None
     ):
         raise Refusal(
@@ -193,7 +204,11 @@ def validate_restock(db: Database, proposal: RestockProposal) -> tuple[int, int]
         )
     unit_cost = int(json.loads(product["record"])["unit_cost_cents"])
     total = unit_cost * proposal.quantity
-    balance = cash_balance_cents(db)
+    balance = int(
+        connection.execute(
+            "SELECT COALESCE(SUM(amount_cents), 0) AS total FROM cash_entries"
+        ).fetchone()["total"]
+    )
     if total > balance:
         raise Refusal(
             f"Restock costs {total} but only {balance} cash is available.",
@@ -204,75 +219,91 @@ def validate_restock(db: Database, proposal: RestockProposal) -> tuple[int, int]
     return unit_cost, total
 
 
+def validate_restock(db: Database, proposal: RestockProposal) -> tuple[int, int]:
+    """Public validation helper. Reads the same facts `apply_restock` re-checks
+    under lock; use it to explain a refusal, never as authority to act."""
+    return _validate_restock_locked(db.connection, proposal)
+
+
 def apply_restock(
     db: Database, proposal: RestockProposal, assignment_id: str, signal_id: str | None = None
 ) -> dict[str, object]:
     """Validate, then commit inventory, cash, and the event in ONE transaction.
 
-    Idempotent per assignment: replaying the same assignment is a no-op, so a
-    retried execution cannot double-order stock.
-    """
-    # Idempotency is keyed on (assignment, sku). Keying on the assignment alone
-    # would let a replay for one product silently report success for another.
-    #
-    # This scan runs BEFORE validation, so replaying an already-committed pair
-    # returns the original payload without re-checking the proposal. A garbage
-    # quantity on a replayed pair is therefore reported as success rather than
-    # refused. The world does not move -- this masks an invalid proposal, it does
-    # not act on one -- but the asymmetry is deliberate and worth knowing.
-    existing = db.connection.execute(
-        "SELECT payload FROM events WHERE kind = 'replenishment.committed'"
-    ).fetchall()
-    for row in existing:
-        payload = json.loads(row["payload"])
-        if (payload.get("assignment_id"), payload.get("sku")) == (
-            assignment_id,
-            proposal.sku,
-        ):
-            return {**payload, "idempotent_replay": True}
+    Everything that decides whether to act -- the idempotency claim, the
+    validation, the cash check -- happens INSIDE a `BEGIN IMMEDIATE`, together
+    with the writes. An earlier version scanned the event log and validated cash
+    before opening its transaction, so two concurrent retries both passed the
+    scan and both ordered: on_hand went to 14 with two purchase entries.
 
-    unit_cost, total = validate_restock(db, proposal)
-    cash_id = new_id("cash")
-    with db.transaction():
-        db.connection.execute(
-            "UPDATE inventory SET on_hand = on_hand + ? WHERE sku = ?",
-            (proposal.quantity, proposal.sku),
-        )
-        # Purchases are NEGATIVE: cash leaves the organization to buy stock.
-        db.connection.execute(
-            "INSERT INTO cash_entries(id, amount_cents, record) VALUES (?, ?, ?)",
-            (
-                cash_id,
-                -total,
-                json.dumps(
-                    {
-                        "reason": "purchase",
-                        "sku": proposal.sku,
-                        "qty": proposal.quantity,
-                        "unit_cost_cents": unit_cost,
-                        "assignment_id": assignment_id,
-                    }
-                ),
-            ),
-        )
-        if signal_id is not None:
-            db.connection.execute(
-                "UPDATE signals SET record = json_set(record, '$.severity', 'resolved') "
-                "WHERE id = ?",
-                (signal_id,),
+    Idempotency is a PRIMARY KEY on (assignment, sku) in `effect_keys`, not a
+    scan. The database refuses the second claim; nothing depends on timing.
+    """
+    key = f"restock:{assignment_id}:{proposal.sku}"
+    try:
+        with db.immediate() as connection:
+            existing = connection.execute(
+                "SELECT payload FROM effect_keys WHERE key = ?", (key,)
+            ).fetchone()
+            if existing is not None:
+                return {**json.loads(existing["payload"]), "idempotent_replay": True}
+
+            unit_cost, total = _validate_restock_locked(connection, proposal)
+            cash_id = new_id("cash")
+            connection.execute(
+                "UPDATE inventory SET on_hand = on_hand + ? WHERE sku = ?",
+                (proposal.quantity, proposal.sku),
             )
+            # Purchases are NEGATIVE: cash leaves the organization to buy stock.
+            connection.execute(
+                "INSERT INTO cash_entries(id, amount_cents, record) VALUES (?, ?, ?)",
+                (
+                    cash_id,
+                    -total,
+                    json.dumps(
+                        {
+                            "reason": "purchase",
+                            "sku": proposal.sku,
+                            "qty": proposal.quantity,
+                            "unit_cost_cents": unit_cost,
+                            "assignment_id": assignment_id,
+                        }
+                    ),
+                ),
+            )
+            if signal_id is not None:
+                connection.execute(
+                    "UPDATE signals SET record = json_set(record, '$.severity', 'resolved') "
+                    "WHERE id = ?",
+                    (signal_id,),
+                )
+            row = connection.execute(
+                "SELECT on_hand FROM inventory WHERE sku = ?", (proposal.sku,)
+            ).fetchone()
+            payload = {
+                "sku": proposal.sku,
+                "qty": proposal.quantity,
+                "unit_cost_cents": unit_cost,
+                "total_cost_cents": total,
+                "on_hand": int(row["on_hand"]),
+                "cash_id": cash_id,
+                "assignment_id": assignment_id,
+                "signal_id": signal_id,
+            }
+            # The PRIMARY KEY makes a concurrent second claim fail here, inside
+            # the same transaction that does the work, so it rolls back with it.
+            connection.execute(
+                "INSERT INTO effect_keys(key, kind, payload, created_at) VALUES (?, ?, ?, ?)",
+                (key, "replenishment", json.dumps(payload), utc_now().isoformat()),
+            )
+            append_event(db, "replenishment.committed", payload)
+            return payload
+    except sqlite3.IntegrityError as error:
+        if "effect_keys" not in str(error):
+            raise
         row = db.connection.execute(
-            "SELECT on_hand FROM inventory WHERE sku = ?", (proposal.sku,)
+            "SELECT payload FROM effect_keys WHERE key = ?", (key,)
         ).fetchone()
-        payload = {
-            "sku": proposal.sku,
-            "qty": proposal.quantity,
-            "unit_cost_cents": unit_cost,
-            "total_cost_cents": total,
-            "on_hand": int(row["on_hand"]),
-            "cash_id": cash_id,
-            "assignment_id": assignment_id,
-            "signal_id": signal_id,
-        }
-        append_event(db, "replenishment.committed", payload)
-    return payload
+        if row is None:
+            raise
+        return {**json.loads(row["payload"]), "idempotent_replay": True}

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -22,6 +22,32 @@ class Product:
     price_cents: int
 
 
+@dataclass(frozen=True)
+class CashEntry:
+    """One movement of money, as a signed amount in cents.
+
+    Cash is a ledger of movements, not a balance field. The balance is
+    `SUM(amount_cents)`, so nothing overwrites a total and nothing can quietly
+    lose money. Sales are positive; purchases are negative.
+
+    `assignment_id` is present so a purchase can be tied to the execution that
+    authorized it -- `cash_reconciles` uses exactly that link to check the money
+    that moved matches the replenishment that was committed.
+    """
+
+    id: str
+    amount_cents: int
+    reason: str
+    sku: str | None = None
+    qty: int | None = None
+    unit_cost_cents: int | None = None
+    assignment_id: str | None = None
+
+    @property
+    def is_purchase(self) -> bool:
+        return self.amount_cents < 0
+
+
 @dataclass
 class InventoryPosition:
     sku: str
@@ -107,6 +133,28 @@ def record_sale(db: Database, sku: str, quantity: int, unit_price_cents: int) ->
             },
         )
     return signal
+
+
+def cash_entries(db: Database) -> list[CashEntry]:
+    """Read the cash ledger as domain records rather than raw rows."""
+    rows = db.connection.execute(
+        "SELECT id, amount_cents, record FROM cash_entries ORDER BY rowid"
+    ).fetchall()
+    entries: list[CashEntry] = []
+    for row in rows:
+        record = json.loads(row["record"])
+        entries.append(
+            CashEntry(
+                id=str(row["id"]),
+                amount_cents=int(row["amount_cents"]),
+                reason=str(record.get("reason", "sale" if int(row["amount_cents"]) > 0 else "")),
+                sku=record.get("sku"),
+                qty=record.get("qty"),
+                unit_cost_cents=record.get("unit_cost_cents"),
+                assignment_id=record.get("assignment_id"),
+            )
+        )
+    return entries
 
 
 def below_reorder(db: Database) -> list[str]:

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -208,6 +208,92 @@ def _state_digest(db: Database, sku: str) -> str:
     return digest_payload(facts)
 
 
+def _authorize_effect(
+    connection: sqlite3.Connection, assignment_id: str, subject: str
+) -> dict[str, str]:
+    """Prove the assignment authorizing this effect is real, done, and relevant.
+
+    An effect used to accept any string as its `assignment_id`, so the ledger
+    could show that SOME assignment completed and that SOME replenishment
+    happened while nothing established the first caused the second. Two true
+    facts arranged so their conjunction implies something false -- the same
+    shape as the defect this unit exists to remove.
+
+    Runs inside the caller's immediate transaction, so the authorization cannot
+    be invalidated between the check and the write.
+    """
+    if not assignment_id:
+        raise Refusal(
+            "The effect names no assignment.",
+            "An unattributed change to the world has no authority behind it.",
+            "sovereign-agent status",
+            "Run the assignment that authorizes this effect.",
+        )
+    row = connection.execute(
+        "SELECT a.record AS assignment, s.record AS sow, s.outcome_id AS outcome_id "
+        "FROM assignments a JOIN sows s ON s.id = a.sow_id WHERE a.id = ?",
+        (assignment_id,),
+    ).fetchone()
+    if row is None:
+        raise Refusal(
+            f"Assignment {assignment_id} is not in the ledger.",
+            "Effects are authorized by real assignments, not by naming one.",
+            "sovereign-agent status",
+            "Use the id of an assignment that actually ran.",
+        )
+    assignment = json.loads(row["assignment"])
+    if assignment.get("state") != "COMPLETED":
+        raise Refusal(
+            f"Assignment {assignment_id} is {assignment.get('state')}, not COMPLETED.",
+            "Work that has not finished cannot authorize a change to the world.",
+            "sovereign-agent status",
+            "Finish the assignment first.",
+        )
+
+    receipt = connection.execute(
+        "SELECT record, status FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    if receipt is None:
+        raise Refusal(
+            f"Assignment {assignment_id} has no receipt.",
+            "An execution with no receipt left no evidence that it ran.",
+            "sovereign-agent status",
+            "Re-run the assignment.",
+        )
+    record = json.loads(receipt["record"])
+    if str(receipt["status"]) != "completed" or record.get("status") != "completed":
+        raise Refusal(
+            f"The receipt for {assignment_id} reports {receipt['status']}.",
+            "A failed execution cannot authorize an effect.",
+            "sovereign-agent status",
+            "Fix the failure and re-run.",
+        )
+
+    actor = connection.execute(
+        "SELECT record FROM actors WHERE id = ?", (assignment["actor_id"],)
+    ).fetchone()
+    if actor is None or "write_workspace" not in json.loads(actor["record"]).get("authority", []):
+        raise Refusal(
+            f"Actor {assignment['actor_id']} lacks authority to change the world.",
+            "Authority comes from the role table, not from having run.",
+            "sovereign-agent actor list",
+            "Assign an actor whose authority permits this work.",
+        )
+
+    outcome = connection.execute(
+        "SELECT record FROM outcomes WHERE id = ?", (row["outcome_id"],)
+    ).fetchone()
+    declared = json.loads(outcome["record"]).get("subject") if outcome else None
+    if declared and declared != subject:
+        raise Refusal(
+            f"This effect changes {subject}, but the outcome is about {declared}.",
+            "An effect must move the thing the outcome is about.",
+            "sovereign-agent status",
+            f"Apply the effect to {declared}.",
+        )
+    return {"outcome_id": str(row["outcome_id"]), "actor_id": str(assignment["actor_id"])}
+
+
 def _validate_restock_locked(
     connection: sqlite3.Connection, proposal: RestockProposal
 ) -> tuple[int, int]:
@@ -284,18 +370,21 @@ def apply_restock(
     before opening its transaction, so two concurrent retries both passed the
     scan and both ordered: on_hand went to 14 with two purchase entries.
 
-    Idempotency is a PRIMARY KEY on (assignment, sku) in `effect_keys`, not a
-    scan. The database refuses the second claim; nothing depends on timing.
+    Idempotency is `UNIQUE(assignment_id, kind, subject)` in `effects`, not a
+    scan. The database refuses the second claim; nothing depends on timing, and
+    a foreign key means a fabricated assignment cannot be named at all.
     """
-    key = f"restock:{assignment_id}:{proposal.sku}"
     try:
         with db.immediate() as connection:
             existing = connection.execute(
-                "SELECT payload FROM effect_keys WHERE key = ?", (key,)
+                "SELECT payload FROM effects WHERE assignment_id = ? AND kind = ? AND subject = ?",
+                (assignment_id, "replenishment", proposal.sku),
             ).fetchone()
             if existing is not None:
                 return {**json.loads(existing["payload"]), "idempotent_replay": True}
 
+            # Authority FIRST, inside the same lock as the write.
+            authorization = _authorize_effect(connection, assignment_id, proposal.sku)
             unit_cost, total = _validate_restock_locked(connection, proposal)
             cash_id = new_id("cash")
             connection.execute(
@@ -336,21 +425,33 @@ def apply_restock(
                 "on_hand": int(row["on_hand"]),
                 "cash_id": cash_id,
                 "assignment_id": assignment_id,
+                "outcome_id": authorization["outcome_id"],
                 "signal_id": signal_id,
             }
-            # The PRIMARY KEY makes a concurrent second claim fail here, inside
-            # the same transaction that does the work, so it rolls back with it.
+            # UNIQUE(assignment_id, kind, subject) makes a concurrent second
+            # claim fail here, inside the transaction that does the work, so it
+            # rolls back with it. The FK makes a fabricated assignment
+            # un-insertable at the database boundary.
             connection.execute(
-                "INSERT INTO effect_keys(key, kind, payload, created_at) VALUES (?, ?, ?, ?)",
-                (key, "replenishment", json.dumps(payload), utc_now().isoformat()),
+                "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    new_id("eff"),
+                    assignment_id,
+                    "replenishment",
+                    proposal.sku,
+                    json.dumps(payload),
+                    utc_now().isoformat(),
+                ),
             )
             append_event(db, "replenishment.committed", payload)
             return payload
     except sqlite3.IntegrityError as error:
-        if "effect_keys" not in str(error):
+        if "effects" not in str(error):
             raise
         row = db.connection.execute(
-            "SELECT payload FROM effect_keys WHERE key = ?", (key,)
+            "SELECT payload FROM effects WHERE assignment_id = ? AND kind = ? AND subject = ?",
+            (assignment_id, "replenishment", proposal.sku),
         ).fetchone()
         if row is None:
             raise

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -433,8 +433,8 @@ def apply_restock(
             # rolls back with it. The FK makes a fabricated assignment
             # un-insertable at the database boundary.
             connection.execute(
-                "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
+                "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at, "
+                "outcome_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     new_id("eff"),
                     assignment_id,
@@ -442,6 +442,7 @@ def apply_restock(
                     proposal.sku,
                     json.dumps(payload),
                     utc_now().isoformat(),
+                    authorization["outcome_id"],
                 ),
             )
             append_event(db, "replenishment.committed", payload)

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -212,12 +212,18 @@ def apply_restock(
     Idempotent per assignment: replaying the same assignment is a no-op, so a
     retried execution cannot double-order stock.
     """
+    # Idempotency is keyed on (assignment, sku). Keying on the assignment alone
+    # would let a replay for one product silently report success for another.
     existing = db.connection.execute(
         "SELECT payload FROM events WHERE kind = 'replenishment.committed'"
     ).fetchall()
     for row in existing:
-        if json.loads(row["payload"]).get("assignment_id") == assignment_id:
-            return {**json.loads(row["payload"]), "idempotent_replay": True}
+        payload = json.loads(row["payload"])
+        if (payload.get("assignment_id"), payload.get("sku")) == (
+            assignment_id,
+            proposal.sku,
+        ):
+            return {**payload, "idempotent_replay": True}
 
     unit_cost, total = validate_restock(db, proposal)
     cash_id = new_id("cash")

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from sovereign_agent.database import Database
 from sovereign_agent.errors import Refusal
 from sovereign_agent.events import append_event
+from sovereign_agent.evidence import digest_payload
 from sovereign_agent.ids import new_id, utc_now
 from sovereign_agent.models import Signal
 
@@ -111,3 +112,155 @@ def cash_balance_cents(db: Database) -> int:
         "SELECT COALESCE(SUM(amount_cents), 0) AS total FROM cash_entries"
     ).fetchone()
     return int(row["total"])
+
+
+@dataclass(frozen=True)
+class RestockProposal:
+    """What an intelligence provider is allowed to ASK for.
+
+    A provider fills this in. It carries no authority: every field is re-checked
+    by `apply_restock` against the ledger before anything is written. Note what
+    is absent — there is no price, no cost, and no cash amount. Cost comes from
+    the product record, so a provider cannot talk the organization into paying
+    more by writing a bigger number.
+    """
+
+    sku: str
+    quantity: int
+
+
+MAX_RESTOCK_UNITS = 50
+
+
+def _state_digest(db: Database, sku: str) -> str:
+    """Digest the exact facts a check reads: inventory row plus cash total.
+
+    An event counter cannot see a silent `UPDATE inventory`. This digest changes
+    if and only if one of the values a check depends on changes.
+    """
+    row = db.connection.execute(
+        "SELECT on_hand, reserved, reorder_point FROM inventory WHERE sku = ?", (sku,)
+    ).fetchone()
+    facts = {
+        "sku": sku,
+        "on_hand": None if row is None else int(row["on_hand"]),
+        "reserved": None if row is None else int(row["reserved"]),
+        "reorder_point": None if row is None else int(row["reorder_point"]),
+        "cash_cents": cash_balance_cents(db),
+    }
+    return digest_payload(facts)
+
+
+def validate_restock(db: Database, proposal: RestockProposal) -> tuple[int, int]:
+    """Refuse an unsound proposal. Returns (unit_cost_cents, total_cost_cents).
+
+    This is the trusted boundary. It runs in Python, reads authoritative rows,
+    and never consults the provider for a value it can look up itself.
+    """
+    if proposal.quantity <= 0:
+        raise Refusal(
+            f"Proposed restock quantity {proposal.quantity} is not positive.",
+            "An effect must move the world in the direction it claims.",
+            "sovereign-agent status",
+            "Propose a quantity of at least 1.",
+        )
+    if proposal.quantity > MAX_RESTOCK_UNITS:
+        raise Refusal(
+            f"Proposed restock of {proposal.quantity} exceeds the bound of {MAX_RESTOCK_UNITS}.",
+            "Bounded authority: a provider may propose, but not without limit.",
+            "sovereign-agent status",
+            f"Propose at most {MAX_RESTOCK_UNITS} units.",
+        )
+    product = db.connection.execute(
+        "SELECT record FROM products WHERE sku = ?", (proposal.sku,)
+    ).fetchone()
+    if product is None:
+        raise Refusal(
+            f"Unknown SKU {proposal.sku}.",
+            "Actors cannot invent a product by naming one.",
+            "sqlite3 .sovereign/organization.db 'select sku from products'",
+            "Propose a SKU that exists in the catalog.",
+        )
+    if (
+        db.connection.execute("SELECT 1 FROM inventory WHERE sku = ?", (proposal.sku,)).fetchone()
+        is None
+    ):
+        raise Refusal(
+            f"No inventory row for {proposal.sku}.",
+            "Restock adjusts a position that must already exist.",
+            "sovereign-agent status",
+            "Seed the catalog first.",
+        )
+    unit_cost = int(json.loads(product["record"])["unit_cost_cents"])
+    total = unit_cost * proposal.quantity
+    balance = cash_balance_cents(db)
+    if total > balance:
+        raise Refusal(
+            f"Restock costs {total} but only {balance} cash is available.",
+            "The organization refuses to spend money it does not have.",
+            "sovereign-agent status",
+            "Propose a smaller quantity.",
+        )
+    return unit_cost, total
+
+
+def apply_restock(
+    db: Database, proposal: RestockProposal, assignment_id: str, signal_id: str | None = None
+) -> dict[str, object]:
+    """Validate, then commit inventory, cash, and the event in ONE transaction.
+
+    Idempotent per assignment: replaying the same assignment is a no-op, so a
+    retried execution cannot double-order stock.
+    """
+    existing = db.connection.execute(
+        "SELECT payload FROM events WHERE kind = 'replenishment.committed'"
+    ).fetchall()
+    for row in existing:
+        if json.loads(row["payload"]).get("assignment_id") == assignment_id:
+            return {**json.loads(row["payload"]), "idempotent_replay": True}
+
+    unit_cost, total = validate_restock(db, proposal)
+    cash_id = new_id("cash")
+    with db.transaction():
+        db.connection.execute(
+            "UPDATE inventory SET on_hand = on_hand + ? WHERE sku = ?",
+            (proposal.quantity, proposal.sku),
+        )
+        # Purchases are NEGATIVE: cash leaves the organization to buy stock.
+        db.connection.execute(
+            "INSERT INTO cash_entries(id, amount_cents, record) VALUES (?, ?, ?)",
+            (
+                cash_id,
+                -total,
+                json.dumps(
+                    {
+                        "reason": "purchase",
+                        "sku": proposal.sku,
+                        "qty": proposal.quantity,
+                        "unit_cost_cents": unit_cost,
+                        "assignment_id": assignment_id,
+                    }
+                ),
+            ),
+        )
+        if signal_id is not None:
+            db.connection.execute(
+                "UPDATE signals SET record = json_set(record, '$.severity', 'resolved') "
+                "WHERE id = ?",
+                (signal_id,),
+            )
+        row = db.connection.execute(
+            "SELECT on_hand FROM inventory WHERE sku = ?", (proposal.sku,)
+        ).fetchone()
+        payload = {
+            "sku": proposal.sku,
+            "qty": proposal.quantity,
+            "unit_cost_cents": unit_cost,
+            "total_cost_cents": total,
+            "on_hand": int(row["on_hand"]),
+            "cash_id": cash_id,
+            "assignment_id": assignment_id,
+            "signal_id": signal_id,
+        }
+        append_event(db, "replenishment.committed", payload)
+    return payload

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -214,6 +214,12 @@ def apply_restock(
     """
     # Idempotency is keyed on (assignment, sku). Keying on the assignment alone
     # would let a replay for one product silently report success for another.
+    #
+    # This scan runs BEFORE validation, so replaying an already-committed pair
+    # returns the original payload without re-checking the proposal. A garbage
+    # quantity on a replayed pair is therefore reported as success rather than
+    # refused. The world does not move -- this masks an invalid proposal, it does
+    # not act on one -- but the asymmetry is deliberate and worth knowing.
     existing = db.connection.execute(
         "SELECT payload FROM events WHERE kind = 'replenishment.committed'"
     ).fetchall()

--- a/src/reference_organizations/store/demo.py
+++ b/src/reference_organizations/store/demo.py
@@ -81,6 +81,7 @@ def run_simulated(root: Path) -> str:
             "replenishment_event_exists",
         ],
         owner="principal-human",
+        subject=SKU,
     )
     org.activate(outcome.id, "master-course")
 
@@ -106,6 +107,6 @@ def run_simulated(root: Path) -> str:
     apply_restock(org.db, proposal, assignment.id, signal.id)
 
     org.review(sow.id, "sparring-course", "operator-course")
-    org.verify_outcome(outcome.id, "verifier-course", SKU)
-    org.accept(outcome.id, "principal-human", SKU)
+    org.verify_outcome(outcome.id, "verifier-course")
+    org.accept(outcome.id, "principal-human")
     return org.status_text(outcome.id)

--- a/src/reference_organizations/store/demo.py
+++ b/src/reference_organizations/store/demo.py
@@ -106,7 +106,8 @@ def run_simulated(root: Path) -> str:
     proposal = propose_restock_from_report(report_path, SKU)
     apply_restock(org.db, proposal, assignment.id, signal.id)
 
-    org.review(sow.id, "sparring-course", "operator-course")
+    # Verify FIRST: a reviewer with no evidence in front of them is rubber-stamping.
     org.verify_outcome(outcome.id, "verifier-course")
+    org.review(sow.id, "sparring-course")
     org.accept(outcome.id, "principal-human")
     return org.status_text(outcome.id)

--- a/src/reference_organizations/store/demo.py
+++ b/src/reference_organizations/store/demo.py
@@ -94,6 +94,10 @@ def run_simulated(root: Path) -> str:
         scope=f"Manually dispatched replenishment after signal {signal.id}",
         role=Role.OPERATOR,
         actor_id="master-course",
+        # This SOW must actually restock. Declaring it means acceptance checks
+        # that THIS execution did it, rather than that the shelf happens to be
+        # full because of work done last week.
+        required_effect_kind="replenishment",
     )
     org.ready_sow(sow.id)
     assignment = org.assign(sow.id, "operator-course", "master-course")

--- a/src/reference_organizations/store/demo.py
+++ b/src/reference_organizations/store/demo.py
@@ -1,13 +1,69 @@
-"""Deterministic simulated store demo: manual replenishment, no Pulse."""
+"""Deterministic simulated store demo: manual replenishment, no Pulse.
+
+The loop this runs, end to end:
+
+    sale -> inventory falls below the reorder point -> durable signal
+      -> governed outcome and SOW -> assignment to an operator actor
+      -> provider PROPOSES a bounded restock -> Python VALIDATES it
+      -> inventory + cash + event commit atomically
+      -> deterministic checks execute -> check-bound evidence is stored
+      -> an independent reviewer reviews -> the Principal accepts
+
+Nothing here wakes itself up. A human runs it. Proactive waking is Pulse, and
+Pulse arrives in Unit 9 — this demo does not pretend to have it.
+"""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from reference_organizations.store import below_reorder, cash_balance_cents, record_sale, seed
-from sovereign_agent.evidence import record_check
+from reference_organizations.store import (
+    RestockProposal,
+    apply_restock,
+    below_reorder,
+    record_sale,
+    seed,
+)
+from sovereign_agent.errors import Refusal
 from sovereign_agent.models import Role
 from sovereign_agent.organization import Organization
+
+SKU = "SKU-TEA"
+
+
+def propose_restock_from_report(report_path: Path, sku: str) -> RestockProposal:
+    """Read the provider's proposal. Refuse anything malformed.
+
+    The provider is an intelligence, not an authority. It may ask for a quantity.
+    It does not get to name the price, pick the SKU's cost, or decide which
+    checks will judge its work. A malformed report is a refusal, never a guess.
+    """
+    if not report_path.is_file():
+        raise Refusal(
+            "The provider wrote no report.",
+            "A silent actor has not done the work.",
+            str(report_path),
+            "Re-run the assignment.",
+        )
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise Refusal(
+            f"The provider report is not valid JSON: {error}.",
+            "A malformed report fails closed. It never becomes a guessed success.",
+            str(report_path),
+            "Fix the provider or re-run the assignment.",
+        ) from error
+    requested = payload.get("proposed_restock_units")
+    if not isinstance(requested, int):
+        raise Refusal(
+            f"The provider proposed {requested!r} units, which is not a whole number.",
+            "The effect boundary only accepts a proposal it can check.",
+            str(report_path),
+            "Have the provider propose an integer quantity.",
+        )
+    return RestockProposal(sku=sku, quantity=requested)
 
 
 def run_simulated(root: Path) -> str:
@@ -15,14 +71,23 @@ def run_simulated(root: Path) -> str:
     seed(org.db)
     outcome = org.create_outcome(
         title="Keep the tea jar stocked",
-        desired_state="On-hand tea stays at or above the reorder point after a sale.",
-        checks=["inventory_non_negative", "cash_reconciles", "replenishment_sow_accepted"],
+        desired_state=(
+            "On-hand tea is at or above the reorder point, the purchase is "
+            "reconciled, and the replenishment is on the ledger."
+        ),
+        checks=[
+            "inventory_at_or_above_reorder_point",
+            "cash_reconciles",
+            "replenishment_event_exists",
+        ],
         owner="principal-human",
     )
     org.activate(outcome.id, "master-course")
-    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+
+    signal = record_sale(org.db, SKU, 2, 400)
     if not below_reorder(org.db):
         raise RuntimeError("fixture sale should cross the reorder point")
+
     sow = org.create_sow(
         outcome.id,
         scope=f"Manually dispatched replenishment after signal {signal.id}",
@@ -32,18 +97,15 @@ def run_simulated(root: Path) -> str:
     org.ready_sow(sow.id)
     assignment = org.assign(sow.id, "operator-course", "master-course")
     assignment = org.run_assignment(assignment.id)
-    evidence = record_check(
-        assignment.id,
-        "inventory_non_negative",
-        ["sqlite", "inventory"],
-        0 if cash_balance_cents(org.db) >= 0 else 1,
+
+    # The provider proposed. Python decides.
+    report_path = (
+        root / ".sovereign" / "runs" / assignment.workspace_id / ".sovereign-out" / "report.json"
     )
-    with org.db.transaction():
-        org.db.connection.execute(
-            "INSERT INTO evidence(id, assignment_id, record) VALUES (?, ?, ?)",
-            (evidence.id, assignment.id, evidence.model_dump_json()),
-        )
+    proposal = propose_restock_from_report(report_path, SKU)
+    apply_restock(org.db, proposal, assignment.id, signal.id)
+
     org.review(sow.id, "sparring-course", "operator-course")
-    org.verify_outcome(outcome.id, "verifier-course")
-    org.accept(outcome.id, "principal-human", "operator-course", [evidence.id])
+    org.verify_outcome(outcome.id, "verifier-course", SKU)
+    org.accept(outcome.id, "principal-human", SKU)
     return org.status_text(outcome.id)

--- a/src/sovereign_agent/checks.py
+++ b/src/sovereign_agent/checks.py
@@ -62,37 +62,54 @@ def _cash_cents(db: Database) -> int:
     return int(row["total"])
 
 
-def _digest_for(db: Database, sku: str) -> str:
-    """Digest the facts every store check depends on.
+def _digest_observation(check_id: str, observed: dict[str, Any]) -> str:
+    """Digest EXACTLY what this check observed.
 
-    Deliberately NOT an event counter: a plain `UPDATE inventory` changes the
-    world without appending an event, so a counter would report 'fresh' while
-    the claim had already become false.
+    A shared digest over inventory-plus-cash-total looked thorough and was not:
+    `cash_reconciles` and `replenishment_event_exists` read individual events and
+    cash rows, so appending a duplicate replenishment event changed what those
+    checks saw while the shared digest stayed identical -- and stale evidence
+    passed as fresh. Reported on PR #24.
+
+    Digesting the check's own observation makes the digest cover what the check
+    read BY CONSTRUCTION: it is derived from the predicate's own output, so it
+    cannot drift out of step with the predicate.
+
+    Deliberately still NOT an event counter: a plain `UPDATE inventory` changes
+    the world without appending an event.
     """
-    return digest_payload(
-        {"sku": sku, "inventory": _inventory_row(db, sku), "cash": _cash_cents(db)}
-    )
+    return digest_payload({"check_id": check_id, "observed": observed})
 
 
 def inventory_at_or_above_reorder_point(db: Database, sku: str) -> CheckResult:
-    """WORLD FACT: is there actually enough stock on the shelf right now?"""
+    """WORLD FACT: is there actually enough stock available right now?
+
+    Measures `on_hand - reserved`, not `on_hand`. Sparring pointed out that the
+    check loaded `reserved`, digested it, and never consulted it: with
+    on_hand=8 and reserved=8 the shelf is empty and the check was green. Nothing
+    writes `reserved` today, so it was latent -- and it would have become a lie
+    the day reservations landed, in a diff that never touched this file.
+    """
+    check_id = "inventory_at_or_above_reorder_point"
     row = _inventory_row(db, sku)
-    digest = _digest_for(db, sku)
     if row is None:
+        observed: dict[str, Any] = {"sku": sku}
         return CheckResult(
-            "inventory_at_or_above_reorder_point",
+            check_id,
             False,
-            {"sku": sku},
-            digest,
+            observed,
+            _digest_observation(check_id, observed),
             f"No inventory row for {sku}.",
         )
-    ok = row["on_hand"] >= row["reorder_point"]
+    available = row["on_hand"] - row["reserved"]
+    observed = {"sku": sku, **row, "available": available}
     return CheckResult(
-        "inventory_at_or_above_reorder_point",
-        ok,
-        {"sku": sku, **row},
-        digest,
-        f"on_hand={row['on_hand']} vs reorder_point={row['reorder_point']}",
+        check_id,
+        available >= row["reorder_point"],
+        observed,
+        _digest_observation(check_id, observed),
+        f"available={available} (on_hand={row['on_hand']} - reserved={row['reserved']}) "
+        f"vs reorder_point={row['reorder_point']}",
     )
 
 
@@ -104,7 +121,6 @@ def cash_reconciles(db: Database, sku: str) -> CheckResult:
     cash movement must equal exactly -(qty * unit_cost) for the committed
     replenishment, and the entry must be tied to that same assignment.
     """
-    digest = _digest_for(db, sku)
     events = [
         json.loads(row["payload"])
         for row in db.connection.execute(
@@ -113,8 +129,17 @@ def cash_reconciles(db: Database, sku: str) -> CheckResult:
     ]
     events = [event for event in events if event.get("sku") == sku]
     if not events:
+        empty_facts: dict[str, Any] = {
+            "sku": sku,
+            "entries": [],
+            "cash_cents": _cash_cents(db),
+        }
         return CheckResult(
-            "cash_reconciles", False, {"sku": sku}, digest, "No replenishment to reconcile against."
+            "cash_reconciles",
+            False,
+            empty_facts,
+            _digest_observation("cash_reconciles", empty_facts),
+            "No replenishment to reconcile against.",
         )
     problems: list[str] = []
     observed: list[dict[str, Any]] = []
@@ -133,18 +158,22 @@ def cash_reconciles(db: Database, sku: str) -> CheckResult:
             problems.append(f"cash entry {event['cash_id']} is {actual}, expected {expected}")
         if record.get("assignment_id") != event.get("assignment_id"):
             problems.append(f"cash entry {event['cash_id']} is not tied to the replenishment")
+    facts: dict[str, Any] = {
+        "sku": sku,
+        "entries": observed,
+        "cash_cents": _cash_cents(db),
+    }
     return CheckResult(
         "cash_reconciles",
         not problems,
-        {"sku": sku, "entries": observed, "cash_cents": _cash_cents(db)},
-        digest,
+        facts,
+        _digest_observation("cash_reconciles", facts),
         "; ".join(problems) if problems else f"{len(observed)} purchase entr(y/ies) reconcile",
     )
 
 
 def replenishment_event_exists(db: Database, sku: str) -> CheckResult:
     """WORLD FACT: did a replenishment actually get committed to the ledger?"""
-    digest = _digest_for(db, sku)
     rows = [
         json.loads(row["payload"])
         for row in db.connection.execute(
@@ -152,11 +181,21 @@ def replenishment_event_exists(db: Database, sku: str) -> CheckResult:
         ).fetchall()
     ]
     matching = [row for row in rows if row.get("sku") == sku]
+    # Identities, not just a count: two events with the same count but different
+    # contents are not the same observation.
+    observed = {
+        "sku": sku,
+        "count": len(matching),
+        "events": sorted(
+            (str(row.get("assignment_id")), str(row.get("cash_id")), int(row.get("qty", 0)))
+            for row in matching
+        ),
+    }
     return CheckResult(
         "replenishment_event_exists",
         bool(matching),
-        {"sku": sku, "count": len(matching)},
-        digest,
+        observed,
+        _digest_observation("replenishment_event_exists", observed),
         f"{len(matching)} replenishment event(s) for {sku}",
     )
 

--- a/src/sovereign_agent/checks.py
+++ b/src/sovereign_agent/checks.py
@@ -1,0 +1,199 @@
+"""The check registry: deterministic questions with checkable answers.
+
+A check is a small Python function that reads authoritative state and answers
+one question about the world. Checks are looked up by a stable identifier, so an
+outcome declares *which* questions must be answered, and nothing else gets to
+decide that later.
+
+Two rules make this teachable rather than magical:
+
+1. A check is named for the fact it measures. `inventory_at_or_above_reorder_point`
+   reads inventory. If it read cash, the name would be a lie — and that lie is the
+   exact defect this module was written to remove.
+2. A check returns the facts it observed *and* a digest of the state it read. The
+   digest lets acceptance notice that the world moved after the check ran.
+
+There is deliberately no rule engine here. A registry of named functions is
+something a learner can read end to end in a minute.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from sovereign_agent.database import Database
+from sovereign_agent.evidence import digest_payload
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """The answer to one deterministic question, with its supporting facts."""
+
+    check_id: str
+    success: bool
+    observed: dict[str, Any] = field(default_factory=dict)
+    state_digest: str = ""
+    detail: str = ""
+
+
+CheckFn = Callable[[Database, str], CheckResult]
+
+
+def _inventory_row(db: Database, sku: str) -> dict[str, int] | None:
+    row = db.connection.execute(
+        "SELECT on_hand, reserved, reorder_point FROM inventory WHERE sku = ?", (sku,)
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "on_hand": int(row["on_hand"]),
+        "reserved": int(row["reserved"]),
+        "reorder_point": int(row["reorder_point"]),
+    }
+
+
+def _cash_cents(db: Database) -> int:
+    row = db.connection.execute(
+        "SELECT COALESCE(SUM(amount_cents), 0) AS total FROM cash_entries"
+    ).fetchone()
+    return int(row["total"])
+
+
+def _digest_for(db: Database, sku: str) -> str:
+    """Digest the facts every store check depends on.
+
+    Deliberately NOT an event counter: a plain `UPDATE inventory` changes the
+    world without appending an event, so a counter would report 'fresh' while
+    the claim had already become false.
+    """
+    return digest_payload(
+        {"sku": sku, "inventory": _inventory_row(db, sku), "cash": _cash_cents(db)}
+    )
+
+
+def inventory_at_or_above_reorder_point(db: Database, sku: str) -> CheckResult:
+    """WORLD FACT: is there actually enough stock on the shelf right now?"""
+    row = _inventory_row(db, sku)
+    digest = _digest_for(db, sku)
+    if row is None:
+        return CheckResult(
+            "inventory_at_or_above_reorder_point",
+            False,
+            {"sku": sku},
+            digest,
+            f"No inventory row for {sku}.",
+        )
+    ok = row["on_hand"] >= row["reorder_point"]
+    return CheckResult(
+        "inventory_at_or_above_reorder_point",
+        ok,
+        {"sku": sku, **row},
+        digest,
+        f"on_hand={row['on_hand']} vs reorder_point={row['reorder_point']}",
+    )
+
+
+def cash_reconciles(db: Database, sku: str) -> CheckResult:
+    """WORLD FACT: does the purchase cash entry match the replenishment event?
+
+    This is a reconciliation, not a solvency test. `SUM(...) >= 0` would happily
+    pass a purchase that recorded -9999 for six units of tea. Here the recorded
+    cash movement must equal exactly -(qty * unit_cost) for the committed
+    replenishment, and the entry must be tied to that same assignment.
+    """
+    digest = _digest_for(db, sku)
+    events = [
+        json.loads(row["payload"])
+        for row in db.connection.execute(
+            "SELECT payload FROM events WHERE kind = 'replenishment.committed' ORDER BY seq"
+        ).fetchall()
+    ]
+    events = [event for event in events if event.get("sku") == sku]
+    if not events:
+        return CheckResult(
+            "cash_reconciles", False, {"sku": sku}, digest, "No replenishment to reconcile against."
+        )
+    problems: list[str] = []
+    observed: list[dict[str, Any]] = []
+    for event in events:
+        row = db.connection.execute(
+            "SELECT amount_cents, record FROM cash_entries WHERE id = ?", (event["cash_id"],)
+        ).fetchone()
+        if row is None:
+            problems.append(f"cash entry {event['cash_id']} is missing")
+            continue
+        expected = -(int(event["qty"]) * int(event["unit_cost_cents"]))
+        actual = int(row["amount_cents"])
+        record = json.loads(row["record"])
+        observed.append({"cash_id": event["cash_id"], "expected": expected, "actual": actual})
+        if actual != expected:
+            problems.append(f"cash entry {event['cash_id']} is {actual}, expected {expected}")
+        if record.get("assignment_id") != event.get("assignment_id"):
+            problems.append(f"cash entry {event['cash_id']} is not tied to the replenishment")
+    return CheckResult(
+        "cash_reconciles",
+        not problems,
+        {"sku": sku, "entries": observed, "cash_cents": _cash_cents(db)},
+        digest,
+        "; ".join(problems) if problems else f"{len(observed)} purchase entr(y/ies) reconcile",
+    )
+
+
+def replenishment_event_exists(db: Database, sku: str) -> CheckResult:
+    """WORLD FACT: did a replenishment actually get committed to the ledger?"""
+    digest = _digest_for(db, sku)
+    rows = [
+        json.loads(row["payload"])
+        for row in db.connection.execute(
+            "SELECT payload FROM events WHERE kind = 'replenishment.committed'"
+        ).fetchall()
+    ]
+    matching = [row for row in rows if row.get("sku") == sku]
+    return CheckResult(
+        "replenishment_event_exists",
+        bool(matching),
+        {"sku": sku, "count": len(matching)},
+        digest,
+        f"{len(matching)} replenishment event(s) for {sku}",
+    )
+
+
+REGISTRY: dict[str, CheckFn] = {
+    "inventory_at_or_above_reorder_point": inventory_at_or_above_reorder_point,
+    "cash_reconciles": cash_reconciles,
+    "replenishment_event_exists": replenishment_event_exists,
+}
+
+# Checks about the world vs checks about the process. Both matter, but only the
+# first kind can tell you the business outcome is true.
+WORLD_FACT_CHECKS = frozenset(REGISTRY)
+
+
+def run_check(db: Database, check_id: str, subject: str) -> CheckResult:
+    """Execute one declared check. Unknown or erroring checks FAIL CLOSED.
+
+    An unknown check is not a pass and not a skip: an outcome that declares a
+    question nobody can answer has not been proved.
+    """
+    fn = REGISTRY.get(check_id)
+    if fn is None:
+        return CheckResult(
+            check_id,
+            False,
+            {"subject": subject},
+            "",
+            f"Unknown check '{check_id}'. Unknown checks fail closed.",
+        )
+    try:
+        return fn(db, subject)
+    except Exception as error:  # noqa: BLE001 - an erroring check must never pass
+        return CheckResult(
+            check_id,
+            False,
+            {"subject": subject},
+            "",
+            f"Check raised {type(error).__name__}: {error}",
+        )

--- a/src/sovereign_agent/cli.py
+++ b/src/sovereign_agent/cli.py
@@ -86,7 +86,7 @@ def _actor_list(namespace: argparse.Namespace) -> int:
 def _outcome_new(namespace: argparse.Namespace) -> int:
     org = Organization(_root(namespace))
     outcome = org.create_outcome(
-        namespace.title, namespace.desired, namespace.checks, namespace.owner
+        namespace.title, namespace.desired, namespace.checks, namespace.owner, namespace.subject
     )
     print(outcome.id)
     return 0
@@ -132,7 +132,7 @@ def _ruling_decide(namespace: argparse.Namespace) -> int:
 
 def _verify(namespace: argparse.Namespace) -> int:
     org = Organization(_root(namespace))
-    results = org.verify_outcome(namespace.outcome_id, namespace.actor, namespace.subject)
+    results = org.verify_outcome(namespace.outcome_id, namespace.actor)
     for result in results:
         print(f"{result.check_id} {'PASS' if result.success else 'FAIL'} {result.detail}")
     return 0 if all(result.success for result in results) else 1
@@ -142,7 +142,7 @@ def _accept(namespace: argparse.Namespace) -> int:
     org = Organization(_root(namespace))
     # No --evidence and no --performer. Acceptance derives both from the ledger:
     # a caller that supplies its own proof is not being checked.
-    acceptance = org.accept(namespace.outcome_id, namespace.actor, namespace.subject)
+    acceptance = org.accept(namespace.outcome_id, namespace.actor)
     print(f"ACCEPTED {acceptance.outcome_id}")
     for reference in acceptance.evidence_refs:
         print(f"  evidence {reference}")
@@ -196,6 +196,7 @@ def build_parser() -> argparse.ArgumentParser:
     created.add_argument("--desired", default="The outcome's acceptance checks pass.")
     created.add_argument("--checks", nargs="*", default=["inventory_at_or_above_reorder_point"])
     created.add_argument("--owner", default="principal-human")
+    created.add_argument("--subject", default="SKU-TEA")
     created.set_defaults(handler=_outcome_new)
 
     plan = subparsers.add_parser("plan", parents=[shared], help="activate an outcome and add a SOW")
@@ -233,7 +234,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     verify.add_argument("outcome_id")
     verify.add_argument("--actor", default="verifier-course")
-    verify.add_argument("--subject", default="SKU-TEA")
     verify.set_defaults(handler=_verify)
 
     accept = subparsers.add_parser(
@@ -241,7 +241,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     accept.add_argument("outcome_id")
     accept.add_argument("--actor", default="principal-human")
-    accept.add_argument("--subject", default="SKU-TEA")
     accept.set_defaults(handler=_accept)
 
     demo = subparsers.add_parser("demo", parents=[shared], help="run a scripted teaching scenario")

--- a/src/sovereign_agent/cli.py
+++ b/src/sovereign_agent/cli.py
@@ -132,17 +132,20 @@ def _ruling_decide(namespace: argparse.Namespace) -> int:
 
 def _verify(namespace: argparse.Namespace) -> int:
     org = Organization(_root(namespace))
-    outcome = org.verify_outcome(namespace.outcome_id, namespace.actor)
-    print(outcome.state)
-    return 0
+    results = org.verify_outcome(namespace.outcome_id, namespace.actor, namespace.subject)
+    for result in results:
+        print(f"{result.check_id} {'PASS' if result.success else 'FAIL'} {result.detail}")
+    return 0 if all(result.success for result in results) else 1
 
 
 def _accept(namespace: argparse.Namespace) -> int:
     org = Organization(_root(namespace))
-    acceptance = org.accept(
-        namespace.outcome_id, namespace.actor, namespace.performer, namespace.evidence
-    )
+    # No --evidence and no --performer. Acceptance derives both from the ledger:
+    # a caller that supplies its own proof is not being checked.
+    acceptance = org.accept(namespace.outcome_id, namespace.actor, namespace.subject)
     print(f"ACCEPTED {acceptance.outcome_id}")
+    for reference in acceptance.evidence_refs:
+        print(f"  evidence {reference}")
     return 0
 
 
@@ -191,7 +194,7 @@ def build_parser() -> argparse.ArgumentParser:
     created = outcome_sub.add_parser("new", parents=[shared])
     created.add_argument("title")
     created.add_argument("--desired", default="The outcome's acceptance checks pass.")
-    created.add_argument("--checks", nargs="*", default=["evidence_present"])
+    created.add_argument("--checks", nargs="*", default=["inventory_at_or_above_reorder_point"])
     created.add_argument("--owner", default="principal-human")
     created.set_defaults(handler=_outcome_new)
 
@@ -230,6 +233,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     verify.add_argument("outcome_id")
     verify.add_argument("--actor", default="verifier-course")
+    verify.add_argument("--subject", default="SKU-TEA")
     verify.set_defaults(handler=_verify)
 
     accept = subparsers.add_parser(
@@ -237,8 +241,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     accept.add_argument("outcome_id")
     accept.add_argument("--actor", default="principal-human")
-    accept.add_argument("--performer", default="operator-course")
-    accept.add_argument("--evidence", nargs="+", required=True)
+    accept.add_argument("--subject", default="SKU-TEA")
     accept.set_defaults(handler=_accept)
 
     demo = subparsers.add_parser("demo", parents=[shared], help="run a scripted teaching scenario")

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -303,9 +303,27 @@ CREATE INDEX IF NOT EXISTS verifications_by_sow ON verifications(sow_id);
 """
 
 
-# Every table acceptance reads as PROOF. Append-only belongs on all of them, not
-# on whichever one happened to be load-bearing when the guards were written.
-PROOF_TABLES: tuple[str, ...] = ("events", "effects", "verifications", "reviews", "evidence")
+# Tables whose rows must never be rewritten once written. This is MUTATION
+# SAFETY, not authentication: the guards stop ordinary tools and honest mistakes
+# from altering history. They do not stop an arbitrary database writer, who can
+# still append.
+#
+# It is a maintained LIST, not a discovery mechanism. Adding a proof-bearing
+# table means adding it here AND shipping a new migration -- editing an
+# already-stamped migration would guard fresh installs and silently skip every
+# upgraded database.
+#
+# `receipts` is deliberately absent: `put_serialized` rewrites a receipt in
+# place while an assignment runs. Acceptance still treats it as proof, and
+# guards that instead by requiring the canonical record and the indexed columns
+# to agree (`Organization._trusted_receipt`).
+APPEND_ONLY_TABLES: tuple[str, ...] = (
+    "events",
+    "effects",
+    "verifications",
+    "reviews",
+    "evidence",
+)
 
 
 def _append_only_triggers(table: str) -> str:
@@ -330,7 +348,9 @@ END;
 """
 
 
-MIGRATION_12 = "".join(_append_only_triggers(table) for table in PROOF_TABLES if table != "events")
+MIGRATION_12 = "".join(
+    _append_only_triggers(table) for table in APPEND_ONLY_TABLES if table != "events"
+)
 
 
 MIGRATIONS: tuple[tuple[int, str], ...] = (

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -256,6 +256,34 @@ CREATE INDEX IF NOT EXISTS effects_by_outcome ON effects(outcome_id, assignment_
 """
 
 
+MIGRATION_10 = """
+-- The effect edge is what ties an execution to the change it made. Leaving it
+-- nullable left the crucial edge optional. SQLite cannot add NOT NULL in place,
+-- so the table is rebuilt.
+CREATE TABLE effects_v2 (
+    id TEXT PRIMARY KEY,
+    assignment_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    outcome_id TEXT NOT NULL,
+    UNIQUE(assignment_id, kind, subject),
+    FOREIGN KEY(assignment_id) REFERENCES assignments(id),
+    FOREIGN KEY(outcome_id) REFERENCES outcomes(id),
+    CHECK (outcome_id <> '')
+);
+INSERT INTO effects_v2(id, assignment_id, kind, subject, payload, created_at, outcome_id)
+    SELECT id, assignment_id, kind, subject, payload, created_at,
+           COALESCE(NULLIF(outcome_id, ''), json_extract(payload, '$.outcome_id'))
+    FROM effects
+    WHERE COALESCE(NULLIF(outcome_id, ''), json_extract(payload, '$.outcome_id')) IS NOT NULL;
+DROP TABLE effects;
+ALTER TABLE effects_v2 RENAME TO effects;
+CREATE INDEX IF NOT EXISTS effects_by_outcome ON effects(outcome_id, assignment_id);
+"""
+
+
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (1, MIGRATION_1),
     (2, MIGRATION_2),
@@ -266,6 +294,7 @@ MIGRATIONS: tuple[tuple[int, str], ...] = (
     (7, MIGRATION_7),
     (8, MIGRATION_8),
     (9, MIGRATION_9),
+    (10, MIGRATION_10),
 )
 
 

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -244,6 +244,18 @@ CREATE INDEX IF NOT EXISTS receipts_by_assignment ON receipts(assignment_id);
 """
 
 
+MIGRATION_9 = """
+-- The effect edge existed but could only be followed through the JSON payload,
+-- so acceptance never followed it: the authorization graph and the acceptance
+-- graph met at the SUBJECT (any two outcomes about one SKU shared effects)
+-- rather than at the execution. A structured FK makes the edge queryable.
+ALTER TABLE effects ADD COLUMN outcome_id TEXT REFERENCES outcomes(id);
+UPDATE effects SET outcome_id = json_extract(payload, '$.outcome_id')
+    WHERE outcome_id IS NULL;
+CREATE INDEX IF NOT EXISTS effects_by_outcome ON effects(outcome_id, assignment_id);
+"""
+
+
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (1, MIGRATION_1),
     (2, MIGRATION_2),
@@ -253,6 +265,7 @@ MIGRATIONS: tuple[tuple[int, str], ...] = (
     (6, MIGRATION_6),
     (7, MIGRATION_7),
     (8, MIGRATION_8),
+    (9, MIGRATION_9),
 )
 
 

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -121,9 +121,28 @@ CREATE INDEX IF NOT EXISTS evidence_binding
     ON evidence(outcome_id, check_id);
 """
 
+MIGRATION_3 = """
+-- `recursive_triggers` is a PER-CONNECTION pragma, not a property of the schema.
+-- The BEFORE DELETE guard therefore only stopped `INSERT OR REPLACE` on
+-- connections the application itself opened. Anyone using a plain `sqlite3`
+-- shell -- including a learner following Chapter 1 -- could silently overwrite
+-- an event and leave the row count unchanged.
+--
+-- This guard needs no pragma: it refuses an INSERT whose id already exists, so
+-- append-only holds from ANY client. Enforcement now matches the claim.
+CREATE TRIGGER IF NOT EXISTS events_no_replace
+BEFORE INSERT ON events
+WHEN EXISTS (SELECT 1 FROM events WHERE id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, 'events are append-only: replace refused');
+END;
+"""
+
+
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (1, MIGRATION_1),
     (2, MIGRATION_2),
+    (3, MIGRATION_3),
 )
 
 

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -186,6 +186,64 @@ ALTER TABLE receipts ADD COLUMN status TEXT NOT NULL DEFAULT '';
 """
 
 
+MIGRATION_7 = """
+-- effect_keys held ONE concatenated string while the code called it a key on
+-- (assignment, sku). Structured columns with a composite constraint make the
+-- schema say what the docstring claimed.
+CREATE TABLE IF NOT EXISTS effects (
+    id TEXT PRIMARY KEY,
+    assignment_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(assignment_id, kind, subject),
+    FOREIGN KEY(assignment_id) REFERENCES assignments(id)
+);
+
+-- A verification is a BATCH of evidence produced by one run of the checks.
+-- Without it, review binds to "whatever evidence existed" and acceptance uses
+-- "whatever evidence exists now", and nothing forces those to be the same set.
+CREATE TABLE IF NOT EXISTS verifications (
+    id TEXT PRIMARY KEY,
+    outcome_id TEXT NOT NULL,
+    assignment_id TEXT NOT NULL,
+    aggregate_digest TEXT NOT NULL,
+    passed INTEGER NOT NULL,
+    record TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(outcome_id) REFERENCES outcomes(id)
+);
+CREATE INDEX IF NOT EXISTS verifications_by_outcome ON verifications(outcome_id);
+
+ALTER TABLE evidence ADD COLUMN verification_id TEXT REFERENCES verifications(id);
+ALTER TABLE reviews ADD COLUMN verification_id TEXT REFERENCES verifications(id);
+"""
+
+
+MIGRATION_8 = """
+-- Sparring's unprompted find: Receipt.assignment_id defaulted to "",
+-- _latest_assignment_id returned "", and this column was nullable -- "the
+-- performer who never worked" in a new costume. It refused every way Sparring
+-- pushed it, but only via guards three layers from the default. SQLite cannot
+-- add a NOT NULL constraint in place, so this rebuilds the table.
+CREATE TABLE receipts_v2 (
+    id TEXT PRIMARY KEY,
+    record TEXT NOT NULL,
+    assignment_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    CHECK (assignment_id <> '')
+);
+INSERT INTO receipts_v2(id, record, assignment_id, status)
+    SELECT id, record, COALESCE(NULLIF(assignment_id, ''), 'asg_unattributed_legacy'),
+           COALESCE(status, '')
+    FROM receipts;
+DROP TABLE receipts;
+ALTER TABLE receipts_v2 RENAME TO receipts;
+CREATE INDEX IF NOT EXISTS receipts_by_assignment ON receipts(assignment_id);
+"""
+
+
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (1, MIGRATION_1),
     (2, MIGRATION_2),
@@ -193,6 +251,8 @@ MIGRATIONS: tuple[tuple[int, str], ...] = (
     (4, MIGRATION_4),
     (5, MIGRATION_5),
     (6, MIGRATION_6),
+    (7, MIGRATION_7),
+    (8, MIGRATION_8),
 )
 
 

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -348,9 +348,18 @@ END;
 """
 
 
-MIGRATION_12 = "".join(
-    _append_only_triggers(table) for table in APPEND_ONLY_TABLES if table != "events"
-)
+# Frozen at the tables version 12 shipped with. Computing this from
+# APPEND_ONLY_TABLES made adding a table change the bytes of an ALREADY-STAMPED
+# version: fresh installs guarded, every upgraded database silently skipped --
+# this PR's recurring shape, a guarantee staying put while the load moves,
+# pre-installed in the fix built to stop it. Raised by Sparring.
+#
+# A new proof-bearing table gets a NEW migration version.
+# `test_migration_12_content_is_frozen` fails if this list is edited, so the
+# rule enforces itself rather than relying on anyone remembering it.
+MIGRATION_12_TABLES: tuple[str, ...] = ("effects", "verifications", "reviews", "evidence")
+
+MIGRATION_12 = "".join(_append_only_triggers(table) for table in MIGRATION_12_TABLES)
 
 
 MIGRATIONS: tuple[tuple[int, str], ...] = (

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -303,6 +303,36 @@ CREATE INDEX IF NOT EXISTS verifications_by_sow ON verifications(sow_id);
 """
 
 
+# Every table acceptance reads as PROOF. Append-only belongs on all of them, not
+# on whichever one happened to be load-bearing when the guards were written.
+PROOF_TABLES: tuple[str, ...] = ("events", "effects", "verifications", "reviews", "evidence")
+
+
+def _append_only_triggers(table: str) -> str:
+    """The same three guards, for one proof-bearing table."""
+    return f"""
+CREATE TRIGGER IF NOT EXISTS {table}_no_update
+BEFORE UPDATE ON {table}
+BEGIN
+    SELECT RAISE(ABORT, '{table} are append-only: update refused');
+END;
+CREATE TRIGGER IF NOT EXISTS {table}_no_delete
+BEFORE DELETE ON {table}
+BEGIN
+    SELECT RAISE(ABORT, '{table} are append-only: delete refused');
+END;
+CREATE TRIGGER IF NOT EXISTS {table}_no_replace
+BEFORE INSERT ON {table}
+WHEN EXISTS (SELECT 1 FROM {table} WHERE id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, '{table} are append-only: replace refused');
+END;
+"""
+
+
+MIGRATION_12 = "".join(_append_only_triggers(table) for table in PROOF_TABLES if table != "events")
+
+
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (1, MIGRATION_1),
     (2, MIGRATION_2),
@@ -315,6 +345,7 @@ MIGRATIONS: tuple[tuple[int, str], ...] = (
     (9, MIGRATION_9),
     (10, MIGRATION_10),
     (11, MIGRATION_11),
+    (12, MIGRATION_12),
 )
 
 

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -273,14 +273,33 @@ CREATE TABLE effects_v2 (
     FOREIGN KEY(outcome_id) REFERENCES outcomes(id),
     CHECK (outcome_id <> '')
 );
+-- NO `WHERE ... IS NOT NULL` filter. An earlier version had one, so that the
+-- NOT NULL rebuild would always succeed -- and it dropped every legacy row it
+-- could not attribute before DROPping the old table, destroying an operational
+-- record from an append-only ledger while reporting success.
+--
+-- Fail closed instead: an unattributable row makes this INSERT violate NOT NULL,
+-- the whole migration rolls back inside its BEGIN IMMEDIATE, version 10 is not
+-- stamped, and the original table is still there to be repaired by hand. A
+-- migration that cannot preserve the ledger must refuse to run, not quietly
+-- decide which history was worth keeping.
 INSERT INTO effects_v2(id, assignment_id, kind, subject, payload, created_at, outcome_id)
     SELECT id, assignment_id, kind, subject, payload, created_at,
            COALESCE(NULLIF(outcome_id, ''), json_extract(payload, '$.outcome_id'))
-    FROM effects
-    WHERE COALESCE(NULLIF(outcome_id, ''), json_extract(payload, '$.outcome_id')) IS NOT NULL;
+    FROM effects;
 DROP TABLE effects;
 ALTER TABLE effects_v2 RENAME TO effects;
 CREATE INDEX IF NOT EXISTS effects_by_outcome ON effects(outcome_id, assignment_id);
+"""
+
+
+MIGRATION_11 = """
+-- A verification must name the SOW it is about. Without it, verification
+-- selected a SOW implicitly by row order and the caller could not say which
+-- work was being verified -- so with two completed SOWs one became permanently
+-- unreviewable, and which one was arbitrary.
+ALTER TABLE verifications ADD COLUMN sow_id TEXT REFERENCES sows(id);
+CREATE INDEX IF NOT EXISTS verifications_by_sow ON verifications(sow_id);
 """
 
 
@@ -295,6 +314,7 @@ MIGRATIONS: tuple[tuple[int, str], ...] = (
     (8, MIGRATION_8),
     (9, MIGRATION_9),
     (10, MIGRATION_10),
+    (11, MIGRATION_11),
 )
 
 

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-SCHEMA = """
+MIGRATION_1 = """
 PRAGMA foreign_keys = ON;
 CREATE TABLE IF NOT EXISTS schema_migrations (
     version INTEGER PRIMARY KEY,
@@ -93,6 +93,39 @@ CREATE TABLE IF NOT EXISTS signals (
 );
 """
 
+MIGRATION_2 = """
+-- Append-only enforcement lives at the database boundary, not in Python habit.
+-- Without these, `UPDATE events` and `DELETE FROM events` both succeed.
+CREATE TRIGGER IF NOT EXISTS events_no_update
+BEFORE UPDATE ON events
+BEGIN
+    SELECT RAISE(ABORT, 'events are append-only: update refused');
+END;
+CREATE TRIGGER IF NOT EXISTS events_no_delete
+BEFORE DELETE ON events
+BEGIN
+    SELECT RAISE(ABORT, 'events are append-only: delete refused');
+END;
+
+-- Evidence must be bound to what it proves. Columns are indexed rather than
+-- buried in the JSON record so acceptance can query bindings directly.
+-- REFERENCES on ALTER ADD COLUMN IS enforced by SQLite: a fabricated
+-- outcome id is refused by the database, not merely by Python.
+ALTER TABLE evidence ADD COLUMN outcome_id TEXT REFERENCES outcomes(id);
+ALTER TABLE evidence ADD COLUMN check_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE evidence ADD COLUMN success INTEGER NOT NULL DEFAULT 0;
+-- Digest of the exact inputs the check read. An event counter cannot detect a
+-- silent UPDATE to inventory, so staleness is measured over the read state itself.
+ALTER TABLE evidence ADD COLUMN state_digest TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS evidence_binding
+    ON evidence(outcome_id, check_id);
+"""
+
+MIGRATIONS: tuple[tuple[int, str], ...] = (
+    (1, MIGRATION_1),
+    (2, MIGRATION_2),
+)
+
 
 class Database:
     def __init__(self, path: Path) -> None:
@@ -102,19 +135,41 @@ class Database:
         self.connection.row_factory = sqlite3.Row
         self.connection.execute("PRAGMA foreign_keys = ON")
         self.connection.execute("PRAGMA journal_mode = WAL")
+        # Without recursive triggers, `INSERT OR REPLACE` deletes the old row
+        # WITHOUT firing the BEFORE DELETE guard, silently defeating append-only.
+        self.connection.execute("PRAGMA recursive_triggers = ON")
         self.migrate()
 
+    def applied_versions(self) -> set[int]:
+        """Versions already recorded. Empty when the ledger table does not exist yet."""
+        try:
+            rows = self.connection.execute("SELECT version FROM schema_migrations").fetchall()
+        except sqlite3.OperationalError:
+            return set()
+        return {int(row["version"]) for row in rows}
+
     def migrate(self) -> None:
-        self.connection.executescript(SCHEMA)
-        applied = {
-            int(row["version"])
-            for row in self.connection.execute("SELECT version FROM schema_migrations")
-        }
-        if 1 not in applied:
-            self.connection.execute(
-                "INSERT INTO schema_migrations(version, applied_at) VALUES (1, datetime('now'))"
-            )
-            self.connection.commit()
+        """Apply pending migrations in order. Forward-only; never downgrades.
+
+        Each migration commits with its own version stamp, so a failure part way
+        through leaves every earlier migration applied and recorded, and the
+        failing one fully rolled back. The database stays openable.
+        """
+        applied = self.applied_versions()
+        for version, script in MIGRATIONS:
+            if version in applied:
+                continue
+            try:
+                self.connection.executescript(script)
+                self.connection.execute(
+                    "INSERT INTO schema_migrations(version, applied_at) "
+                    "VALUES (?, datetime('now'))",
+                    (version,),
+                )
+                self.connection.commit()
+            except Exception:
+                self.connection.rollback()
+                raise
 
     @contextmanager
     def transaction(self) -> Iterator[sqlite3.Connection]:

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -139,11 +139,61 @@ END;
 """
 
 
+MIGRATION_4 = """
+-- A preflight scan of the event log is not an idempotency key: two callers can
+-- both pass the scan before either writes, and both then order stock. The
+-- database has to be the one saying "this already happened".
+CREATE TABLE IF NOT EXISTS effect_keys (
+    key TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+"""
+
+
+MIGRATION_5 = """
+-- Claiming a lease by reading a JSON blob, deciding in Python, then writing the
+-- blob back is a read-then-write race: two workers both read NEW and both win.
+-- A compare-and-set needs the state in a column the UPDATE can test.
+ALTER TABLE messages ADD COLUMN state TEXT NOT NULL DEFAULT 'NEW';
+ALTER TABLE messages ADD COLUMN claim_owner TEXT;
+ALTER TABLE messages ADD COLUMN claim_expires_at TEXT;
+UPDATE messages SET
+    state = COALESCE(json_extract(record, '$.state'), 'NEW'),
+    claim_owner = json_extract(record, '$.claim_owner'),
+    claim_expires_at = json_extract(record, '$.claim_expires_at');
+"""
+
+
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (1, MIGRATION_1),
     (2, MIGRATION_2),
     (3, MIGRATION_3),
+    (4, MIGRATION_4),
+    (5, MIGRATION_5),
 )
+
+
+def _split_statements(script: str) -> list[str]:
+    """Split a migration into executable statements.
+
+    `sqlite3` refuses more than one statement per `execute()`, and migrations
+    contain CREATE TRIGGER bodies with internal semicolons. `sqlite3.complete_statement`
+    knows where a statement genuinely ends, including inside BEGIN ... END.
+    """
+    statements: list[str] = []
+    buffer = ""
+    for line in script.splitlines(keepends=True):
+        if not line.strip() or line.lstrip().startswith("--"):
+            continue
+        buffer += line
+        if sqlite3.complete_statement(buffer):
+            statements.append(buffer.strip())
+            buffer = ""
+    if buffer.strip():
+        statements.append(buffer.strip())
+    return statements
 
 
 class Database:
@@ -170,25 +220,57 @@ class Database:
     def migrate(self) -> None:
         """Apply pending migrations in order. Forward-only; never downgrades.
 
-        Each migration commits with its own version stamp, so a failure part way
-        through leaves every earlier migration applied and recorded, and the
-        failing one fully rolled back. The database stays openable.
+        Each migration's DDL **and** its version stamp go inside one explicit
+        `BEGIN IMMEDIATE`, so a failure part way through leaves the database
+        exactly as it was. SQLite rolls DDL back like any other statement.
+
+        This deliberately does not use `executescript()`. That helper COMMITs
+        any open transaction before it runs, which silently defeated the
+        rollback this docstring promises: a migration that created a table and
+        then hit invalid SQL left the table behind, unstamped, so reopening
+        re-ran it and failed forever.
         """
         applied = self.applied_versions()
         for version, script in MIGRATIONS:
             if version in applied:
                 continue
+            previous = self.connection.isolation_level
+            self.connection.isolation_level = None
             try:
-                self.connection.executescript(script)
+                self.connection.execute("BEGIN IMMEDIATE")
+                for statement in _split_statements(script):
+                    self.connection.execute(statement)
                 self.connection.execute(
                     "INSERT INTO schema_migrations(version, applied_at) "
                     "VALUES (?, datetime('now'))",
                     (version,),
                 )
-                self.connection.commit()
+                self.connection.execute("COMMIT")
             except Exception:
-                self.connection.rollback()
+                self.connection.execute("ROLLBACK")
                 raise
+            finally:
+                self.connection.isolation_level = previous
+
+    @contextmanager
+    def immediate(self) -> Iterator[sqlite3.Connection]:
+        """A write transaction that takes its lock UP FRONT.
+
+        `BEGIN IMMEDIATE` acquires the reserved lock before any statement runs,
+        so two connections cannot both read a row, both decide to act, and both
+        write. Deferred transactions -- SQLite's default -- allow exactly that.
+        """
+        previous = self.connection.isolation_level
+        self.connection.isolation_level = None
+        try:
+            self.connection.execute("BEGIN IMMEDIATE")
+            yield self.connection
+            self.connection.execute("COMMIT")
+        except Exception:
+            self.connection.execute("ROLLBACK")
+            raise
+        finally:
+            self.connection.isolation_level = previous
 
     @contextmanager
     def transaction(self) -> Iterator[sqlite3.Connection]:
@@ -236,8 +318,16 @@ class Database:
             )
         elif table == "messages":
             self.connection.execute(
-                "INSERT OR REPLACE INTO messages(id, recipient, record) VALUES (?, ?, ?)",
-                (record_id, record["recipient"], payload),
+                "INSERT OR REPLACE INTO messages(id, recipient, record, state, claim_owner, "
+                "claim_expires_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    record_id,
+                    record["recipient"],
+                    payload,
+                    record.get("state", "NEW"),
+                    record.get("claim_owner"),
+                    record.get("claim_expires_at"),
+                ),
             )
         else:
             self.connection.execute(

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -166,12 +166,33 @@ UPDATE messages SET
 """
 
 
+MIGRATION_6 = """
+-- A review that leaves no record is a claim nobody can check later. Acceptance
+-- could not consult reviews because there was nothing durable to consult.
+CREATE TABLE IF NOT EXISTS reviews (
+    id TEXT PRIMARY KEY,
+    sow_id TEXT NOT NULL,
+    outcome_id TEXT NOT NULL,
+    reviewer_actor_id TEXT NOT NULL,
+    decision TEXT NOT NULL,
+    record TEXT NOT NULL,
+    FOREIGN KEY(sow_id) REFERENCES sows(id),
+    FOREIGN KEY(outcome_id) REFERENCES outcomes(id)
+);
+CREATE INDEX IF NOT EXISTS reviews_by_outcome ON reviews(outcome_id);
+-- Receipts must name the execution they describe, or they cannot be tied to it.
+ALTER TABLE receipts ADD COLUMN assignment_id TEXT;
+ALTER TABLE receipts ADD COLUMN status TEXT NOT NULL DEFAULT '';
+"""
+
+
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (1, MIGRATION_1),
     (2, MIGRATION_2),
     (3, MIGRATION_3),
     (4, MIGRATION_4),
     (5, MIGRATION_5),
+    (6, MIGRATION_6),
 )
 
 
@@ -340,9 +361,11 @@ class Database:
         json.loads(payload)
         if table != "receipts":
             raise ValueError("put_serialized is restricted to canonical receipts")
+        record = json.loads(payload)
         self.connection.execute(
-            "INSERT OR REPLACE INTO receipts(id, record) VALUES (?, ?)",
-            (record_id, payload),
+            "INSERT OR REPLACE INTO receipts(id, record, assignment_id, status) "
+            "VALUES (?, ?, ?, ?)",
+            (record_id, payload, record.get("assignment_id"), record.get("status", "")),
         )
 
     def close(self) -> None:

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -348,18 +348,91 @@ END;
 """
 
 
-# Frozen at the tables version 12 shipped with. Computing this from
-# APPEND_ONLY_TABLES made adding a table change the bytes of an ALREADY-STAMPED
-# version: fresh installs guarded, every upgraded database silently skipped --
-# this PR's recurring shape, a guarantee staying put while the load moves,
-# pre-installed in the fix built to stop it. Raised by Sparring.
+# Migration 12 as it SHIPPED, byte for byte. Not generated.
 #
-# A new proof-bearing table gets a NEW migration version.
-# `test_migration_12_content_is_frozen` fails if this list is edited, so the
-# rule enforces itself rather than relying on anyone remembering it.
+# The first attempt froze the table LIST and left the body flowing through the
+# shared `_append_only_triggers()` helper -- so editing that helper still
+# rewrote the bytes of an already-applied migration, which is the exact failure
+# the freeze was built to prevent. I froze membership and called it content.
+# Proven by mutation: a harmless comment in the helper changed MIGRATION_12's
+# digest while the "frozen" test passed.
+#
+# An applied migration is history. `_append_only_triggers()` stays, for building
+# FUTURE migrations only; version 12 no longer depends on it, and its digest is
+# pinned by `test_migration_12_content_is_frozen`.
 MIGRATION_12_TABLES: tuple[str, ...] = ("effects", "verifications", "reviews", "evidence")
 
-MIGRATION_12 = "".join(_append_only_triggers(table) for table in MIGRATION_12_TABLES)
+MIGRATION_12_SHA256 = "cb5483b35e4ef78d761381dc9a1ac940c59b574f7716c17c84bf9b6c89392a5e"
+
+MIGRATION_12 = """
+CREATE TRIGGER IF NOT EXISTS effects_no_update
+BEFORE UPDATE ON effects
+BEGIN
+    SELECT RAISE(ABORT, 'effects are append-only: update refused');
+END;
+CREATE TRIGGER IF NOT EXISTS effects_no_delete
+BEFORE DELETE ON effects
+BEGIN
+    SELECT RAISE(ABORT, 'effects are append-only: delete refused');
+END;
+CREATE TRIGGER IF NOT EXISTS effects_no_replace
+BEFORE INSERT ON effects
+WHEN EXISTS (SELECT 1 FROM effects WHERE id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, 'effects are append-only: replace refused');
+END;
+
+CREATE TRIGGER IF NOT EXISTS verifications_no_update
+BEFORE UPDATE ON verifications
+BEGIN
+    SELECT RAISE(ABORT, 'verifications are append-only: update refused');
+END;
+CREATE TRIGGER IF NOT EXISTS verifications_no_delete
+BEFORE DELETE ON verifications
+BEGIN
+    SELECT RAISE(ABORT, 'verifications are append-only: delete refused');
+END;
+CREATE TRIGGER IF NOT EXISTS verifications_no_replace
+BEFORE INSERT ON verifications
+WHEN EXISTS (SELECT 1 FROM verifications WHERE id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, 'verifications are append-only: replace refused');
+END;
+
+CREATE TRIGGER IF NOT EXISTS reviews_no_update
+BEFORE UPDATE ON reviews
+BEGIN
+    SELECT RAISE(ABORT, 'reviews are append-only: update refused');
+END;
+CREATE TRIGGER IF NOT EXISTS reviews_no_delete
+BEFORE DELETE ON reviews
+BEGIN
+    SELECT RAISE(ABORT, 'reviews are append-only: delete refused');
+END;
+CREATE TRIGGER IF NOT EXISTS reviews_no_replace
+BEFORE INSERT ON reviews
+WHEN EXISTS (SELECT 1 FROM reviews WHERE id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, 'reviews are append-only: replace refused');
+END;
+
+CREATE TRIGGER IF NOT EXISTS evidence_no_update
+BEFORE UPDATE ON evidence
+BEGIN
+    SELECT RAISE(ABORT, 'evidence are append-only: update refused');
+END;
+CREATE TRIGGER IF NOT EXISTS evidence_no_delete
+BEFORE DELETE ON evidence
+BEGIN
+    SELECT RAISE(ABORT, 'evidence are append-only: delete refused');
+END;
+CREATE TRIGGER IF NOT EXISTS evidence_no_replace
+BEFORE INSERT ON evidence
+WHEN EXISTS (SELECT 1 FROM evidence WHERE id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, 'evidence are append-only: replace refused');
+END;
+"""
 
 
 MIGRATIONS: tuple[tuple[int, str], ...] = (

--- a/src/sovereign_agent/execution.py
+++ b/src/sovereign_agent/execution.py
@@ -114,9 +114,11 @@ def write_failed_receipt(
     category: str,
     message: str,
     started_at: datetime | None = None,
+    assignment_id: str = "",
 ) -> Receipt:
     receipt = Receipt(
         id=new_id("rct"),
+        assignment_id=assignment_id,
         actor_id=actor.id,
         provider=actor.provider,
         provider_session_ref=None,
@@ -138,6 +140,7 @@ def invoke_actor(
     workspace: Path,
     output: Path,
     provider_session_id: str | None = None,
+    assignment_id: str = "",
 ) -> tuple[Receipt, ActorReport | None]:
     workspace_write = "write_workspace" in actor.authority
     if "report" not in actor.authority or not workspace_write:
@@ -240,6 +243,7 @@ def invoke_actor(
         failure_message = "Provider did not write the mandatory report."
     receipt = Receipt(
         id=new_id("rct"),
+        assignment_id=assignment_id,
         actor_id=actor.id,
         provider=actor.provider,
         provider_session_ref=session_ref,

--- a/src/sovereign_agent/governance.py
+++ b/src/sovereign_agent/governance.py
@@ -2,15 +2,27 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from sovereign_agent.files import write_json, write_text
+from sovereign_agent.files import atomic_write, write_json, write_text
 from sovereign_agent.models import Outcome, Ruling, StatementOfWork
 
 
-def project_outcome(root: Path, outcome: Outcome, sows: list[StatementOfWork]) -> None:
-    directory = root / "governance" / "outcomes" / outcome.id
-    write_json(directory / "outcome.json", outcome.model_dump(mode="json"))
+def render_outcome(outcome: Outcome, sows: list[StatementOfWork]) -> dict[str, bytes]:
+    """Render the projection WITHOUT writing it.
+
+    Verification needs the expected bytes in memory. When rendering and writing
+    were one function, `verify_projections.py` had to call the writer to learn
+    what the files should contain -- so it silently repaired the drift it was
+    supposed to report. A verifier that edits reality until it agrees with
+    itself is not a check.
+    """
+    files: dict[str, bytes] = {
+        "outcome.json": json.dumps(
+            outcome.model_dump(mode="json"), indent=2, sort_keys=True, default=str
+        ).encode()
+    }
     lines = [
         f"# {outcome.title}",
         "",
@@ -29,12 +41,21 @@ def project_outcome(root: Path, outcome: Outcome, sows: list[StatementOfWork]) -
         "## SOWs",
         "",
     ]
-    sow_lines = [f"- `{sow.id}` ({sow.state}): {sow.scope}" for sow in sows] or ["- none"]
-    lines.extend(sow_lines)
+    lines.extend([f"- `{sow.id}` ({sow.state}): {sow.scope}" for sow in sows] or ["- none"])
     lines.append("")
-    write_text(directory / "README.md", "\n".join(lines))
+    files["README.md"] = "\n".join(lines).encode()
     for sow in sows:
-        write_json(directory / "sows" / f"{sow.id}.json", sow.model_dump(mode="json"))
+        files[f"sows/{sow.id}.json"] = json.dumps(
+            sow.model_dump(mode="json"), indent=2, sort_keys=True, default=str
+        ).encode()
+    return files
+
+
+def project_outcome(root: Path, outcome: Outcome, sows: list[StatementOfWork]) -> None:
+    """Write the rendered projection. Derived output; never authoritative."""
+    directory = root / "governance" / "outcomes" / outcome.id
+    for name, data in render_outcome(outcome, sows).items():
+        atomic_write(directory / name, data)
 
 
 def project_ruling(root: Path, ruling: Ruling) -> None:

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -212,6 +212,7 @@ class Verification(StrictModel):
 
     id: str
     outcome_id: str
+    sow_id: str
     assignment_id: str
     evidence_refs: list[str]
     check_ids: list[str]

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -81,9 +81,19 @@ class Outcome(StrictModel):
 
 
 class StatementOfWork(StrictModel):
+    """A unit of work: a deliverable and the test for having delivered it.
+
+    `required_effect_kind` says whether this SOW must change the world, and how.
+    Not every legitimate SOW does — an investigation or a report may deliver
+    without moving inventory — so "the execution must have contributed" cannot
+    be a universal rule. It is a rule the SOW declares about itself, and
+    acceptance then enforces exactly what was declared.
+    """
+
     id: str
     outcome_id: str
     scope: str
+    required_effect_kind: str | None = None
     non_goals: list[str]
     deliverables: list[str]
     done_when: str

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -171,7 +171,14 @@ class Evidence(StrictModel):
 
 
 class Receipt(StrictModel):
+    """What an execution did. `assignment_id` ties it to the work it describes.
+
+    Without that field a receipt floats free: acceptance cannot tell whether the
+    successful receipt it found belongs to the execution being accepted.
+    """
+
     id: str
+    assignment_id: str = ""
     actor_id: str
     provider: str
     provider_session_ref: str | None
@@ -182,6 +189,25 @@ class Receipt(StrictModel):
     failure_category: str | None = None
     failure_message: str | None = None
     evidence_refs: list[str]
+
+
+class Review(StrictModel):
+    """An independent actor's durable judgement of one SOW.
+
+    Bound to the evidence it read and the state it read them against, so a later
+    reader can ask what the reviewer actually saw rather than trusting that a
+    status field once changed.
+    """
+
+    id: str
+    sow_id: str
+    outcome_id: str
+    reviewer_actor_id: str
+    performer_actor_ids: list[str]
+    evidence_refs: list[str]
+    decision: str
+    state_digest: str
+    created_at: datetime
 
 
 class Acceptance(StrictModel):

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -191,6 +191,25 @@ class Receipt(StrictModel):
     evidence_refs: list[str]
 
 
+class Verification(StrictModel):
+    """One complete run of an outcome's declared checks.
+
+    A batch, not a loose pile. Review binds to one verification id and
+    acceptance requires a review of the exact batch it is accepting on, so
+    "Sparring reviewed this outcome" cannot silently mean "Sparring reviewed
+    some earlier evidence that has since been replaced".
+    """
+
+    id: str
+    outcome_id: str
+    assignment_id: str
+    evidence_refs: list[str]
+    check_ids: list[str]
+    aggregate_digest: str
+    passed: bool
+    created_at: datetime
+
+
 class Review(StrictModel):
     """An independent actor's durable judgement of one SOW.
 
@@ -204,6 +223,7 @@ class Review(StrictModel):
     outcome_id: str
     reviewer_actor_id: str
     performer_actor_ids: list[str]
+    verification_id: str
     evidence_refs: list[str]
     decision: str
     state_digest: str

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -62,9 +62,18 @@ class Role(StrEnum):
 
 
 class Outcome(StrictModel):
+    """A state of the world someone wants, and how to check it.
+
+    `subject` is what the checks are ABOUT — the SKU, in the store. It lives on
+    the outcome rather than being passed in at verification time, because a
+    caller who chooses the subject chooses which world gets inspected, and can
+    point acceptance at a healthy product while the real one sits empty.
+    """
+
     id: str
     title: str
     desired_state: str
+    subject: str = ""
     acceptance_checks: list[str]
     state: OutcomeState
     owner_actor_id: str

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -137,6 +137,14 @@ class Approval(StrictModel):
 
 
 class Evidence(StrictModel):
+    """A record of one check having been run, bound to what it proves.
+
+    `outcome_id`, `check_id` and `assignment_id` are the binding: they say which
+    question was asked, about which outcome, during which execution. Without
+    them an evidence id is just a filename, and acceptance cannot tell proof
+    from decoration.
+    """
+
     id: str
     assignment_id: str
     kind: str
@@ -145,6 +153,12 @@ class Evidence(StrictModel):
     artifact_refs: list[str]
     digest: str
     created_at: datetime
+    outcome_id: str = ""
+    check_id: str = ""
+    success: bool = False
+    observed: dict[str, Any] = Field(default_factory=dict)
+    state_digest: str = ""
+    verifier_actor_id: str = ""
 
 
 class Receipt(StrictModel):
@@ -180,7 +194,14 @@ class Signal(StrictModel):
 
 
 class ActorReport(StrictModel):
+    """What an actor reports back. Advisory, not authoritative.
+
+    `proposed_checks` and `proposed_restock_units` are REQUESTS. Deterministic
+    Python decides which checks actually run and whether the proposal is sound.
+    """
+
     status: str = Field(pattern="^(completed|blocked|failed)$")
+    proposed_restock_units: int | None = None
     changed_artifacts: list[str] = Field(default_factory=list)
     proposed_checks: list[str] = Field(default_factory=list)
     questions: list[str] = Field(default_factory=list)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -946,8 +946,12 @@ class Organization:
         ).fetchall()
         if {str(row["id"]) for row in rows} != observation_evidence:
             raise Refusal(
-                "The reviewed evidence is not the evidence supporting acceptance.",
-                "Evidence was added or removed after the review.",
+                "The evidence supporting acceptance does not match its verification.",
+                "Evidence was added to or removed from the outcome's final "
+                "observation after it was recorded. This batch has no reviewer "
+                "of its own -- each SOW's review is checked separately -- so the "
+                "mismatch is between the evidence and the verification that "
+                "produced it, not between evidence and a review.",
                 "sovereign-agent status",
                 "Verify again and obtain a fresh review.",
             )

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -395,19 +395,11 @@ class Organization:
     def verify_sow(self, sow_id: str, verifier_id: str) -> list[CheckResult]:
         """Execute the declared checks FOR ONE NAMED SOW's execution.
 
-        The caller says which work is being verified. The previous API took only
+        The caller says which work is being verified. An earlier API took only
         an outcome and picked a SOW implicitly by row order, so with two
-        completed SOWs one of them became permanently unreviewable and which one
-        was arbitrary -- `sows_for()` has no ordering contract.
+        completed SOWs one became permanently unreviewable.
         """
-        verifier = self.actor(verifier_id)
-        require_authority(verifier.role, "run_checks")
         sow = self._sow(sow_id)
-        outcome = self._outcome(sow.outcome_id)
-        if outcome.state != OutcomeState.VERIFYING:
-            outcome.state = advance_outcome(outcome.state, OutcomeState.VERIFYING)
-            self._save_outcome(outcome, "outcome.verifying")
-
         execution_id = self.completed_assignment_for_sow(sow_id)
         if not execution_id:
             raise Refusal(
@@ -416,6 +408,22 @@ class Organization:
                 "sovereign-agent status",
                 "Run this SOW's assignment first.",
             )
+        return self._record_verification(sow.outcome_id, sow_id, verifier_id, execution_id)
+
+    def _record_verification(
+        self, outcome_id: str, sow_id: str, verifier_id: str, execution_id: str = ""
+    ) -> list[CheckResult]:
+        """Run the declared checks and persist one batch of check-bound evidence.
+
+        `sow_id` empty means the outcome-level batch: the final observation that
+        the condition holds now, which belongs to no single unit of work.
+        """
+        verifier = self.actor(verifier_id)
+        require_authority(verifier.role, "run_checks")
+        outcome = self._outcome(outcome_id)
+        if outcome.state != OutcomeState.VERIFYING:
+            outcome.state = advance_outcome(outcome.state, OutcomeState.VERIFYING)
+            self._save_outcome(outcome, "outcome.verifying")
 
         subject = outcome.subject
         results = [run_check(self.db, check_id, subject) for check_id in outcome.acceptance_checks]
@@ -424,7 +432,7 @@ class Organization:
         evidence_ids = [new_id("evd") for _ in results]
         aggregate = digest_payload(
             {
-                "outcome_id": sow.outcome_id,
+                "outcome_id": outcome_id,
                 "sow_id": sow_id,
                 "assignment_id": execution_id,
                 "checks": [
@@ -435,7 +443,7 @@ class Organization:
         )
         verification = Verification(
             id=verification_id,
-            outcome_id=sow.outcome_id,
+            outcome_id=outcome_id,
             sow_id=sow_id,
             assignment_id=execution_id,
             evidence_refs=evidence_ids,
@@ -452,8 +460,9 @@ class Organization:
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     verification_id,
-                    sow.outcome_id,
-                    sow_id,
+                    outcome_id,
+                    # NULL, not "": the FK to sows must not see an empty string.
+                    sow_id or None,
                     execution_id,
                     aggregate,
                     1 if verification.passed else 0,
@@ -465,7 +474,7 @@ class Organization:
                 evidence = Evidence(
                     id=evidence_id,
                     assignment_id=execution_id,
-                    outcome_id=sow.outcome_id,
+                    outcome_id=outcome_id,
                     check_id=result.check_id,
                     success=result.success,
                     observed=result.observed,
@@ -477,7 +486,7 @@ class Organization:
                     digest=digest_payload(
                         {
                             "check_id": result.check_id,
-                            "outcome_id": sow.outcome_id,
+                            "outcome_id": outcome_id,
                             "success": result.success,
                             "observed": result.observed,
                         }
@@ -492,7 +501,7 @@ class Organization:
                         evidence.id,
                         execution_id,
                         evidence.model_dump_json(),
-                        sow.outcome_id,
+                        outcome_id,
                         result.check_id,
                         1 if result.success else 0,
                         result.state_digest,
@@ -501,9 +510,9 @@ class Organization:
                 )
             append_event(
                 self.db,
-                "sow.verified",
+                "sow.verified" if sow_id else "outcome.verified",
                 {
-                    "outcome_id": sow.outcome_id,
+                    "outcome_id": outcome_id,
                     "sow_id": sow_id,
                     "verification_id": verification_id,
                     "by": verifier_id,
@@ -525,6 +534,8 @@ class Organization:
             if self.completed_assignment_for_sow(sow.id):
                 results = self.verify_sow(sow.id, verifier_id)
                 verified_any = True
+        if verified_any:
+            results = self.verify_outcome_condition(outcome_id, verifier_id)
         if not verified_any:
             raise Refusal(
                 f"Outcome {outcome_id} has no completed execution to verify.",
@@ -533,6 +544,25 @@ class Organization:
                 "Run an assignment first.",
             )
         return results
+
+    def verify_outcome_condition(self, outcome_id: str, verifier_id: str) -> list[CheckResult]:
+        """One final observation that the outcome's condition holds NOW.
+
+        Distinct from every SOW's verification. A SOW's batch proves what that
+        unit of work produced; this proves the state of the world at acceptance
+        time, and it is selected explicitly rather than by being whichever SOW
+        was iterated last.
+        """
+        return self._record_verification(outcome_id, "", verifier_id)
+
+    def outcome_verification(self, outcome_id: str) -> Verification | None:
+        """The outcome-level batch: the final observation, not a SOW's."""
+        row = self.db.connection.execute(
+            "SELECT record FROM verifications WHERE outcome_id = ? AND "
+            "(sow_id IS NULL OR sow_id = '') ORDER BY rowid DESC LIMIT 1",
+            (outcome_id,),
+        ).fetchone()
+        return Verification.model_validate_json(row["record"]) if row else None
 
     def verification_for_sow(self, sow_id: str) -> Verification | None:
         """The most recent verification OF THIS SOW."""
@@ -592,17 +622,22 @@ class Organization:
         return {str(row["assignment_id"]) for row in rows}
 
     def effect_kinds_for_execution(self, assignment_id: str) -> set[str]:
-        """What this specific execution changed, CORROBORATED BY THE EVENT LOG.
+        """What this specific execution changed, cross-checked against the events.
 
-        Append-only cannot stop a forged APPEND -- inserting is exactly what it
-        permits -- so a new `effects` row naming an idle assignment would
-        otherwise credit it with work it never did. Every effect is committed in
-        the same transaction as its event, so an effect with no matching event
-        is not a record of anything that happened.
+        Every effect is committed in the same transaction as its event, so an
+        effect with no matching event is an INCOMPLETE record -- a half-written
+        state, or a row someone added by hand.
 
-        `events` is the one table where a forged append is also detectable: the
-        payload names the assignment, and rewriting an existing event is refused
-        outright. Corroboration puts the proof back on the guarded table.
+        This detects inconsistency. It does NOT authenticate. Two coordinated
+        fresh appends -- an effect and its event -- are mutually consistent and
+        equally forged, and this will accept them. An earlier version of this
+        docstring claimed corroboration stopped a forged append; it does not,
+        and saying so contradicted the trust boundary this project already
+        documents. SQLite writers are inside that boundary: anyone who can write
+        arbitrary rows can rewrite the organization's memory, and no number of
+        cross-table checks changes that. Authenticating against an arbitrary
+        writer needs a trust root outside the database. See
+        docs/rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md.
         """
         rows = self.db.connection.execute(
             "SELECT DISTINCT kind FROM effects WHERE assignment_id = ?", (assignment_id,)
@@ -833,7 +868,6 @@ class Organization:
         # outcome-level evidence binding below then uses the verification of the
         # SOW that was verified last, which is the batch describing the world as
         # acceptance sees it.
-        verification = None
         for sow in sows:
             sow_verification = self.verification_for_sow(sow.id)
             if sow_verification is None:
@@ -857,13 +891,18 @@ class Organization:
                     "sovereign-agent status",
                     "Have a reviewer review this SOW's current verification.",
                 )
-            verification = sow_verification
+        # The final world observation is its OWN verification, not whichever
+        # SOW happened to be iterated last. `sows_for()` has no ordering
+        # contract, so review order silently changed which batch acceptance
+        # treated as final -- row order standing in for proof, again.
+        verification = self.outcome_verification(outcome_id)
         if verification is None:
             raise Refusal(
-                "No verification for this outcome.",
-                "Acceptance rests on a completed run of the declared checks.",
+                "The outcome condition has not been verified.",
+                "Each SOW proves its own work; the outcome needs one final "
+                "observation that the condition holds now.",
                 "sovereign-agent verify",
-                "Run verification first.",
+                "Verify the outcome after every SOW is reviewed.",
             )
         review_rows = self.db.connection.execute(
             "SELECT record, decision, reviewer_actor_id, verification_id FROM reviews "
@@ -877,26 +916,12 @@ class Organization:
                 "sovereign-agent status",
                 "Have a reviewer review the SOW.",
             )
-        current_reviews = [
-            row for row in review_rows if str(row["verification_id"]) == verification.id
-        ]
-        if not current_reviews:
-            raise Refusal(
-                "The current verification has not been reviewed.",
-                "The evidence supporting acceptance must be the evidence a "
-                "reviewer actually saw, not an earlier batch it replaced.",
-                "sovereign-agent status",
-                "Have a reviewer review the current verification.",
-            )
-        for row in current_reviews:
+        # Reviews are validated PER SOW above. The outcome-level batch is the
+        # final observation of the world, not a unit of work, so it has no
+        # reviewer of its own -- requiring one would mean reviewing a
+        # measurement rather than reviewing work.
+        for row in review_rows:
             self._trusted_review(row)
-            if str(row["decision"]) != "accepted":
-                raise Refusal(
-                    f"Review by {row['reviewer_actor_id']} decided {row['decision']}.",
-                    "An outcome cannot be accepted over an unresolved review.",
-                    "sovereign-agent status",
-                    "Repair the work, verify again, and obtain a new review.",
-                )
             if str(row["reviewer_actor_id"]) == accepter_id:
                 raise Refusal(
                     f"{accepter_id} reviewed this work and cannot also accept it.",
@@ -904,7 +929,12 @@ class Organization:
                     "sovereign-agent actor list",
                     "Have the Principal accept.",
                 )
-        reviewed_evidence = set(self._trusted_review(current_reviews[0]).evidence_refs)
+        reviewed_evidence = {
+            str(row["id"])
+            for row in self.db.connection.execute(
+                "SELECT id FROM evidence WHERE verification_id = ?", (verification.id,)
+            )
+        }
 
         rows = self.db.connection.execute(
             "SELECT id, check_id, success, state_digest, assignment_id FROM evidence "
@@ -940,14 +970,21 @@ class Organization:
                     "sovereign-agent verify",
                     "Fix the underlying problem and verify again.",
                 )
-            bound = [row for row in usable if str(row["assignment_id"]) == execution_id]
-            if not bound:
-                raise Refusal(
-                    f"Evidence for '{check_id}' is not bound to this execution.",
-                    "Evidence from another run does not prove this one.",
-                    "sovereign-agent verify",
-                    "Verify against the current assignment.",
-                )
+            # The outcome-level batch belongs to no single execution: it is the
+            # final observation of the world, not a record of one unit of work.
+            # Per-execution binding is enforced on each SOW's own batch above.
+            bound = usable
+            if verification.assignment_id:
+                bound = [
+                    row for row in usable if str(row["assignment_id"]) == verification.assignment_id
+                ]
+                if not bound:
+                    raise Refusal(
+                        f"Evidence for '{check_id}' is not bound to this execution.",
+                        "Evidence from another run does not prove this one.",
+                        "sovereign-agent verify",
+                        "Verify against the current assignment.",
+                    )
             fresh = [
                 row for row in bound if str(row["state_digest"]) == current[check_id].state_digest
             ]

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -96,7 +96,12 @@ class Organization:
         return actor
 
     def create_outcome(
-        self, title: str, desired_state: str, checks: list[str], owner: str
+        self,
+        title: str,
+        desired_state: str,
+        checks: list[str],
+        owner: str,
+        subject: str = "",
     ) -> Outcome:
         actor = self.actor(owner)
         require_authority(actor.role, "define_outcome")
@@ -104,6 +109,7 @@ class Organization:
             id=new_id("out"),
             title=title,
             desired_state=desired_state,
+            subject=subject,
             acceptance_checks=checks,
             state=OutcomeState.PROPOSED,
             owner_actor_id=owner,
@@ -246,9 +252,7 @@ class Organization:
         self._save_sow(sow, "sow.reviewed")
         return sow
 
-    def verify_outcome(
-        self, outcome_id: str, verifier_id: str, subject: str = "SKU-TEA"
-    ) -> list[CheckResult]:
+    def verify_outcome(self, outcome_id: str, verifier_id: str) -> list[CheckResult]:
         """Actually execute every declared acceptance check and persist evidence.
 
         This used to advance a state field and nothing else. A verification that
@@ -266,6 +270,9 @@ class Organization:
             self._save_outcome(outcome, "outcome.verifying")
 
         execution_id = self._latest_assignment_id(outcome_id)
+        # The SUBJECT comes from the outcome, never from the caller. A caller
+        # that picks the subject picks which world gets inspected.
+        subject = outcome.subject
         results = [run_check(self.db, check_id, subject) for check_id in outcome.acceptance_checks]
         with self.db.transaction():
             for result in results:
@@ -338,7 +345,7 @@ class Organization:
         rows = self.db.connection.execute("SELECT sow_id, actor_id FROM assignments").fetchall()
         return {str(row["actor_id"]) for row in rows if row["sow_id"] in sow_ids}
 
-    def accept(self, outcome_id: str, accepter_id: str, subject: str = "SKU-TEA") -> Acceptance:
+    def accept(self, outcome_id: str, accepter_id: str) -> Acceptance:
         """Accept only if the declared outcome is TRUE RIGHT NOW.
 
         Acceptance does not trust a list of evidence ids handed to it. A caller
@@ -389,8 +396,10 @@ class Organization:
             )
 
         execution_id = self._latest_assignment_id(outcome_id)
+        # Subject is read from the outcome, not supplied. Otherwise acceptance
+        # could be pointed at a healthy product while the real one sits empty.
         current = {
-            check_id: run_check(self.db, check_id, subject)
+            check_id: run_check(self.db, check_id, outcome.subject)
             for check_id in outcome.acceptance_checks
         }
         failed_now = sorted(cid for cid, result in current.items() if not result.success)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -592,11 +592,34 @@ class Organization:
         return {str(row["assignment_id"]) for row in rows}
 
     def effect_kinds_for_execution(self, assignment_id: str) -> set[str]:
-        """What this specific execution changed, by kind."""
+        """What this specific execution changed, CORROBORATED BY THE EVENT LOG.
+
+        Append-only cannot stop a forged APPEND -- inserting is exactly what it
+        permits -- so a new `effects` row naming an idle assignment would
+        otherwise credit it with work it never did. Every effect is committed in
+        the same transaction as its event, so an effect with no matching event
+        is not a record of anything that happened.
+
+        `events` is the one table where a forged append is also detectable: the
+        payload names the assignment, and rewriting an existing event is refused
+        outright. Corroboration puts the proof back on the guarded table.
+        """
         rows = self.db.connection.execute(
             "SELECT DISTINCT kind FROM effects WHERE assignment_id = ?", (assignment_id,)
         ).fetchall()
-        return {str(row["kind"]) for row in rows}
+        claimed = {str(row["kind"]) for row in rows}
+        if not claimed:
+            return claimed
+        corroborated: set[str] = set()
+        for kind in claimed:
+            witnessed = self.db.connection.execute(
+                "SELECT COUNT(*) AS c FROM events "
+                "WHERE kind = ? AND json_extract(payload, '$.assignment_id') = ?",
+                (f"{kind}.committed", assignment_id),
+            ).fetchone()
+            if int(witnessed["c"]) > 0:
+                corroborated.add(kind)
+        return corroborated
 
     def performers_for(self, outcome_id: str) -> set[str]:
         """Who actually did the work, DERIVED FROM THE LEDGER.

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -23,6 +23,7 @@ from sovereign_agent.models import (
     Message,
     Outcome,
     OutcomeState,
+    Review,
     Role,
     Ruling,
     SowState,
@@ -199,7 +200,9 @@ class Organization:
         started_at = utc_now()
         failure: Exception | None = None
         try:
-            receipt, report = invoke_actor(worker, sow, workspace, output)
+            receipt, report = invoke_actor(
+                worker, sow, workspace, output, assignment_id=assignment.id
+            )
         except Refusal as error:
             receipt = write_failed_receipt(
                 worker,
@@ -207,6 +210,7 @@ class Organization:
                 error.category,
                 str(error),
                 started_at,
+                assignment_id=assignment.id,
             )
             report = None
             failure = error
@@ -217,6 +221,7 @@ class Organization:
                 "internal_error",
                 f"{type(error).__name__}: {error}",
                 started_at,
+                assignment_id=assignment.id,
             )
             report = None
             failure = error
@@ -242,15 +247,80 @@ class Organization:
             raise failure
         return assignment
 
-    def review(self, sow_id: str, reviewer_id: str, performer_id: str) -> StatementOfWork:
+    def review(self, sow_id: str, reviewer_id: str) -> Review:
+        """An independent actor reviews the work and leaves a durable record.
+
+        No `performer_id` parameter: the performers come from the assignments in
+        the ledger. A caller that names the performer supplies the evidence for
+        its own separation check.
+
+        The review binds to the evidence that exists at review time and the state
+        digest it was read against, so `accept()` can ask what the reviewer
+        actually saw. Reviewing before any evidence exists is refused -- the
+        SOW's own `done_when` requires evidence, so approving without it would
+        contradict the document being approved.
+        """
         reviewer = self.actor(reviewer_id)
         require_authority(reviewer.role, "review")
-        forbid_self_approval(performer_id, reviewer_id)
         sow = self._sow(sow_id)
-        sow.state = advance_sow(sow.state, SowState.ACCEPTED)
-        relay_send(self.db, reviewer_id, performer_id, "review", f"SOW {sow_id} accepted")
-        self._save_sow(sow, "sow.reviewed")
-        return sow
+        performers = self.performers_for(sow.outcome_id)
+        for performer_id in sorted(performers):
+            forbid_self_approval(performer_id, reviewer_id)
+
+        rows = self.db.connection.execute(
+            "SELECT id, success, state_digest FROM evidence WHERE outcome_id = ?",
+            (sow.outcome_id,),
+        ).fetchall()
+        if not rows:
+            raise Refusal(
+                "No evidence to review.",
+                "The SOW's done_when requires evidence. Reviewing before it "
+                "exists approves a document that contradicts itself.",
+                "sovereign-agent verify",
+                "Run verification first, then review.",
+            )
+        failing = [str(row["id"]) for row in rows if int(row["success"]) != 1]
+        decision = "changes_requested" if failing else "accepted"
+
+        review = Review(
+            id=new_id("rev"),
+            sow_id=sow_id,
+            outcome_id=sow.outcome_id,
+            reviewer_actor_id=reviewer_id,
+            performer_actor_ids=sorted(performers),
+            evidence_refs=[str(row["id"]) for row in rows],
+            decision=decision,
+            state_digest=str(rows[-1]["state_digest"]),
+            created_at=utc_now(),
+        )
+        if decision == "accepted":
+            sow.state = advance_sow(sow.state, SowState.ACCEPTED)
+        else:
+            sow.state = advance_sow(sow.state, SowState.CHANGES_REQUESTED)
+
+        with self.db.transaction():
+            self.db.connection.execute(
+                "INSERT INTO reviews(id, sow_id, outcome_id, reviewer_actor_id, decision, "
+                "record) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    review.id,
+                    sow_id,
+                    sow.outcome_id,
+                    reviewer_id,
+                    decision,
+                    review.model_dump_json(),
+                ),
+            )
+            self.db.put("sows", sow.id, sow.model_dump(mode="json"))
+            append_event(
+                self.db,
+                "sow.reviewed",
+                {"id": sow.id, "review": review.id, "decision": decision, "by": reviewer_id},
+            )
+        for performer_id in sorted(performers):
+            relay_send(self.db, reviewer_id, performer_id, "review", f"SOW {sow_id} {decision}")
+        self._project_outcome(sow.outcome_id)
+        return review
 
     def verify_outcome(self, outcome_id: str, verifier_id: str) -> list[CheckResult]:
         """Actually execute every declared acceptance check and persist evidence.
@@ -411,6 +481,54 @@ class Organization:
                 "sovereign-agent verify",
                 "Fix the world, then verify and accept again.",
             )
+
+        # The work must have SUCCEEDED. Acceptance previously never looked at
+        # receipts, so an outcome whose only receipt said "failed" still accepted.
+        receipt_row = self.db.connection.execute(
+            "SELECT record, status FROM receipts WHERE assignment_id = ?", (execution_id,)
+        ).fetchone()
+        if receipt_row is None:
+            raise Refusal(
+                f"No receipt for execution {execution_id or '(none)'}.",
+                "An execution with no receipt left no evidence that it ran.",
+                "sovereign-agent status",
+                "Run the assignment.",
+            )
+        if str(receipt_row["status"]) != "completed":
+            raise Refusal(
+                f"The execution receipt reports status {receipt_row['status']}.",
+                "Work that did not succeed cannot support an accepted outcome.",
+                "sovereign-agent status",
+                "Fix the failure and re-run the assignment.",
+            )
+
+        # An independent review must exist, and must have accepted.
+        review_rows = self.db.connection.execute(
+            "SELECT record, decision, reviewer_actor_id FROM reviews WHERE outcome_id = ?",
+            (outcome_id,),
+        ).fetchall()
+        if not review_rows:
+            raise Refusal(
+                "No review record for this outcome.",
+                "Acceptance requires an independent actor to have reviewed the work.",
+                "sovereign-agent status",
+                "Have a reviewer review the SOW.",
+            )
+        for row in review_rows:
+            if str(row["decision"]) != "accepted":
+                raise Refusal(
+                    f"Review {row['reviewer_actor_id']} decided {row['decision']}.",
+                    "An outcome cannot be accepted over an unresolved review.",
+                    "sovereign-agent status",
+                    "Resolve the review first.",
+                )
+            if str(row["reviewer_actor_id"]) == accepter_id:
+                raise Refusal(
+                    f"{accepter_id} reviewed this work and cannot also accept it.",
+                    "Review and acceptance are separate acts by separate actors.",
+                    "sovereign-agent actor list",
+                    "Have the Principal accept.",
+                )
 
         rows = self.db.connection.execute(
             "SELECT id, check_id, success, state_digest, assignment_id FROM evidence "

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -320,19 +320,19 @@ class Organization:
         # Only the CURRENT batch. Scanning every historical row meant one failed
         # check poisoned every later review forever, so a corrected world could
         # never be re-reviewed.
-        verification = self.latest_verification(sow.outcome_id)
+        # THIS SOW's own verification, selected by sow_id rather than by row
+        # order across the outcome. The relational chain is checked rather than
+        # assumed: verification.sow_id -> assignment.sow_id -> the reviewed SOW.
+        verification = self.verification_for_sow(sow_id)
         if verification is not None:
-            # The batch must be OF THIS SOW's execution. Reviewing a batch bound
-            # to a different SOW's assignment lends that SOW's proof to this one.
             execution = self.completed_assignment_for_sow(sow_id)
-            if not execution or verification.assignment_id != execution:
+            if verification.sow_id != sow_id or verification.assignment_id != execution:
                 raise Refusal(
-                    f"The current verification belongs to another SOW's execution "
-                    f"({verification.assignment_id or 'none'}).",
+                    f"Verification {verification.id} does not belong to SOW {sow_id}.",
                     "A SOW is independently governed work: its review must rest "
                     "on its own execution, not on a sibling's.",
                     "sovereign-agent verify",
-                    "Run and verify this SOW's own assignment.",
+                    "Verify this SOW's own assignment.",
                 )
         if verification is None:
             raise Refusal(
@@ -392,26 +392,31 @@ class Organization:
         self._project_outcome(sow.outcome_id)
         return review
 
-    def verify_outcome(self, outcome_id: str, verifier_id: str) -> list[CheckResult]:
-        """Actually execute every declared acceptance check and persist evidence.
+    def verify_sow(self, sow_id: str, verifier_id: str) -> list[CheckResult]:
+        """Execute the declared checks FOR ONE NAMED SOW's execution.
 
-        This used to advance a state field and nothing else. A verification that
-        runs no checks is a rubber stamp with a spinner.
-
-        Unknown, malformed, or erroring checks fail closed. Evidence is written
-        for every declared check, pass or fail, so a failed verification leaves a
-        durable record of WHY rather than a silent absence.
+        The caller says which work is being verified. The previous API took only
+        an outcome and picked a SOW implicitly by row order, so with two
+        completed SOWs one of them became permanently unreviewable and which one
+        was arbitrary -- `sows_for()` has no ordering contract.
         """
         verifier = self.actor(verifier_id)
         require_authority(verifier.role, "run_checks")
-        outcome = self._outcome(outcome_id)
+        sow = self._sow(sow_id)
+        outcome = self._outcome(sow.outcome_id)
         if outcome.state != OutcomeState.VERIFYING:
             outcome.state = advance_outcome(outcome.state, OutcomeState.VERIFYING)
             self._save_outcome(outcome, "outcome.verifying")
 
-        execution_id = self._latest_assignment_id(outcome_id)
-        # The SUBJECT comes from the outcome, never from the caller. A caller
-        # that picks the subject picks which world gets inspected.
+        execution_id = self.completed_assignment_for_sow(sow_id)
+        if not execution_id:
+            raise Refusal(
+                f"SOW {sow_id} has no completed execution to verify.",
+                "Verification inspects the result of work that has run.",
+                "sovereign-agent status",
+                "Run this SOW's assignment first.",
+            )
+
         subject = outcome.subject
         results = [run_check(self.db, check_id, subject) for check_id in outcome.acceptance_checks]
 
@@ -419,7 +424,8 @@ class Organization:
         evidence_ids = [new_id("evd") for _ in results]
         aggregate = digest_payload(
             {
-                "outcome_id": outcome_id,
+                "outcome_id": sow.outcome_id,
+                "sow_id": sow_id,
                 "assignment_id": execution_id,
                 "checks": [
                     {"check_id": r.check_id, "success": r.success, "digest": r.state_digest}
@@ -429,7 +435,8 @@ class Organization:
         )
         verification = Verification(
             id=verification_id,
-            outcome_id=outcome_id,
+            outcome_id=sow.outcome_id,
+            sow_id=sow_id,
             assignment_id=execution_id,
             evidence_refs=evidence_ids,
             check_ids=[r.check_id for r in results],
@@ -440,11 +447,13 @@ class Organization:
 
         with self.db.transaction():
             self.db.connection.execute(
-                "INSERT INTO verifications(id, outcome_id, assignment_id, aggregate_digest, "
-                "passed, record, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO verifications(id, outcome_id, sow_id, assignment_id, "
+                "aggregate_digest, passed, record, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     verification_id,
-                    outcome_id,
+                    sow.outcome_id,
+                    sow_id,
                     execution_id,
                     aggregate,
                     1 if verification.passed else 0,
@@ -456,7 +465,7 @@ class Organization:
                 evidence = Evidence(
                     id=evidence_id,
                     assignment_id=execution_id,
-                    outcome_id=outcome_id,
+                    outcome_id=sow.outcome_id,
                     check_id=result.check_id,
                     success=result.success,
                     observed=result.observed,
@@ -468,7 +477,7 @@ class Organization:
                     digest=digest_payload(
                         {
                             "check_id": result.check_id,
-                            "outcome_id": outcome_id,
+                            "outcome_id": sow.outcome_id,
                             "success": result.success,
                             "observed": result.observed,
                         }
@@ -483,7 +492,7 @@ class Organization:
                         evidence.id,
                         execution_id,
                         evidence.model_dump_json(),
-                        outcome_id,
+                        sow.outcome_id,
                         result.check_id,
                         1 if result.success else 0,
                         result.state_digest,
@@ -492,9 +501,10 @@ class Organization:
                 )
             append_event(
                 self.db,
-                "outcome.verified",
+                "sow.verified",
                 {
-                    "id": outcome_id,
+                    "outcome_id": sow.outcome_id,
+                    "sow_id": sow_id,
                     "verification_id": verification_id,
                     "by": verifier_id,
                     "passed": sum(1 for r in results if r.success),
@@ -502,6 +512,35 @@ class Organization:
                 },
             )
         return results
+
+    def verify_outcome(self, outcome_id: str, verifier_id: str) -> list[CheckResult]:
+        """Verify every SOW of an outcome that has a completed execution.
+
+        A convenience over `verify_sow`, kept because the single-SOW demo reads
+        better without naming the SOW. It never guesses: it verifies them all.
+        """
+        results: list[CheckResult] = []
+        verified_any = False
+        for sow in self.sows_for(outcome_id):
+            if self.completed_assignment_for_sow(sow.id):
+                results = self.verify_sow(sow.id, verifier_id)
+                verified_any = True
+        if not verified_any:
+            raise Refusal(
+                f"Outcome {outcome_id} has no completed execution to verify.",
+                "Verification inspects the result of work that has run.",
+                "sovereign-agent status",
+                "Run an assignment first.",
+            )
+        return results
+
+    def verification_for_sow(self, sow_id: str) -> Verification | None:
+        """The most recent verification OF THIS SOW."""
+        row = self.db.connection.execute(
+            "SELECT record FROM verifications WHERE sow_id = ? ORDER BY rowid DESC LIMIT 1",
+            (sow_id,),
+        ).fetchone()
+        return Verification.model_validate_json(row["record"]) if row else None
 
     def latest_verification(self, outcome_id: str) -> Verification | None:
         """The most recent complete batch for this outcome."""
@@ -612,6 +651,26 @@ class Organization:
             )
         return receipt
 
+    def _require_deliverables(self, sow: StatementOfWork, execution: str) -> None:
+        """Every declared deliverable must exist in the execution's workspace.
+
+        A non-effectful SOW changes nothing in the world, so the only thing
+        distinguishing "delivered" from "ran and returned" is the artifact it
+        promised. Judging such a SOW by the outcome's store checks would be the
+        name/value mismatch this unit exists to remove, one scope up.
+        """
+        assignment = self._assignment(execution)
+        output = self.root / ".sovereign" / "runs" / assignment.workspace_id / ".sovereign-out"
+        for deliverable in sow.deliverables:
+            if not (output / deliverable).is_file():
+                raise Refusal(
+                    f"SOW {sow.id} promised {deliverable} and did not produce it.",
+                    "A unit of work is done when its deliverable exists, not "
+                    "when its execution returns.",
+                    str(output),
+                    "Re-run the assignment so it writes its deliverable.",
+                )
+
     def _trusted_review(self, row: Any) -> Review:
         """Load one review, validating the record against its indexed columns."""
         review = Review.model_validate_json(row["record"])
@@ -720,6 +779,10 @@ class Organization:
                     "Run this SOW's assignment.",
                 )
             self._trusted_receipt(execution)
+            # Every SOW must have DELIVERED, effectful or not. For an
+            # investigation the deliverable IS the proof: outcome-level store
+            # checks say nothing about whether a report was written.
+            self._require_deliverables(sow, execution)
             if sow.required_effect_kind is None:
                 continue
             # No `if contributors and ...` guard: the empty case is the STRONGEST
@@ -743,7 +806,35 @@ class Organization:
         # now while the review referenced whatever existed then, so a second
         # verification could replace every reviewed row and acceptance would
         # still report that the work had been reviewed.
-        verification = self.latest_verification(outcome_id)
+        # Each SOW's proof chain is validated on its own verification. The
+        # outcome-level evidence binding below then uses the verification of the
+        # SOW that was verified last, which is the batch describing the world as
+        # acceptance sees it.
+        verification = None
+        for sow in sows:
+            sow_verification = self.verification_for_sow(sow.id)
+            if sow_verification is None:
+                raise Refusal(
+                    f"SOW {sow.id} has not been verified.",
+                    "Acceptance rests on a completed run of the declared checks "
+                    "for every unit of work.",
+                    "sovereign-agent verify",
+                    "Verify each SOW.",
+                )
+            sow_reviews = self.db.connection.execute(
+                "SELECT record, decision, reviewer_actor_id, verification_id FROM reviews "
+                "WHERE sow_id = ? AND verification_id = ?",
+                (sow.id, sow_verification.id),
+            ).fetchall()
+            if not sow_reviews:
+                raise Refusal(
+                    f"SOW {sow.id} has no review of its current verification.",
+                    "The evidence supporting acceptance must be the evidence a "
+                    "reviewer actually saw, not an earlier batch it replaced.",
+                    "sovereign-agent status",
+                    "Have a reviewer review this SOW's current verification.",
+                )
+            verification = sow_verification
         if verification is None:
             raise Refusal(
                 "No verification for this outcome.",

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -796,7 +796,6 @@ class Organization:
                 "Declare at least one acceptance check.",
             )
 
-        execution_id = self._latest_assignment_id(outcome_id)
         # Subject is read from the outcome, not supplied. Otherwise acceptance
         # could be pointed at a healthy product while the real one sits empty.
         current = {
@@ -813,9 +812,10 @@ class Organization:
                 "Fix the world, then verify and accept again.",
             )
 
-        # The work must have SUCCEEDED. Acceptance previously never looked at
-        # receipts, so an outcome whose only receipt said "failed" still accepted.
-        self._trusted_receipt(execution_id)
+        # Receipts are validated PER SOW below, on each SOW's own execution.
+        # A single outcome-level receipt check used `_latest_assignment_id`,
+        # which is row-order selection across all SOWs -- the concept this
+        # design replaced. Removed rather than reordered.
 
         # The bound execution must have CONTRIBUTED. Ruling
         # 2026-08-26-outcomes-are-conditions-sows-are-work: an outcome is a
@@ -859,15 +859,13 @@ class Organization:
                     "Do the work this SOW declares, or drop its required effect.",
                 )
 
-        # Acceptance rests on ONE verification batch, and the review must be of
-        # that exact batch. Previously acceptance used whatever evidence existed
-        # now while the review referenced whatever existed then, so a second
-        # verification could replace every reviewed row and acceptance would
-        # still report that the work had been reviewed.
-        # Each SOW's proof chain is validated on its own verification. The
-        # outcome-level evidence binding below then uses the verification of the
-        # SOW that was verified last, which is the batch describing the world as
-        # acceptance sees it.
+        # Each SOW's proof chain is validated on its own verification, and the
+        # review must be of that exact batch: a second verification could
+        # otherwise replace every reviewed row while acceptance still reported
+        # the work reviewed. The final world observation is selected separately,
+        # below, by `outcome_verification` -- NOT by whichever SOW happens to be
+        # iterated last, which is what an earlier version of this comment
+        # described and an earlier version of this code did.
         for sow in sows:
             sow_verification = self.verification_for_sow(sow.id)
             if sow_verification is None:
@@ -929,7 +927,12 @@ class Organization:
                     "sovereign-agent actor list",
                     "Have the Principal accept.",
                 )
-        reviewed_evidence = {
+        # The evidence of the final observation. Deliberately NOT called
+        # "reviewed evidence": the outcome observation has no reviewer of its
+        # own -- each SOW's review is validated above -- and naming it for a
+        # review binding that does not exist would teach a relationship the
+        # code does not have.
+        observation_evidence = {
             str(row["id"])
             for row in self.db.connection.execute(
                 "SELECT id FROM evidence WHERE verification_id = ?", (verification.id,)
@@ -941,7 +944,7 @@ class Organization:
             "WHERE outcome_id = ? AND verification_id = ?",
             (outcome_id, verification.id),
         ).fetchall()
-        if {str(row["id"]) for row in rows} != reviewed_evidence:
+        if {str(row["id"]) for row in rows} != observation_evidence:
             raise Refusal(
                 "The reviewed evidence is not the evidence supporting acceptance.",
                 "Evidence was added or removed after the review.",

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -23,11 +23,13 @@ from sovereign_agent.models import (
     Message,
     Outcome,
     OutcomeState,
+    Receipt,
     Review,
     Role,
     Ruling,
     SowState,
     StatementOfWork,
+    Verification,
 )
 from sovereign_agent.policy import (
     advance_outcome,
@@ -168,7 +170,12 @@ class Organization:
                 "actor list",
                 "Pick an actor with the SOW role.",
             )
-        if sow.state == SowState.READY:
+        # READY -> ASSIGNED is the first attempt; CHANGES_REQUESTED -> ASSIGNED
+        # is recovery. Policy always allowed the second transition and nothing
+        # ever used it, so a SOW that had changes requested was terminal: the
+        # only way forward was to delete the organization and start over. That
+        # is the opposite of what Chapter 2 teaches about refusal.
+        if sow.state in {SowState.READY, SowState.CHANGES_REQUESTED}:
             sow.state = advance_sow(sow.state, SowState.ASSIGNED)
         assignment = Assignment(
             id=new_id("asg"),
@@ -267,20 +274,23 @@ class Organization:
         for performer_id in sorted(performers):
             forbid_self_approval(performer_id, reviewer_id)
 
-        rows = self.db.connection.execute(
-            "SELECT id, success, state_digest FROM evidence WHERE outcome_id = ?",
-            (sow.outcome_id,),
-        ).fetchall()
-        if not rows:
+        # Only the CURRENT batch. Scanning every historical row meant one failed
+        # check poisoned every later review forever, so a corrected world could
+        # never be re-reviewed.
+        verification = self.latest_verification(sow.outcome_id)
+        if verification is None:
             raise Refusal(
-                "No evidence to review.",
+                "No verification to review.",
                 "The SOW's done_when requires evidence. Reviewing before it "
                 "exists approves a document that contradicts itself.",
                 "sovereign-agent verify",
                 "Run verification first, then review.",
             )
-        failing = [str(row["id"]) for row in rows if int(row["success"]) != 1]
-        decision = "changes_requested" if failing else "accepted"
+        rows = self.db.connection.execute(
+            "SELECT id, success, state_digest FROM evidence WHERE verification_id = ?",
+            (verification.id,),
+        ).fetchall()
+        decision = "accepted" if verification.passed else "changes_requested"
 
         review = Review(
             id=new_id("rev"),
@@ -288,20 +298,23 @@ class Organization:
             outcome_id=sow.outcome_id,
             reviewer_actor_id=reviewer_id,
             performer_actor_ids=sorted(performers),
+            verification_id=verification.id,
             evidence_refs=[str(row["id"]) for row in rows],
             decision=decision,
-            state_digest=str(rows[-1]["state_digest"]),
+            # A digest over the WHOLE batch, not the last row that happened to
+            # come back from the query.
+            state_digest=verification.aggregate_digest,
             created_at=utc_now(),
         )
         if decision == "accepted":
             sow.state = advance_sow(sow.state, SowState.ACCEPTED)
-        else:
+        elif sow.state != SowState.CHANGES_REQUESTED:
             sow.state = advance_sow(sow.state, SowState.CHANGES_REQUESTED)
 
         with self.db.transaction():
             self.db.connection.execute(
                 "INSERT INTO reviews(id, sow_id, outcome_id, reviewer_actor_id, decision, "
-                "record) VALUES (?, ?, ?, ?, ?, ?)",
+                "record, verification_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     review.id,
                     sow_id,
@@ -309,6 +322,7 @@ class Organization:
                     reviewer_id,
                     decision,
                     review.model_dump_json(),
+                    verification.id,
                 ),
             )
             self.db.put("sows", sow.id, sow.model_dump(mode="json"))
@@ -344,10 +358,47 @@ class Organization:
         # that picks the subject picks which world gets inspected.
         subject = outcome.subject
         results = [run_check(self.db, check_id, subject) for check_id in outcome.acceptance_checks]
+
+        verification_id = new_id("ver")
+        evidence_ids = [new_id("evd") for _ in results]
+        aggregate = digest_payload(
+            {
+                "outcome_id": outcome_id,
+                "assignment_id": execution_id,
+                "checks": [
+                    {"check_id": r.check_id, "success": r.success, "digest": r.state_digest}
+                    for r in results
+                ],
+            }
+        )
+        verification = Verification(
+            id=verification_id,
+            outcome_id=outcome_id,
+            assignment_id=execution_id,
+            evidence_refs=evidence_ids,
+            check_ids=[r.check_id for r in results],
+            aggregate_digest=aggregate,
+            passed=all(r.success for r in results),
+            created_at=utc_now(),
+        )
+
         with self.db.transaction():
-            for result in results:
+            self.db.connection.execute(
+                "INSERT INTO verifications(id, outcome_id, assignment_id, aggregate_digest, "
+                "passed, record, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    verification_id,
+                    outcome_id,
+                    execution_id,
+                    aggregate,
+                    1 if verification.passed else 0,
+                    verification.model_dump_json(),
+                    verification.created_at.isoformat(),
+                ),
+            )
+            for evidence_id, result in zip(evidence_ids, results, strict=True):
                 evidence = Evidence(
-                    id=new_id("evd"),
+                    id=evidence_id,
                     assignment_id=execution_id,
                     outcome_id=outcome_id,
                     check_id=result.check_id,
@@ -371,7 +422,7 @@ class Organization:
                 )
                 self.db.connection.execute(
                     "INSERT INTO evidence(id, assignment_id, record, outcome_id, check_id, "
-                    "success, state_digest) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    "success, state_digest, verification_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         evidence.id,
                         execution_id,
@@ -380,6 +431,7 @@ class Organization:
                         result.check_id,
                         1 if result.success else 0,
                         result.state_digest,
+                        verification_id,
                     ),
                 )
             append_event(
@@ -387,12 +439,21 @@ class Organization:
                 "outcome.verified",
                 {
                     "id": outcome_id,
+                    "verification_id": verification_id,
                     "by": verifier_id,
                     "passed": sum(1 for r in results if r.success),
                     "total": len(results),
                 },
             )
         return results
+
+    def latest_verification(self, outcome_id: str) -> Verification | None:
+        """The most recent complete batch for this outcome."""
+        row = self.db.connection.execute(
+            "SELECT record FROM verifications WHERE outcome_id = ? ORDER BY rowid DESC LIMIT 1",
+            (outcome_id,),
+        ).fetchone()
+        return Verification.model_validate_json(row["record"]) if row else None
 
     def _latest_assignment_id(self, outcome_id: str) -> str:
         """The execution evidence is bound to. Empty when no work has run yet."""
@@ -414,6 +475,66 @@ class Organization:
         sow_ids = {sow.id for sow in self.sows_for(outcome_id)}
         rows = self.db.connection.execute("SELECT sow_id, actor_id FROM assignments").fetchall()
         return {str(row["actor_id"]) for row in rows if row["sow_id"] in sow_ids}
+
+    def _trusted_receipt(self, assignment_id: str) -> Receipt:
+        """Load one receipt, validating every source against the others.
+
+        The indexed columns and the canonical JSON are two representations of
+        one fact. Reading only the column let an edit to the record alone pass
+        acceptance while the external verifier called the same state
+        unverifiable -- an accepted state known to be false by another tool.
+        """
+        row = self.db.connection.execute(
+            "SELECT record, assignment_id, status FROM receipts WHERE assignment_id = ?",
+            (assignment_id,),
+        ).fetchone()
+        if row is None:
+            raise Refusal(
+                f"No receipt for execution {assignment_id or '(none)'}.",
+                "An execution with no receipt left no evidence that it ran.",
+                "sovereign-agent status",
+                "Run the assignment.",
+            )
+        receipt = Receipt.model_validate_json(row["record"])
+        if receipt.assignment_id != str(row["assignment_id"]):
+            raise Refusal(
+                f"Receipt {receipt.id} disagrees with its index on assignment.",
+                "Two representations of one fact must agree, or neither is trusted.",
+                "sovereign-agent status",
+                "Re-run the assignment.",
+            )
+        if receipt.status != str(row["status"]):
+            raise Refusal(
+                f"Receipt {receipt.id} says {receipt.status}, its index says {row['status']}.",
+                "Two representations of one fact must agree, or neither is trusted.",
+                "sovereign-agent status",
+                "Re-run the assignment.",
+            )
+        if receipt.status != "completed":
+            raise Refusal(
+                f"The execution receipt reports status {receipt.status}.",
+                "Work that did not succeed cannot support an accepted outcome.",
+                "sovereign-agent status",
+                "Fix the failure and re-run the assignment.",
+            )
+        return receipt
+
+    def _trusted_review(self, row: Any) -> Review:
+        """Load one review, validating the record against its indexed columns."""
+        review = Review.model_validate_json(row["record"])
+        for field, column in (
+            (review.decision, "decision"),
+            (review.reviewer_actor_id, "reviewer_actor_id"),
+            (review.verification_id, "verification_id"),
+        ):
+            if field != str(row[column]):
+                raise Refusal(
+                    f"Review {review.id} disagrees with its index on {column}.",
+                    "Two representations of one fact must agree, or neither is trusted.",
+                    "sovereign-agent status",
+                    "Obtain a fresh review.",
+                )
+        return review
 
     def accept(self, outcome_id: str, accepter_id: str) -> Acceptance:
         """Accept only if the declared outcome is TRUE RIGHT NOW.
@@ -484,27 +605,24 @@ class Organization:
 
         # The work must have SUCCEEDED. Acceptance previously never looked at
         # receipts, so an outcome whose only receipt said "failed" still accepted.
-        receipt_row = self.db.connection.execute(
-            "SELECT record, status FROM receipts WHERE assignment_id = ?", (execution_id,)
-        ).fetchone()
-        if receipt_row is None:
-            raise Refusal(
-                f"No receipt for execution {execution_id or '(none)'}.",
-                "An execution with no receipt left no evidence that it ran.",
-                "sovereign-agent status",
-                "Run the assignment.",
-            )
-        if str(receipt_row["status"]) != "completed":
-            raise Refusal(
-                f"The execution receipt reports status {receipt_row['status']}.",
-                "Work that did not succeed cannot support an accepted outcome.",
-                "sovereign-agent status",
-                "Fix the failure and re-run the assignment.",
-            )
+        self._trusted_receipt(execution_id)
 
-        # An independent review must exist, and must have accepted.
+        # Acceptance rests on ONE verification batch, and the review must be of
+        # that exact batch. Previously acceptance used whatever evidence existed
+        # now while the review referenced whatever existed then, so a second
+        # verification could replace every reviewed row and acceptance would
+        # still report that the work had been reviewed.
+        verification = self.latest_verification(outcome_id)
+        if verification is None:
+            raise Refusal(
+                "No verification for this outcome.",
+                "Acceptance rests on a completed run of the declared checks.",
+                "sovereign-agent verify",
+                "Run verification first.",
+            )
         review_rows = self.db.connection.execute(
-            "SELECT record, decision, reviewer_actor_id FROM reviews WHERE outcome_id = ?",
+            "SELECT record, decision, reviewer_actor_id, verification_id FROM reviews "
+            "WHERE outcome_id = ? ORDER BY rowid DESC",
             (outcome_id,),
         ).fetchall()
         if not review_rows:
@@ -514,13 +632,25 @@ class Organization:
                 "sovereign-agent status",
                 "Have a reviewer review the SOW.",
             )
-        for row in review_rows:
+        current_reviews = [
+            row for row in review_rows if str(row["verification_id"]) == verification.id
+        ]
+        if not current_reviews:
+            raise Refusal(
+                "The current verification has not been reviewed.",
+                "The evidence supporting acceptance must be the evidence a "
+                "reviewer actually saw, not an earlier batch it replaced.",
+                "sovereign-agent status",
+                "Have a reviewer review the current verification.",
+            )
+        for row in current_reviews:
+            self._trusted_review(row)
             if str(row["decision"]) != "accepted":
                 raise Refusal(
-                    f"Review {row['reviewer_actor_id']} decided {row['decision']}.",
+                    f"Review by {row['reviewer_actor_id']} decided {row['decision']}.",
                     "An outcome cannot be accepted over an unresolved review.",
                     "sovereign-agent status",
-                    "Resolve the review first.",
+                    "Repair the work, verify again, and obtain a new review.",
                 )
             if str(row["reviewer_actor_id"]) == accepter_id:
                 raise Refusal(
@@ -529,12 +659,20 @@ class Organization:
                     "sovereign-agent actor list",
                     "Have the Principal accept.",
                 )
+        reviewed_evidence = set(self._trusted_review(current_reviews[0]).evidence_refs)
 
         rows = self.db.connection.execute(
             "SELECT id, check_id, success, state_digest, assignment_id FROM evidence "
-            "WHERE outcome_id = ?",
-            (outcome_id,),
+            "WHERE outcome_id = ? AND verification_id = ?",
+            (outcome_id, verification.id),
         ).fetchall()
+        if {str(row["id"]) for row in rows} != reviewed_evidence:
+            raise Refusal(
+                "The reviewed evidence is not the evidence supporting acceptance.",
+                "Evidence was added or removed after the review.",
+                "sovereign-agent status",
+                "Verify again and obtain a fresh review.",
+            )
         by_check: dict[str, list[Any]] = {}
         for row in rows:
             by_check.setdefault(str(row["check_id"]), []).append(row)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from sovereign_agent.actors import load_actors, write_config
+from sovereign_agent.checks import CheckResult, run_check
 from sovereign_agent.database import Database
 from sovereign_agent.errors import Refusal
 from sovereign_agent.events import append_event
+from sovereign_agent.evidence import digest_payload
 from sovereign_agent.execution import invoke_actor, write_failed_receipt
 from sovereign_agent.governance import project_outcome, project_ruling
 from sovereign_agent.ids import new_id, utc_now
@@ -16,6 +19,7 @@ from sovereign_agent.models import (
     Actor,
     Assignment,
     AssignmentState,
+    Evidence,
     Message,
     Outcome,
     OutcomeState,
@@ -242,41 +246,216 @@ class Organization:
         self._save_sow(sow, "sow.reviewed")
         return sow
 
-    def verify_outcome(self, outcome_id: str, verifier_id: str) -> Outcome:
+    def verify_outcome(
+        self, outcome_id: str, verifier_id: str, subject: str = "SKU-TEA"
+    ) -> list[CheckResult]:
+        """Actually execute every declared acceptance check and persist evidence.
+
+        This used to advance a state field and nothing else. A verification that
+        runs no checks is a rubber stamp with a spinner.
+
+        Unknown, malformed, or erroring checks fail closed. Evidence is written
+        for every declared check, pass or fail, so a failed verification leaves a
+        durable record of WHY rather than a silent absence.
+        """
         verifier = self.actor(verifier_id)
         require_authority(verifier.role, "run_checks")
         outcome = self._outcome(outcome_id)
-        outcome.state = advance_outcome(outcome.state, OutcomeState.VERIFYING)
-        self._save_outcome(outcome, "outcome.verifying")
-        return outcome
+        if outcome.state != OutcomeState.VERIFYING:
+            outcome.state = advance_outcome(outcome.state, OutcomeState.VERIFYING)
+            self._save_outcome(outcome, "outcome.verifying")
 
-    def accept(
-        self, outcome_id: str, accepter_id: str, performer_id: str, evidence_ids: list[str]
-    ) -> Acceptance:
+        execution_id = self._latest_assignment_id(outcome_id)
+        results = [run_check(self.db, check_id, subject) for check_id in outcome.acceptance_checks]
+        with self.db.transaction():
+            for result in results:
+                evidence = Evidence(
+                    id=new_id("evd"),
+                    assignment_id=execution_id,
+                    outcome_id=outcome_id,
+                    check_id=result.check_id,
+                    success=result.success,
+                    observed=result.observed,
+                    state_digest=result.state_digest,
+                    kind=result.check_id,
+                    command=["sovereign-agent", "verify", result.check_id],
+                    exit_code=0 if result.success else 1,
+                    artifact_refs=[],
+                    digest=digest_payload(
+                        {
+                            "check_id": result.check_id,
+                            "outcome_id": outcome_id,
+                            "success": result.success,
+                            "observed": result.observed,
+                        }
+                    ),
+                    verifier_actor_id=verifier_id,
+                    created_at=utc_now(),
+                )
+                self.db.connection.execute(
+                    "INSERT INTO evidence(id, assignment_id, record, outcome_id, check_id, "
+                    "success, state_digest) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        evidence.id,
+                        execution_id,
+                        evidence.model_dump_json(),
+                        outcome_id,
+                        result.check_id,
+                        1 if result.success else 0,
+                        result.state_digest,
+                    ),
+                )
+            append_event(
+                self.db,
+                "outcome.verified",
+                {
+                    "id": outcome_id,
+                    "by": verifier_id,
+                    "passed": sum(1 for r in results if r.success),
+                    "total": len(results),
+                },
+            )
+        return results
+
+    def _latest_assignment_id(self, outcome_id: str) -> str:
+        """The execution evidence is bound to. Empty when no work has run yet."""
+        sow_ids = {sow.id for sow in self.sows_for(outcome_id)}
+        rows = self.db.connection.execute(
+            "SELECT id, sow_id FROM assignments ORDER BY rowid DESC"
+        ).fetchall()
+        for row in rows:
+            if row["sow_id"] in sow_ids:
+                return str(row["id"])
+        return ""
+
+    def performers_for(self, outcome_id: str) -> set[str]:
+        """Who actually did the work, DERIVED FROM THE LEDGER.
+
+        Never ask the caller who performed the work. A caller that supplies the
+        performer supplies the evidence for its own separation check.
+        """
+        sow_ids = {sow.id for sow in self.sows_for(outcome_id)}
+        rows = self.db.connection.execute("SELECT sow_id, actor_id FROM assignments").fetchall()
+        return {str(row["actor_id"]) for row in rows if row["sow_id"] in sow_ids}
+
+    def accept(self, outcome_id: str, accepter_id: str, subject: str = "SKU-TEA") -> Acceptance:
+        """Accept only if the declared outcome is TRUE RIGHT NOW.
+
+        Acceptance does not trust a list of evidence ids handed to it. A caller
+        that supplies its own proof is not being checked. Instead this:
+
+        1. re-derives who performed the work, from assignments in the ledger;
+        2. requires every SOW to be accepted;
+        3. RE-EXECUTES every declared check against current state;
+        4. requires stored evidence for every declared check, bound to this
+           outcome and this execution, and successful;
+        5. requires the stored evidence to still describe the world it was
+           written about (state digest agreement).
+
+        Step 3 is the one that matters. Evidence is an audit record of what was
+        observed; the guarantee comes from asking the world again at the moment
+        of acceptance. Stock sold between verification and acceptance makes the
+        claim false, and this refuses.
+        """
         accepter = self.actor(accepter_id)
         require_authority(accepter.role, "accept")
-        forbid_self_approval(performer_id, accepter_id)
         outcome = self._outcome(outcome_id)
+
+        performers = self.performers_for(outcome_id)
+        for performer_id in sorted(performers):
+            forbid_self_approval(performer_id, accepter_id)
+
         sows = self.sows_for(outcome_id)
+        if not sows:
+            raise Refusal(
+                "No SOW exists for this outcome.",
+                "An outcome with no work cannot have been delivered.",
+                "sovereign-agent status",
+                "Create and complete a SOW first.",
+            )
         if any(sow.state != SowState.ACCEPTED for sow in sows):
             raise Refusal(
                 "SOWs remain open.",
                 "Acceptance requires every SOW to be accepted.",
-                "status",
+                "sovereign-agent status",
                 "Finish review first.",
             )
-        if not evidence_ids:
+        if not outcome.acceptance_checks:
             raise Refusal(
-                "No evidence.",
-                "Prose cannot set work to accepted.",
-                "verify",
-                "Run verifier checks.",
+                "Outcome declares no acceptance checks.",
+                "An outcome nobody can check cannot be proved true.",
+                "governance/outcomes",
+                "Declare at least one acceptance check.",
             )
+
+        execution_id = self._latest_assignment_id(outcome_id)
+        current = {
+            check_id: run_check(self.db, check_id, subject)
+            for check_id in outcome.acceptance_checks
+        }
+        failed_now = sorted(cid for cid, result in current.items() if not result.success)
+        if failed_now:
+            raise Refusal(
+                f"Checks failing at acceptance time: {', '.join(failed_now)}.",
+                "Accepted means the declared outcome is true NOW, not that it was "
+                "true once when a check happened to run.",
+                "sovereign-agent verify",
+                "Fix the world, then verify and accept again.",
+            )
+
+        rows = self.db.connection.execute(
+            "SELECT id, check_id, success, state_digest, assignment_id FROM evidence "
+            "WHERE outcome_id = ?",
+            (outcome_id,),
+        ).fetchall()
+        by_check: dict[str, list[Any]] = {}
+        for row in rows:
+            by_check.setdefault(str(row["check_id"]), []).append(row)
+
+        accepted_refs: list[str] = []
+        for check_id in outcome.acceptance_checks:
+            candidates = by_check.get(check_id, [])
+            if not candidates:
+                raise Refusal(
+                    f"No evidence for declared check '{check_id}'.",
+                    "Every declared check needs a record of having been run.",
+                    "sovereign-agent verify",
+                    "Run verification before accepting.",
+                )
+            usable = [row for row in candidates if int(row["success"]) == 1]
+            if not usable:
+                raise Refusal(
+                    f"Evidence for '{check_id}' reports failure.",
+                    "Failed evidence is a record of a problem, not a permission.",
+                    "sovereign-agent verify",
+                    "Fix the underlying problem and verify again.",
+                )
+            bound = [row for row in usable if str(row["assignment_id"]) == execution_id]
+            if not bound:
+                raise Refusal(
+                    f"Evidence for '{check_id}' is not bound to this execution.",
+                    "Evidence from another run does not prove this one.",
+                    "sovereign-agent verify",
+                    "Verify against the current assignment.",
+                )
+            fresh = [
+                row for row in bound if str(row["state_digest"]) == current[check_id].state_digest
+            ]
+            if not fresh:
+                raise Refusal(
+                    f"Evidence for '{check_id}' is stale.",
+                    "The state changed after this evidence was written, so it "
+                    "describes a world that no longer exists.",
+                    "sovereign-agent verify",
+                    "Re-run verification against current state.",
+                )
+            accepted_refs.append(str(fresh[-1]["id"]))
+
         outcome.state = advance_outcome(outcome.state, OutcomeState.ACCEPTED)
         acceptance = Acceptance(
             outcome_id=outcome_id,
             accepted_by=accepter_id,
-            evidence_refs=evidence_ids,
+            evidence_refs=accepted_refs,
             accepted_at=utc_now(),
         )
         with self.db.transaction():
@@ -285,7 +464,12 @@ class Organization:
                 "INSERT OR REPLACE INTO acceptance(outcome_id, record) VALUES (?, ?)",
                 (outcome_id, acceptance.model_dump_json()),
             )
-            append_event(self.db, "outcome.accepted", {"id": outcome_id, "by": accepter_id})
+            append_event(
+                self.db,
+                "outcome.accepted",
+                {"id": outcome_id, "by": accepter_id, "evidence": accepted_refs},
+            )
+        # NOT part of the transaction above: see docs/persistence-boundary.md.
         project_outcome(self.root, outcome, sows)
         return acceptance
 

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -133,13 +133,21 @@ class Organization:
         self._save_outcome(outcome, "outcome.activated")
         return outcome
 
-    def create_sow(self, outcome_id: str, scope: str, role: Role, actor_id: str) -> StatementOfWork:
+    def create_sow(
+        self,
+        outcome_id: str,
+        scope: str,
+        role: Role,
+        actor_id: str,
+        required_effect_kind: str | None = None,
+    ) -> StatementOfWork:
         actor = self.actor(actor_id)
         require_authority(actor.role, "plan")
         sow = StatementOfWork(
             id=new_id("sow"),
             outcome_id=outcome_id,
             scope=scope,
+            required_effect_kind=required_effect_kind,
             non_goals=["expand authority", "skip evidence"],
             deliverables=["report.json"],
             done_when="Evidence exists and a different actor has reviewed it.",
@@ -313,6 +321,19 @@ class Organization:
         # check poisoned every later review forever, so a corrected world could
         # never be re-reviewed.
         verification = self.latest_verification(sow.outcome_id)
+        if verification is not None:
+            # The batch must be OF THIS SOW's execution. Reviewing a batch bound
+            # to a different SOW's assignment lends that SOW's proof to this one.
+            execution = self.completed_assignment_for_sow(sow_id)
+            if not execution or verification.assignment_id != execution:
+                raise Refusal(
+                    f"The current verification belongs to another SOW's execution "
+                    f"({verification.assignment_id or 'none'}).",
+                    "A SOW is independently governed work: its review must rest "
+                    "on its own execution, not on a sibling's.",
+                    "sovereign-agent verify",
+                    "Run and verify this SOW's own assignment.",
+                )
         if verification is None:
             raise Refusal(
                 "No verification to review.",
@@ -490,37 +511,53 @@ class Organization:
         ).fetchone()
         return Verification.model_validate_json(row["record"]) if row else None
 
-    def _latest_assignment_id(self, outcome_id: str) -> str:
-        """The most recent COMPLETED execution for this outcome.
+    def completed_assignment_for_sow(self, sow_id: str) -> str:
+        """The current completed execution OF THIS SOW. Empty if none has run.
 
-        "Newest row" was never a proof rule, it was an ordering accident: a
-        second `assign()` created a row that could not run and it immediately
-        became the identity everything bound to. Only completed executions can
-        carry evidence, so only they are eligible.
+        Proof is per-SOW because governance is per-SOW. Selecting the newest
+        completed assignment across the whole outcome let one SOW's execution,
+        evidence and effect stand as proof for a different SOW that did nothing.
+        Narrowing "newest row" to "newest COMPLETED row" kept the shape and the
+        defect; the shape was the defect.
         """
-        sow_ids = {sow.id for sow in self.sows_for(outcome_id)}
         rows = self.db.connection.execute(
-            "SELECT id, sow_id, record FROM assignments ORDER BY rowid DESC"
+            "SELECT id, record FROM assignments WHERE sow_id = ? ORDER BY rowid DESC",
+            (sow_id,),
         ).fetchall()
         for row in rows:
-            if row["sow_id"] not in sow_ids:
-                continue
             if json.loads(row["record"]).get("state") == AssignmentState.COMPLETED.value:
                 return str(row["id"])
+        return ""
+
+    def _latest_assignment_id(self, outcome_id: str) -> str:
+        """The completed execution of the outcome's most recently worked SOW.
+
+        Retained only for the outcome-level world-check evidence binding; every
+        per-SOW proof goes through `completed_assignment_for_sow`.
+        """
+        for sow in reversed(self.sows_for(outcome_id)):
+            execution = self.completed_assignment_for_sow(sow.id)
+            if execution:
+                return execution
         return ""
 
     def contributing_executions(self, outcome_id: str) -> set[str]:
         """Executions that actually changed the world for this outcome.
 
         Read from the structured `effects` edge, not inferred from world state.
-        An outcome's condition can hold because of work done last week; this
-        answers the different question of what THIS execution did.
         """
         rows = self.db.connection.execute(
             "SELECT DISTINCT assignment_id FROM effects WHERE outcome_id = ?",
             (outcome_id,),
         ).fetchall()
         return {str(row["assignment_id"]) for row in rows}
+
+    def effect_kinds_for_execution(self, assignment_id: str) -> set[str]:
+        """What this specific execution changed, by kind."""
+        rows = self.db.connection.execute(
+            "SELECT DISTINCT kind FROM effects WHERE assignment_id = ?", (assignment_id,)
+        ).fetchall()
+        return {str(row["kind"]) for row in rows}
 
     def performers_for(self, outcome_id: str) -> set[str]:
         """Who actually did the work, DERIVED FROM THE LEDGER.
@@ -670,17 +707,36 @@ class Organization:
         # effect. Without this, an assignment that did nothing inherits credit
         # for a restock done last week, because the checks find replenishments
         # by SKU and the world is still in the state the earlier work left it.
-        contributors = self.contributing_executions(outcome_id)
-        if contributors and execution_id not in contributors:
-            raise Refusal(
-                f"Execution {execution_id} produced no effect for this outcome.",
-                "The condition may well hold, but it holds because of other "
-                "work. Accepting here would credit this execution with a change "
-                "it did not make.",
-                "sovereign-agent status",
-                "Do the work this outcome requires, or accept the outcome that "
-                "the effect actually belongs to.",
-            )
+        # Every SOW is validated on ITS OWN proof, then the outcome's world
+        # condition is re-checked. Previously one execution could satisfy the
+        # whole outcome, so a SOW that did nothing rode on a sibling's work.
+        for sow in sows:
+            execution = self.completed_assignment_for_sow(sow.id)
+            if not execution:
+                raise Refusal(
+                    f"SOW {sow.id} has no completed execution.",
+                    "Every unit of work must have been done by someone.",
+                    "sovereign-agent status",
+                    "Run this SOW's assignment.",
+                )
+            self._trusted_receipt(execution)
+            if sow.required_effect_kind is None:
+                continue
+            # No `if contributors and ...` guard: the empty case is the STRONGEST
+            # form of "this execution did nothing", and guarding the requirement
+            # with it made the requirement vacuous exactly when it mattered most.
+            kinds = self.effect_kinds_for_execution(execution)
+            if sow.required_effect_kind not in kinds:
+                raise Refusal(
+                    f"Execution {execution} produced no {sow.required_effect_kind} "
+                    f"effect for SOW {sow.id}.",
+                    "This SOW declares that it must change the world. The "
+                    "condition may well hold, but it holds because of other work, "
+                    "and accepting here would credit this execution with a change "
+                    "it did not make.",
+                    "sovereign-agent status",
+                    "Do the work this SOW declares, or drop its required effect.",
+                )
 
         # Acceptance rests on ONE verification batch, and the review must be of
         # that exact batch. Previously acceptance used whatever evidence existed

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -953,7 +953,7 @@ class Organization:
                 "mismatch is between the evidence and the verification that "
                 "produced it, not between evidence and a review.",
                 "sovereign-agent status",
-                "Verify again and obtain a fresh review.",
+                "Re-record the outcome observation with verify_outcome_condition.",
             )
         by_check: dict[str, list[Any]] = {}
         for row in rows:

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -175,8 +176,21 @@ class Organization:
         # ever used it, so a SOW that had changes requested was terminal: the
         # only way forward was to delete the organization and start over. That
         # is the opposite of what Chapter 2 teaches about refusal.
-        if sow.state in {SowState.READY, SowState.CHANGES_REQUESTED}:
-            sow.state = advance_sow(sow.state, SowState.ASSIGNED)
+        # Refuse every source state except the two that can legitimately start
+        # work. `assign()` used to create a row from ANY state and only advance
+        # from these two, so a double-click left a second assignment that could
+        # never run -- and `_latest_assignment_id` immediately treated it as the
+        # proof identity, invalidating an otherwise sound outcome.
+        if sow.state not in {SowState.READY, SowState.CHANGES_REQUESTED}:
+            raise Refusal(
+                f"A SOW in {sow.state} cannot be assigned.",
+                "Only work that is ready, or that has had changes requested, "
+                "can be handed to an actor. A retry must not silently create a "
+                "second execution that can never run.",
+                "sovereign-agent status",
+                "Wait for the current execution, or request changes first.",
+            )
+
         assignment = Assignment(
             id=new_id("asg"),
             sow_id=sow.id,
@@ -186,9 +200,30 @@ class Organization:
             state=AssignmentState.CREATED,
             created_at=utc_now(),
         )
-        with self.db.transaction():
-            self.db.put("sows", sow.id, sow.model_dump(mode="json"))
-            self.db.put("assignments", assignment.id, assignment.model_dump(mode="json"))
+        # The state check, the transition and the insert share one immediate
+        # transaction, so two connections cannot both pass the check.
+        with self.db.immediate() as connection:
+            current = json.loads(
+                connection.execute("SELECT record FROM sows WHERE id = ?", (sow.id,)).fetchone()[
+                    "record"
+                ]
+            )["state"]
+            if current not in {SowState.READY.value, SowState.CHANGES_REQUESTED.value}:
+                raise Refusal(
+                    f"A SOW in {current} cannot be assigned.",
+                    "Another connection claimed this SOW first.",
+                    "sovereign-agent status",
+                    "Wait for the current execution.",
+                )
+            sow.state = advance_sow(SowState(current), SowState.ASSIGNED)
+            connection.execute(
+                "INSERT OR REPLACE INTO sows(id, outcome_id, record) VALUES (?, ?, ?)",
+                (sow.id, sow.outcome_id, sow.model_dump_json()),
+            )
+            connection.execute(
+                "INSERT INTO assignments(id, sow_id, actor_id, record) VALUES (?, ?, ?, ?)",
+                (assignment.id, sow.id, actor_id, assignment.model_dump_json()),
+            )
             append_event(self.db, "assignment.created", {"id": assignment.id, "actor_id": actor_id})
         self._project_outcome(sow.outcome_id)
         return assignment
@@ -456,15 +491,36 @@ class Organization:
         return Verification.model_validate_json(row["record"]) if row else None
 
     def _latest_assignment_id(self, outcome_id: str) -> str:
-        """The execution evidence is bound to. Empty when no work has run yet."""
+        """The most recent COMPLETED execution for this outcome.
+
+        "Newest row" was never a proof rule, it was an ordering accident: a
+        second `assign()` created a row that could not run and it immediately
+        became the identity everything bound to. Only completed executions can
+        carry evidence, so only they are eligible.
+        """
         sow_ids = {sow.id for sow in self.sows_for(outcome_id)}
         rows = self.db.connection.execute(
-            "SELECT id, sow_id FROM assignments ORDER BY rowid DESC"
+            "SELECT id, sow_id, record FROM assignments ORDER BY rowid DESC"
         ).fetchall()
         for row in rows:
-            if row["sow_id"] in sow_ids:
+            if row["sow_id"] not in sow_ids:
+                continue
+            if json.loads(row["record"]).get("state") == AssignmentState.COMPLETED.value:
                 return str(row["id"])
         return ""
+
+    def contributing_executions(self, outcome_id: str) -> set[str]:
+        """Executions that actually changed the world for this outcome.
+
+        Read from the structured `effects` edge, not inferred from world state.
+        An outcome's condition can hold because of work done last week; this
+        answers the different question of what THIS execution did.
+        """
+        rows = self.db.connection.execute(
+            "SELECT DISTINCT assignment_id FROM effects WHERE outcome_id = ?",
+            (outcome_id,),
+        ).fetchall()
+        return {str(row["assignment_id"]) for row in rows}
 
     def performers_for(self, outcome_id: str) -> set[str]:
         """Who actually did the work, DERIVED FROM THE LEDGER.
@@ -606,6 +662,25 @@ class Organization:
         # The work must have SUCCEEDED. Acceptance previously never looked at
         # receipts, so an outcome whose only receipt said "failed" still accepted.
         self._trusted_receipt(execution_id)
+
+        # The bound execution must have CONTRIBUTED. Ruling
+        # 2026-08-26-outcomes-are-conditions-sows-are-work: an outcome is a
+        # standing condition and a SOW is a unit of work, so acceptance asserts
+        # both that the condition holds now AND that this execution produced an
+        # effect. Without this, an assignment that did nothing inherits credit
+        # for a restock done last week, because the checks find replenishments
+        # by SKU and the world is still in the state the earlier work left it.
+        contributors = self.contributing_executions(outcome_id)
+        if contributors and execution_id not in contributors:
+            raise Refusal(
+                f"Execution {execution_id} produced no effect for this outcome.",
+                "The condition may well hold, but it holds because of other "
+                "work. Accepting here would credit this execution with a change "
+                "it did not make.",
+                "sovereign-agent status",
+                "Do the work this outcome requires, or accept the outcome that "
+                "the effect actually belongs to.",
+            )
 
         # Acceptance rests on ONE verification batch, and the review must be of
         # that exact batch. Previously acceptance used whatever evidence existed

--- a/src/sovereign_agent/providers/scripted.py
+++ b/src/sovereign_agent/providers/scripted.py
@@ -56,7 +56,11 @@ def write_scripted_report(output: Path, prompt: str) -> ActorReport:
     report = ActorReport(
         status="completed" if "fail" not in scope.lower() else "failed",
         changed_artifacts=["inventory.md"],
-        proposed_checks=["inventory_non_negative", "cash_reconciles"],
+        # A PROPOSAL, not an instruction. validate_restock re-checks every part
+        # of it against the ledger, and reads the unit cost from the product
+        # record rather than from anything written here.
+        proposed_restock_units=6,
+        proposed_checks=["inventory_at_or_above_reorder_point", "cash_reconciles"],
         questions=[],
         notes="scripted fixture",
     )

--- a/src/sovereign_agent/relay.py
+++ b/src/sovereign_agent/relay.py
@@ -52,6 +52,13 @@ def inbox(db: Database, actor_id: str) -> list[Message]:
 
 
 def claim(db: Database, message_id: str, actor_id: str) -> Message:
+    """Take an exclusive lease, or refuse. Compare-and-set, not read-then-write.
+
+    The claim is a single `UPDATE ... WHERE state = 'NEW'` that must affect
+    exactly one row. An earlier version read the message, decided in Python, and
+    wrote it back: two connections both read NEW, both wrote, and both believed
+    they owned the lease.
+    """
     raw = db.get("messages", "id", message_id)
     if raw is None:
         raise Refusal(
@@ -70,20 +77,37 @@ def claim(db: Database, message_id: str, actor_id: str) -> Message:
         )
     if message.state == MessageState.CLAIMED and message.claim_owner == actor_id:
         return message
-    if message.state != MessageState.NEW:
-        raise Refusal(
-            "Message is not claimable.",
-            "Claims are exclusive.",
-            "sovereign-agent inbox",
-            "Wait for lease expiry.",
+
+    now = utc_now()
+    expires_at = now + LEASE
+    with db.immediate() as connection:
+        # One statement decides the winner. Either this row was NEW (or its lease
+        # had expired) at the moment of the UPDATE, or it was not.
+        cursor = connection.execute(
+            "UPDATE messages SET state = 'CLAIMED', claim_owner = ?, claim_expires_at = ?, "
+            "record = json_set(json_set(json_set(record, '$.state', 'CLAIMED'), "
+            "'$.claim_owner', ?), '$.claim_expires_at', ?) "
+            "WHERE id = ? AND (state = 'NEW' OR (state = 'CLAIMED' AND claim_expires_at <= ?))",
+            (
+                actor_id,
+                expires_at.isoformat(),
+                actor_id,
+                expires_at.isoformat(),
+                message_id,
+                now.isoformat(),
+            ),
         )
-    message.state = MessageState.CLAIMED
-    message.claim_owner = actor_id
-    message.claim_expires_at = utc_now() + LEASE
-    with db.transaction():
-        db.put("messages", message.id, message.model_dump(mode="json"))
-        append_event(db, "message.claimed", {"id": message.id, "actor_id": actor_id})
-    return message
+        if cursor.rowcount != 1:
+            raise Refusal(
+                "Message is not claimable.",
+                "Claims are exclusive: another actor holds an unexpired lease.",
+                "sovereign-agent inbox",
+                "Wait for lease expiry.",
+            )
+        append_event(db, "message.claimed", {"id": message_id, "actor_id": actor_id})
+
+    claimed = Message.model_validate(db.get("messages", "id", message_id))
+    return claimed
 
 
 def complete(db: Database, message_id: str, actor_id: str) -> Message:

--- a/src/sovereign_agent/relay.py
+++ b/src/sovereign_agent/relay.py
@@ -103,11 +103,22 @@ def complete(db: Database, message_id: str, actor_id: str) -> Message:
 
 
 def dead_letter(db: Database, message: Message) -> Message:
+    """Retry a failed delivery, or park it as DEAD after MAX_RETRIES.
+
+    The write is inside a transaction and appends an event, like every other
+    state change. It previously wrote outside one, so a crash mid-call could
+    leave a message with no record of why it moved.
+    """
     if message.retry_count < MAX_RETRIES:
         message.retry_count += 1
         message.state = MessageState.NEW
         message.claim_owner = None
+        message.claim_expires_at = None
+        kind = "message.retried"
     else:
         message.state = MessageState.DEAD
-    db.put("messages", message.id, message.model_dump(mode="json"))
+        kind = "message.dead_lettered"
+    with db.transaction():
+        db.put("messages", message.id, message.model_dump(mode="json"))
+        append_event(db, kind, {"id": message.id, "retry_count": message.retry_count})
     return message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest fixtures shared across the suite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .helpers import governed_assignment
+
+
+@pytest.fixture
+def governed(tmp_path: Path):
+    """A seeded store with one completed, authorized assignment."""
+    return governed_assignment(tmp_path)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,46 @@
+"""Shared helpers for building a governed organization in tests.
+
+Effects now require a real, completed, authorized assignment, so tests can no
+longer invent an `assignment_id` string. That is the point of the fix: a test
+that could fabricate authority was testing a system that let anyone fabricate it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from reference_organizations.store import seed
+from sovereign_agent.models import Role
+from sovereign_agent.organization import Organization
+
+STORE_CHECKS = [
+    "inventory_at_or_above_reorder_point",
+    "cash_reconciles",
+    "replenishment_event_exists",
+]
+
+
+def governed_assignment(
+    root: Path, subject: str = "SKU-TEA", checks: list[str] | None = None
+) -> tuple[Organization, str, str, str]:
+    """Seed a store and run one assignment to completion.
+
+    Returns (organization, outcome_id, sow_id, assignment_id) where the
+    assignment genuinely completed and carries a successful receipt — the only
+    kind that can authorize an effect.
+    """
+    org = Organization.init(root)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "Keep the tea jar stocked",
+        "On-hand tea stays at or above the reorder point.",
+        checks if checks is not None else STORE_CHECKS,
+        "principal-human",
+        subject,
+    )
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    assignment = org.assign(sow.id, "operator-course", "master-course")
+    assignment = org.run_assignment(assignment.id)
+    return org, outcome.id, sow.id, assignment.id

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -39,7 +39,7 @@ def governed_assignment(
         subject,
     )
     org.activate(outcome.id, "master-course")
-    sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
+    sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course", "replenishment")
     org.ready_sow(sow.id)
     assignment = org.assign(sow.id, "operator-course", "master-course")
     assignment = org.run_assignment(assignment.id)

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -42,7 +42,7 @@ def test_refuses_when_inventory_is_below_reorder_point(tmp_path: Path) -> None:
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="failing at acceptance time"):
-        org.accept(outcome_id, "principal-human", "SKU-TEA")
+        org.accept(outcome_id, "principal-human")
 
 
 def test_refuses_when_evidence_reports_failure(tmp_path: Path) -> None:
@@ -51,7 +51,7 @@ def test_refuses_when_evidence_reports_failure(tmp_path: Path) -> None:
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="reports failure"):
-        org.accept(outcome_id, "principal-human", "SKU-TEA")
+        org.accept(outcome_id, "principal-human")
 
 
 def test_refuses_when_a_required_check_has_no_evidence(tmp_path: Path) -> None:
@@ -60,7 +60,7 @@ def test_refuses_when_a_required_check_has_no_evidence(tmp_path: Path) -> None:
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="No evidence for declared check"):
-        org.accept(outcome_id, "principal-human", "SKU-TEA")
+        org.accept(outcome_id, "principal-human")
 
 
 def test_refuses_stale_evidence_even_when_checks_still_pass(tmp_path: Path) -> None:
@@ -75,7 +75,7 @@ def test_refuses_stale_evidence_even_when_checks_still_pass(tmp_path: Path) -> N
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="stale"):
-        org.accept(outcome_id, "principal-human", "SKU-TEA")
+        org.accept(outcome_id, "principal-human")
 
 
 def test_refuses_evidence_bound_to_another_execution(tmp_path: Path) -> None:
@@ -84,7 +84,7 @@ def test_refuses_evidence_bound_to_another_execution(tmp_path: Path) -> None:
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="not bound to this execution"):
-        org.accept(outcome_id, "principal-human", "SKU-TEA")
+        org.accept(outcome_id, "principal-human")
 
 
 def test_refuses_evidence_belonging_to_another_outcome(tmp_path: Path) -> None:
@@ -96,7 +96,7 @@ def test_refuses_evidence_belonging_to_another_outcome(tmp_path: Path) -> None:
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="No evidence for declared check"):
-        org.accept(outcome_id, "principal-human", "SKU-TEA")
+        org.accept(outcome_id, "principal-human")
 
 
 def test_fabricated_evidence_row_is_refused_by_the_database(tmp_path: Path) -> None:
@@ -115,7 +115,7 @@ def test_operator_cannot_accept_its_own_work(tmp_path: Path) -> None:
     org, outcome_id = accepted_org(tmp_path)
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal):
-        org.accept(outcome_id, "operator-course", "SKU-TEA")
+        org.accept(outcome_id, "operator-course")
 
 
 def test_performer_is_derived_from_the_ledger_not_supplied(tmp_path: Path) -> None:
@@ -133,7 +133,7 @@ def test_refuses_an_outcome_with_no_sows(tmp_path: Path) -> None:
     outcome = org.create_outcome("t", "d", ["cash_reconciles"], "principal-human")
     org.activate(outcome.id, "master-course")
     with pytest.raises(Refusal, match="No SOW exists"):
-        org.accept(outcome.id, "principal-human", "SKU-TEA")
+        org.accept(outcome.id, "principal-human")
 
 
 def test_malformed_provider_report_is_refused(tmp_path: Path) -> None:
@@ -186,3 +186,44 @@ def test_replenishment_is_idempotent_per_assignment(tmp_path: Path) -> None:
         "SELECT COUNT(*) AS c FROM events WHERE kind = 'replenishment.committed'"
     ).fetchone()
     assert row["c"] == 1, "a replayed assignment must not order stock twice"
+
+
+def test_acceptance_cannot_be_pointed_at_a_different_subject(tmp_path: Path) -> None:
+    """The outcome owns its subject; the caller does not get to choose it.
+
+    Found by the Master while attacking its own fix. An earlier version took the
+    SKU as a parameter to verify/accept. With a second, well-stocked product in
+    the catalogue you could accept the tea outcome by pointing acceptance at the
+    decoy while the tea shelf sat at zero — the same defect this unit exists to
+    fix, reintroduced one level up.
+    """
+    import json
+
+    org, outcome_id = accepted_org(tmp_path)
+
+    org.db.connection.execute(
+        "INSERT OR REPLACE INTO products(sku, record) VALUES ('SKU-DECOY', ?)",
+        (json.dumps({"sku": "SKU-DECOY", "name": "d", "unit_cost_cents": 1, "price_cents": 2}),),
+    )
+    org.db.connection.execute(
+        "INSERT OR REPLACE INTO inventory(sku, on_hand, reserved, reorder_point, record) "
+        "VALUES ('SKU-DECOY', 1, 0, 1, '{}')"
+    )
+    org.db.connection.commit()
+    apply_restock(org.db, RestockProposal("SKU-DECOY", 5), "asg_decoy")
+
+    org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+
+    assert org._outcome(outcome_id).subject == "SKU-TEA"  # noqa: SLF001
+    with pytest.raises(Refusal, match="inventory_at_or_above_reorder_point"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_verify_and_accept_take_no_subject_argument() -> None:
+    """A caller-supplied subject is a caller-supplied world. Keep it out."""
+    import inspect
+
+    for method in (Organization.verify_outcome, Organization.accept):
+        assert "subject" not in inspect.signature(method).parameters

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -18,6 +18,8 @@ from reference_organizations.store.demo import propose_restock_from_report, run_
 from sovereign_agent.errors import Refusal
 from sovereign_agent.organization import Organization
 
+from .helpers import governed_assignment
+
 
 def accepted_org(tmp_path: Path) -> tuple[Organization, str]:
     """A truthfully accepted store, then reopened for tampering."""
@@ -59,7 +61,9 @@ def test_refuses_when_a_required_check_has_no_evidence(tmp_path: Path) -> None:
     org.db.connection.execute("DELETE FROM evidence WHERE check_id = 'cash_reconciles'")
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
-    with pytest.raises(Refusal, match="No evidence for declared check"):
+    # Now caught earlier and more precisely: the batch the reviewer signed off
+    # is no longer the batch supporting acceptance.
+    with pytest.raises(Refusal, match="not the evidence supporting acceptance"):
         org.accept(outcome_id, "principal-human")
 
 
@@ -95,7 +99,7 @@ def test_refuses_evidence_belonging_to_another_outcome(tmp_path: Path) -> None:
     )
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
-    with pytest.raises(Refusal, match="No evidence for declared check"):
+    with pytest.raises(Refusal, match="not the evidence supporting acceptance"):
         org.accept(outcome_id, "principal-human")
 
 
@@ -156,30 +160,31 @@ def test_non_integer_proposal_is_refused(tmp_path: Path) -> None:
 
 
 def test_unbounded_or_invalid_restock_is_refused(tmp_path: Path) -> None:
-    org = Organization.init(tmp_path)
-    seed(org.db)
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path)
     for quantity, expected in [(0, "not positive"), (-5, "not positive"), (999, "exceeds")]:
         with pytest.raises(Refusal, match=expected):
-            apply_restock(org.db, RestockProposal("SKU-TEA", quantity), "asg_x")
-    with pytest.raises(Refusal, match="Unknown SKU"):
-        apply_restock(org.db, RestockProposal("SKU-GHOST", 1), "asg_x")
+            apply_restock(org.db, RestockProposal("SKU-TEA", quantity), assignment_id)
+    # A SKU the outcome is not about is refused by the subject gate before the
+    # catalog is even consulted -- an earlier and stronger refusal than
+    # "Unknown SKU", because the effect is unauthorized regardless of whether
+    # the product exists.
+    with pytest.raises(Refusal, match="but the outcome is about SKU-TEA"):
+        apply_restock(org.db, RestockProposal("SKU-GHOST", 1), assignment_id)
 
 
 def test_restock_beyond_available_cash_is_refused(tmp_path: Path) -> None:
-    org = Organization.init(tmp_path)
-    seed(org.db)
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path)
     org.db.connection.execute("DELETE FROM cash_entries")
     org.db.connection.commit()
     with pytest.raises(Refusal, match="cash is available"):
-        apply_restock(org.db, RestockProposal("SKU-TEA", 10), "asg_x")
+        apply_restock(org.db, RestockProposal("SKU-TEA", 10), assignment_id)
 
 
 def test_replenishment_is_idempotent_per_assignment(tmp_path: Path) -> None:
-    org = Organization.init(tmp_path)
-    seed(org.db)
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path)
     signal = record_sale(org.db, "SKU-TEA", 2, 400)
-    first = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_once", signal.id)
-    second = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_once", signal.id)
+    first = apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
+    second = apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
     assert second.get("idempotent_replay") is True
     assert first["on_hand"] == second["on_hand"]
     row = org.db.connection.execute(
@@ -210,7 +215,6 @@ def test_acceptance_cannot_be_pointed_at_a_different_subject(tmp_path: Path) -> 
         "VALUES ('SKU-DECOY', 1, 0, 1, '{}')"
     )
     org.db.connection.commit()
-    apply_restock(org.db, RestockProposal("SKU-DECOY", 5), "asg_decoy")
 
     org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
     org.db.connection.commit()
@@ -251,6 +255,48 @@ def test_refuses_when_the_execution_receipt_failed(tmp_path: Path) -> None:
     org.db.connection.execute("UPDATE receipts SET status = 'failed'")
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
+    # Editing the column alone is caught as a disagreement between the two
+    # representations, before the status is even consulted.
+    with pytest.raises(Refusal, match="its index says failed"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_refuses_a_receipt_whose_record_says_failed(tmp_path: Path) -> None:
+    """Editing the canonical record alone must also be refused.
+
+    Acceptance previously read only the indexed column, so a record saying
+    "failed" still accepted while the external verifier called the same state
+    unverifiable: an accepted state already known to be false by another tool.
+    """
+    import json
+
+    org, outcome_id = accepted_org(tmp_path)
+    row = org.db.connection.execute("SELECT id, record FROM receipts").fetchone()
+    record = json.loads(row["record"])
+    record["status"] = "failed"
+    org.db.connection.execute(
+        "UPDATE receipts SET record = ? WHERE id = ?", (json.dumps(record), row["id"])
+    )
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="says failed, its index says completed"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_refuses_a_receipt_that_agrees_on_failure(tmp_path: Path) -> None:
+    """Both representations saying "failed" is refused on the merits."""
+    import json
+
+    org, outcome_id = accepted_org(tmp_path)
+    row = org.db.connection.execute("SELECT id, record FROM receipts").fetchone()
+    record = json.loads(row["record"])
+    record["status"] = "failed"
+    org.db.connection.execute(
+        "UPDATE receipts SET record = ?, status = 'failed' WHERE id = ?",
+        (json.dumps(record), row["id"]),
+    )
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="receipt reports status failed"):
         org.accept(outcome_id, "principal-human")
 
@@ -279,14 +325,24 @@ def test_refuses_when_the_review_requested_changes(tmp_path: Path) -> None:
     org.db.connection.execute("UPDATE reviews SET decision = 'changes_requested'")
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
-    with pytest.raises(Refusal, match="decided changes_requested"):
+    with pytest.raises(Refusal, match="disagrees with its index on decision"):
         org.accept(outcome_id, "principal-human")
 
 
 def test_the_reviewer_cannot_also_accept(tmp_path: Path) -> None:
     """Review and acceptance are separate acts by separate actors."""
+    import json
+
     org, outcome_id = accepted_org(tmp_path)
-    org.db.connection.execute("UPDATE reviews SET reviewer_actor_id = 'principal-human'")
+    # Edit BOTH representations so they agree; otherwise the disagreement check
+    # fires first and this stops testing separation.
+    row = org.db.connection.execute("SELECT id, record FROM reviews").fetchone()
+    record = json.loads(row["record"])
+    record["reviewer_actor_id"] = "principal-human"
+    org.db.connection.execute(
+        "UPDATE reviews SET reviewer_actor_id = 'principal-human', record = ? WHERE id = ?",
+        (json.dumps(record), row["id"]),
+    )
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="reviewed this work and cannot also accept"):
@@ -381,6 +437,14 @@ def test_retargeting_the_subject_alone_is_refused(tmp_path: Path) -> None:
 
 
 def _seed_decoy(org: Organization) -> str:
+    """Stock a decoy product directly.
+
+    Effects are now bound to an assignment whose outcome names a matching
+    subject, so a decoy restock cannot be applied through `apply_restock` under
+    a tea outcome -- which is the protection being demonstrated elsewhere. Here
+    the decoy stock is written directly, because the point of these tests is
+    what ACCEPTANCE does about a retargeted subject, not how the stock arrived.
+    """
     import json
 
     org.db.connection.execute(
@@ -389,13 +453,42 @@ def _seed_decoy(org: Organization) -> str:
     )
     org.db.connection.execute(
         "INSERT OR REPLACE INTO inventory(sku, on_hand, reserved, reorder_point, record) "
-        "VALUES ('SKU-DECOY', 1, 0, 1, '{}')"
+        "VALUES ('SKU-DECOY', 9, 0, 1, '{}')"
     )
-    org.db.connection.commit()
     assignment_id = str(
         org.db.connection.execute("SELECT id FROM assignments LIMIT 1").fetchone()["id"]
     )
-    apply_restock(org.db, RestockProposal("SKU-DECOY", 5), assignment_id)
+    payload = json.dumps(
+        {
+            "sku": "SKU-DECOY",
+            "qty": 5,
+            "unit_cost_cents": 1,
+            "total_cost_cents": 5,
+            "on_hand": 9,
+            "cash_id": "cash_decoy",
+            "assignment_id": assignment_id,
+        }
+    )
+    org.db.connection.execute(
+        "INSERT INTO cash_entries(id, amount_cents, record) VALUES ('cash_decoy', -5, ?)",
+        (
+            json.dumps(
+                {
+                    "reason": "purchase",
+                    "sku": "SKU-DECOY",
+                    "qty": 5,
+                    "unit_cost_cents": 1,
+                    "assignment_id": assignment_id,
+                }
+            ),
+        ),
+    )
+    org.db.connection.execute(
+        "INSERT INTO events(id, kind, payload, created_at) "
+        "VALUES ('evt_decoy', 'replenishment.committed', ?, '2026-01-01T00:00:00Z')",
+        (payload,),
+    )
+    org.db.connection.commit()
     return assignment_id
 
 
@@ -422,8 +515,10 @@ def test_the_documented_residual_limit_is_real(tmp_path: Path) -> None:
     check's own reads can detect the QUESTION changing underneath it. Closing it
     needs tamper-evident governance rows, which is out of scope for Unit 6.5.
 
-    If this test ever fails, the limit was closed and the documentation must be
-    re-derived rather than left describing a threat that no longer exists.
+    If the limit is ever closed, `accept()` raises and this test ERRORS rather
+    than failing its assert — the guard fires either way, and either outcome
+    means the documentation must be re-derived rather than left describing a
+    threat that no longer exists. (Precision noted by Sparring.)
     """
     org, outcome_id = accepted_org(tmp_path)
     _seed_decoy(org)
@@ -436,6 +531,12 @@ def test_the_documented_residual_limit_is_real(tmp_path: Path) -> None:
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     org.verify_outcome(outcome_id, "verifier-course")
+    sow_id = org.sows_for(outcome_id)[0].id
+    org.db.connection.execute(
+        "UPDATE sows SET record = json_set(record, '$.state', 'REVIEW') WHERE id = ?", (sow_id,)
+    )
+    org.db.connection.commit()
+    org.review(sow_id, "sparring-course")
     org.accept(outcome_id, "principal-human")
 
     row = org.db.connection.execute(
@@ -445,3 +546,65 @@ def test_the_documented_residual_limit_is_real(tmp_path: Path) -> None:
         "the residual limit documented in docs/persistence-boundary.md no longer "
         "reproduces; re-derive the document against current behaviour"
     )
+
+
+def test_an_effect_cannot_name_a_fabricated_assignment(tmp_path: Path) -> None:
+    """The completed assignment must be the one that caused the effect.
+
+    Reported on PR #24 round 2: `apply_restock` took any string as its
+    assignment_id, so the ledger could show that SOME assignment completed and
+    that SOME replenishment happened while nothing tied them together. Two true
+    facts arranged so their conjunction implies something false.
+    """
+    org, _outcome_id, _sow_id, _assignment_id = governed_assignment(tmp_path)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    with pytest.raises(Refusal, match="not in the ledger"):
+        apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_FAKE", signal.id)
+
+
+def test_an_effect_requires_a_completed_assignment(tmp_path: Path) -> None:
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path)
+    org.db.connection.execute(
+        "UPDATE assignments SET record = json_set(record, '$.state', 'RUNNING') WHERE id = ?",
+        (assignment_id,),
+    )
+    org.db.connection.commit()
+    with pytest.raises(Refusal, match="not COMPLETED"):
+        apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id)
+
+
+def test_an_effect_requires_a_successful_receipt(tmp_path: Path) -> None:
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path)
+    org.db.connection.execute("UPDATE receipts SET status = 'failed'")
+    org.db.connection.commit()
+    with pytest.raises(Refusal, match="receipt for"):
+        apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id)
+
+
+def test_an_effect_must_move_the_outcomes_subject(tmp_path: Path) -> None:
+    """An effect on another product does not deliver this outcome."""
+    import json
+
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path)
+    org.db.connection.execute(
+        "INSERT OR REPLACE INTO products(sku, record) VALUES ('SKU-B', ?)",
+        (json.dumps({"sku": "SKU-B", "name": "b", "unit_cost_cents": 10, "price_cents": 20}),),
+    )
+    org.db.connection.execute(
+        "INSERT OR REPLACE INTO inventory(sku, on_hand, reserved, reorder_point, record) "
+        "VALUES ('SKU-B', 0, 0, 1, '{}')"
+    )
+    org.db.connection.commit()
+    with pytest.raises(Refusal, match="but the outcome is about SKU-TEA"):
+        apply_restock(org.db, RestockProposal("SKU-B", 3), assignment_id)
+
+
+def test_an_effect_requires_an_actor_with_authority(tmp_path: Path) -> None:
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path)
+    org.db.connection.execute(
+        "UPDATE actors SET record = json_set(record, '$.authority', json('[\"read\"]')) "
+        "WHERE id = 'operator-course'"
+    )
+    org.db.connection.commit()
+    with pytest.raises(Refusal, match="lacks authority"):
+        apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id)

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -357,3 +357,91 @@ def test_reserved_stock_is_not_available_stock(tmp_path: Path) -> None:
     result = run_check(org.db, "inventory_at_or_above_reorder_point", "SKU-TEA")
     assert not result.success, "8 reserved out of 8 on hand leaves nothing available"
     assert result.observed["available"] == 0
+
+
+def test_retargeting_the_subject_alone_is_refused(tmp_path: Path) -> None:
+    """Documented limit, claim A. Kept as a test so the doc cannot drift.
+
+    docs/persistence-boundary.md described a subject-retargeting attack that the
+    code had already started refusing, and the description survived as
+    present-tense doctrine for two Sparring rounds because nobody re-ran it.
+    A threat model that cries wolf teaches the next reader to discount it, so
+    each documented claim is pinned by a test.
+    """
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
+    org.db.connection.execute(
+        "UPDATE outcomes SET record = json_set(record, '$.subject', 'SKU-DECOY') WHERE id = ?",
+        (outcome_id,),
+    )
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="Checks failing at acceptance time"):
+        org.accept(outcome_id, "principal-human")
+
+
+def _seed_decoy(org: Organization) -> str:
+    import json
+
+    org.db.connection.execute(
+        "INSERT OR REPLACE INTO products(sku, record) VALUES ('SKU-DECOY', ?)",
+        (json.dumps({"sku": "SKU-DECOY", "name": "d", "unit_cost_cents": 1, "price_cents": 2}),),
+    )
+    org.db.connection.execute(
+        "INSERT OR REPLACE INTO inventory(sku, on_hand, reserved, reorder_point, record) "
+        "VALUES ('SKU-DECOY', 1, 0, 1, '{}')"
+    )
+    org.db.connection.commit()
+    assignment_id = str(
+        org.db.connection.execute("SELECT id FROM assignments LIMIT 1").fetchone()["id"]
+    )
+    apply_restock(org.db, RestockProposal("SKU-DECOY", 5), assignment_id)
+    return assignment_id
+
+
+def test_evidence_about_one_subject_is_not_evidence_about_another(tmp_path: Path) -> None:
+    """Documented limit, claim B: a stocked decoy still cannot reuse tea's evidence."""
+    org, outcome_id = accepted_org(tmp_path)
+    _seed_decoy(org)
+    org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
+    org.db.connection.execute(
+        "UPDATE outcomes SET record = json_set(record, '$.subject', 'SKU-DECOY') WHERE id = ?",
+        (outcome_id,),
+    )
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="stale"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_the_documented_residual_limit_is_real(tmp_path: Path) -> None:
+    """Documented limit, claim C — asserts the limit EXISTS, not that it is safe.
+
+    Retarget plus re-verification produces internally consistent evidence and
+    accepts, while the real subject sits below its reorder point. No digest of a
+    check's own reads can detect the QUESTION changing underneath it. Closing it
+    needs tamper-evident governance rows, which is out of scope for Unit 6.5.
+
+    If this test ever fails, the limit was closed and the documentation must be
+    re-derived rather than left describing a threat that no longer exists.
+    """
+    org, outcome_id = accepted_org(tmp_path)
+    _seed_decoy(org)
+    org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
+    org.db.connection.execute(
+        "UPDATE outcomes SET record = json_set(record, '$.subject', 'SKU-DECOY') WHERE id = ?",
+        (outcome_id,),
+    )
+    org.db.connection.execute("DELETE FROM evidence WHERE outcome_id = ?", (outcome_id,))
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.accept(outcome_id, "principal-human")
+
+    row = org.db.connection.execute(
+        "SELECT on_hand, reorder_point FROM inventory WHERE sku = 'SKU-TEA'"
+    ).fetchone()
+    assert int(row["on_hand"]) < int(row["reorder_point"]), (
+        "the residual limit documented in docs/persistence-boundary.md no longer "
+        "reproduces; re-derive the document against current behaviour"
+    )

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -1,0 +1,188 @@
+"""Acceptance must REFUSE a false claim.
+
+Every test here is a way of lying to the organization. Each one must fail to
+work. A test suite that only demonstrates the happy path cannot tell you whether
+`ACCEPTED` means anything — the defect this unit exists to fix passed 59 such
+tests.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from reference_organizations.store.demo import propose_restock_from_report, run_simulated
+from sovereign_agent.errors import Refusal
+from sovereign_agent.organization import Organization
+
+
+def accepted_org(tmp_path: Path) -> tuple[Organization, str]:
+    """A truthfully accepted store, then reopened for tampering."""
+    run_simulated(tmp_path)
+    org = Organization(tmp_path)
+    outcome_id = str(org.db.connection.execute("SELECT id FROM outcomes").fetchone()["id"])
+    return org, outcome_id
+
+
+def reopen_for_acceptance(org: Organization, outcome_id: str) -> None:
+    """Put the outcome back into VERIFYING so accept() can be re-attempted."""
+    org.db.connection.execute(
+        "UPDATE outcomes SET record = json_set(record, '$.state', 'VERIFYING') WHERE id = ?",
+        (outcome_id,),
+    )
+    org.db.connection.commit()
+
+
+def test_refuses_when_inventory_is_below_reorder_point(tmp_path: Path) -> None:
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE inventory SET on_hand = 1 WHERE sku = 'SKU-TEA'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="failing at acceptance time"):
+        org.accept(outcome_id, "principal-human", "SKU-TEA")
+
+
+def test_refuses_when_evidence_reports_failure(tmp_path: Path) -> None:
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE evidence SET success = 0")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="reports failure"):
+        org.accept(outcome_id, "principal-human", "SKU-TEA")
+
+
+def test_refuses_when_a_required_check_has_no_evidence(tmp_path: Path) -> None:
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("DELETE FROM evidence WHERE check_id = 'cash_reconciles'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="No evidence for declared check"):
+        org.accept(outcome_id, "principal-human", "SKU-TEA")
+
+
+def test_refuses_stale_evidence_even_when_checks_still_pass(tmp_path: Path) -> None:
+    """The subtle one: state moved AFTER verification, but the claim is still true.
+
+    Inventory goes UP, so every check still passes. The evidence nevertheless
+    describes a world that no longer exists, and acceptance says so. An event
+    counter could not detect this, because a plain UPDATE appends no event.
+    """
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE inventory SET on_hand = 20 WHERE sku = 'SKU-TEA'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="stale"):
+        org.accept(outcome_id, "principal-human", "SKU-TEA")
+
+
+def test_refuses_evidence_bound_to_another_execution(tmp_path: Path) -> None:
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE evidence SET assignment_id = 'asg_SOME_OTHER_RUN'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="not bound to this execution"):
+        org.accept(outcome_id, "principal-human", "SKU-TEA")
+
+
+def test_refuses_evidence_belonging_to_another_outcome(tmp_path: Path) -> None:
+    org, outcome_id = accepted_org(tmp_path)
+    other = org.create_outcome("other", "d", ["cash_reconciles"], "principal-human")
+    org.db.connection.execute(
+        "UPDATE evidence SET outcome_id = ? WHERE check_id = 'cash_reconciles'", (other.id,)
+    )
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="No evidence for declared check"):
+        org.accept(outcome_id, "principal-human", "SKU-TEA")
+
+
+def test_fabricated_evidence_row_is_refused_by_the_database(tmp_path: Path) -> None:
+    """A made-up evidence id cannot even be inserted: the FK refuses it."""
+    org, _ = accepted_org(tmp_path)
+    with pytest.raises(sqlite3.IntegrityError):
+        org.db.connection.execute(
+            "INSERT INTO evidence(id, assignment_id, record, outcome_id, check_id, "
+            "success, state_digest) VALUES "
+            "('evd_fake', 'asg', '{}', 'out_GHOST', 'c', 1, 'd')"
+        )
+        org.db.connection.commit()
+
+
+def test_operator_cannot_accept_its_own_work(tmp_path: Path) -> None:
+    org, outcome_id = accepted_org(tmp_path)
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal):
+        org.accept(outcome_id, "operator-course", "SKU-TEA")
+
+
+def test_performer_is_derived_from_the_ledger_not_supplied(tmp_path: Path) -> None:
+    """accept() takes no performer argument, so no caller can name a stand-in."""
+    import inspect
+
+    signature = inspect.signature(Organization.accept)
+    assert "performer_id" not in signature.parameters
+    org, outcome_id = accepted_org(tmp_path)
+    assert "operator-course" in org.performers_for(outcome_id)
+
+
+def test_refuses_an_outcome_with_no_sows(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    outcome = org.create_outcome("t", "d", ["cash_reconciles"], "principal-human")
+    org.activate(outcome.id, "master-course")
+    with pytest.raises(Refusal, match="No SOW exists"):
+        org.accept(outcome.id, "principal-human", "SKU-TEA")
+
+
+def test_malformed_provider_report_is_refused(tmp_path: Path) -> None:
+    bad = tmp_path / "report.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(Refusal, match="not valid JSON"):
+        propose_restock_from_report(bad, "SKU-TEA")
+
+
+def test_absent_provider_report_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(Refusal, match="wrote no report"):
+        propose_restock_from_report(tmp_path / "missing.json", "SKU-TEA")
+
+
+def test_non_integer_proposal_is_refused(tmp_path: Path) -> None:
+    report = tmp_path / "report.json"
+    report.write_text('{"proposed_restock_units": "lots"}', encoding="utf-8")
+    with pytest.raises(Refusal, match="not a whole number"):
+        propose_restock_from_report(report, "SKU-TEA")
+
+
+def test_unbounded_or_invalid_restock_is_refused(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    for quantity, expected in [(0, "not positive"), (-5, "not positive"), (999, "exceeds")]:
+        with pytest.raises(Refusal, match=expected):
+            apply_restock(org.db, RestockProposal("SKU-TEA", quantity), "asg_x")
+    with pytest.raises(Refusal, match="Unknown SKU"):
+        apply_restock(org.db, RestockProposal("SKU-GHOST", 1), "asg_x")
+
+
+def test_restock_beyond_available_cash_is_refused(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    org.db.connection.execute("DELETE FROM cash_entries")
+    org.db.connection.commit()
+    with pytest.raises(Refusal, match="cash is available"):
+        apply_restock(org.db, RestockProposal("SKU-TEA", 10), "asg_x")
+
+
+def test_replenishment_is_idempotent_per_assignment(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    first = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_once", signal.id)
+    second = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_once", signal.id)
+    assert second.get("idempotent_replay") is True
+    assert first["on_hand"] == second["on_hand"]
+    row = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM events WHERE kind = 'replenishment.committed'"
+    ).fetchone()
+    assert row["c"] == 1, "a replayed assignment must not order stock twice"

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -316,7 +316,7 @@ def test_refuses_when_no_review_record_exists(tmp_path: Path) -> None:
     org.db.connection.execute("DELETE FROM reviews")
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
-    with pytest.raises(Refusal, match="No review record"):
+    with pytest.raises(Refusal, match="no review of its current verification"):
         org.accept(outcome_id, "principal-human")
 
 

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -150,7 +150,7 @@ def test_refuses_evidence_belonging_to_another_outcome(tmp_path: Path) -> None:
         org, "UPDATE evidence SET outcome_id = ? WHERE check_id = 'cash_reconciles'", (other.id,)
     )
     reopen_for_acceptance(org, outcome_id)
-    with pytest.raises(Refusal, match="not the evidence supporting acceptance"):
+    with pytest.raises(Refusal, match="does not match its verification"):
         org.accept(outcome_id, "principal-human")
 
 

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -239,3 +239,121 @@ def test_an_outcome_with_no_subject_fails_closed(tmp_path: Path) -> None:
     assert outcome.subject == ""
     for check_id in ("inventory_at_or_above_reorder_point", "cash_reconciles"):
         assert not run_check(org.db, check_id, "").success
+
+
+def test_refuses_when_the_execution_receipt_failed(tmp_path: Path) -> None:
+    """ACCEPTED must depend on the work having succeeded.
+
+    Reported on PR #24: acceptance never inspected receipts, so setting the only
+    receipt to status="failed" still produced an accepted outcome.
+    """
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE receipts SET status = 'failed'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="receipt reports status failed"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_refuses_a_receipt_belonging_to_another_execution(tmp_path: Path) -> None:
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE receipts SET assignment_id = 'asg_OTHER'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="No receipt for execution"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_refuses_when_no_review_record_exists(tmp_path: Path) -> None:
+    """A status field that once changed is not a review."""
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("DELETE FROM reviews")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="No review record"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_refuses_when_the_review_requested_changes(tmp_path: Path) -> None:
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE reviews SET decision = 'changes_requested'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="decided changes_requested"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_the_reviewer_cannot_also_accept(tmp_path: Path) -> None:
+    """Review and acceptance are separate acts by separate actors."""
+    org, outcome_id = accepted_org(tmp_path)
+    org.db.connection.execute("UPDATE reviews SET reviewer_actor_id = 'principal-human'")
+    org.db.connection.commit()
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="reviewed this work and cannot also accept"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_the_review_record_binds_evidence_and_performers(tmp_path: Path) -> None:
+    """A review must record what was read, not merely that it happened."""
+    import json
+
+    org, outcome_id = accepted_org(tmp_path)
+    row = org.db.connection.execute(
+        "SELECT record FROM reviews WHERE outcome_id = ?", (outcome_id,)
+    ).fetchone()
+    review = json.loads(row["record"])
+    assert review["reviewer_actor_id"] == "sparring-course"
+    assert review["performer_actor_ids"] == ["operator-course"]
+    assert len(review["evidence_refs"]) == 3
+    assert review["decision"] == "accepted"
+    assert review["state_digest"]
+
+
+def test_evidence_is_stale_when_events_change_but_inventory_does_not(tmp_path: Path) -> None:
+    """The digest must cover what each check READS, not a fixed pair of facts.
+
+    Reported on PR #24: the shared digest hashed only the inventory row and the
+    cash total, so appending a replenishment event changed what
+    `cash_reconciles` and `replenishment_event_exists` observed while the digest
+    stayed identical. This appends an EXACT duplicate, so every check still
+    passes -- only the observation changed.
+    """
+    import json
+
+    from sovereign_agent.events import append_event
+
+    org, outcome_id = accepted_org(tmp_path)
+    payload = json.loads(
+        org.db.connection.execute(
+            "SELECT payload FROM events WHERE kind = 'replenishment.committed'"
+        ).fetchone()["payload"]
+    )
+    with org.db.transaction():
+        append_event(org.db, "replenishment.committed", payload)
+
+    from sovereign_agent.checks import run_check
+
+    assert run_check(org.db, "cash_reconciles", "SKU-TEA").success, "precondition: still passes"
+    reopen_for_acceptance(org, outcome_id)
+    with pytest.raises(Refusal, match="stale"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_reserved_stock_is_not_available_stock(tmp_path: Path) -> None:
+    """A fully reserved shelf is an empty shelf.
+
+    Raised by Sparring as latent: the check loaded `reserved`, digested it, and
+    never consulted it. Nothing writes `reserved` today, so it would have become
+    a lie the day reservations landed, in a diff that never touched checks.py.
+    """
+    from sovereign_agent.checks import run_check
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    org.db.connection.execute(
+        "UPDATE inventory SET on_hand = 8, reserved = 8 WHERE sku = 'SKU-TEA'"
+    )
+    org.db.connection.commit()
+    result = run_check(org.db, "inventory_at_or_above_reorder_point", "SKU-TEA")
+    assert not result.success, "8 reserved out of 8 on hand leaves nothing available"
+    assert result.observed["available"] == 0

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -81,11 +81,16 @@ def test_refuses_when_evidence_reports_failure(tmp_path: Path) -> None:
 
 def test_refuses_when_a_required_check_has_no_evidence(tmp_path: Path) -> None:
     org, outcome_id = accepted_org(tmp_path)
-    tamper(org, "DELETE FROM evidence WHERE check_id = 'cash_reconciles'")
+    # Delete from the FINAL observation, which is the batch acceptance rests on.
+    tamper(
+        org,
+        "DELETE FROM evidence WHERE check_id = 'cash_reconciles' AND verification_id = "
+        "(SELECT id FROM verifications WHERE outcome_id = ? AND (sow_id IS NULL OR sow_id = '') "
+        "ORDER BY rowid DESC LIMIT 1)",
+        (outcome_id,),
+    )
     reopen_for_acceptance(org, outcome_id)
-    # Now caught earlier and more precisely: the batch the reviewer signed off
-    # is no longer the batch supporting acceptance.
-    with pytest.raises(Refusal, match="not the evidence supporting acceptance"):
+    with pytest.raises(Refusal, match="No evidence for declared check"):
         org.accept(outcome_id, "principal-human")
 
 
@@ -105,11 +110,37 @@ def test_refuses_stale_evidence_even_when_checks_still_pass(tmp_path: Path) -> N
 
 
 def test_refuses_evidence_bound_to_another_execution(tmp_path: Path) -> None:
+    """A SOW's batch must be bound to that SOW's own execution.
+
+    The outcome-level batch is deliberately unbound — it is the final
+    observation of the world, not a record of one unit of work — so this proves
+    the binding where binding is the point.
+    """
     org, outcome_id = accepted_org(tmp_path)
-    tamper(org, "UPDATE evidence SET assignment_id = 'asg_SOME_OTHER_RUN'")
-    reopen_for_acceptance(org, outcome_id)
-    with pytest.raises(Refusal, match="not bound to this execution"):
-        org.accept(outcome_id, "principal-human")
+    sow_id = org.sows_for(outcome_id)[0].id
+    verification = org.verification_for_sow(sow_id)
+    assert verification is not None and verification.assignment_id
+
+    tamper(
+        org,
+        "UPDATE evidence SET assignment_id = 'asg_SOME_OTHER_RUN' WHERE verification_id = ?",
+        (verification.id,),
+    )
+    # The external truth verifier is the gate that walks each SOW's evidence
+    # against its execution, so that is where the rebinding is caught.
+    import subprocess
+    import sys
+
+    org.db.close()
+    repo_root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, str(repo_root / "scripts" / "verify_store_outcome.py"), str(tmp_path)],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    assert result.returncode == 1
+    assert "bound elsewhere" in result.stdout, result.stdout
 
 
 def test_refuses_evidence_belonging_to_another_outcome(tmp_path: Path) -> None:
@@ -555,6 +586,7 @@ def test_the_documented_residual_limit_is_real(tmp_path: Path) -> None:
     )
     org.db.connection.commit()
     org.review(sow_id, "sparring-course")
+    org.verify_outcome_condition(outcome_id, "verifier-course")
     org.accept(outcome_id, "principal-human")
 
     row = org.db.connection.execute(

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -29,6 +29,30 @@ def accepted_org(tmp_path: Path) -> tuple[Organization, str]:
     return org, outcome_id
 
 
+def tamper(org: Organization, statement: str, parameters: tuple = ()) -> None:
+    """Force a change the append-only guards refuse, to test acceptance itself.
+
+    Proof tables carry BEFORE UPDATE/DELETE/REPLACE triggers, so a tampered
+    ledger is not reachable through the database. These tests still matter:
+    acceptance must be independently sound, not merely shielded. Dropping the
+    guard for one statement is defence-in-depth testing — it asks "if the
+    database were compromised, does acceptance still refuse?"
+    """
+    table = statement.split()[1] if statement.upper().startswith("UPDATE") else statement.split()[2]
+    for guard in ("update", "delete", "replace"):
+        org.db.connection.execute(f"DROP TRIGGER IF EXISTS {table}_no_{guard}")
+    try:
+        org.db.connection.execute(statement, parameters)
+        org.db.connection.commit()
+    finally:
+        from sovereign_agent.database import _append_only_triggers
+
+        for piece in _append_only_triggers(table).split("END;"):
+            if piece.strip():
+                org.db.connection.execute(piece + "END;")
+        org.db.connection.commit()
+
+
 def reopen_for_acceptance(org: Organization, outcome_id: str) -> None:
     """Put the outcome back into VERIFYING so accept() can be re-attempted."""
     org.db.connection.execute(
@@ -49,8 +73,7 @@ def test_refuses_when_inventory_is_below_reorder_point(tmp_path: Path) -> None:
 
 def test_refuses_when_evidence_reports_failure(tmp_path: Path) -> None:
     org, outcome_id = accepted_org(tmp_path)
-    org.db.connection.execute("UPDATE evidence SET success = 0")
-    org.db.connection.commit()
+    tamper(org, "UPDATE evidence SET success = 0")
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="reports failure"):
         org.accept(outcome_id, "principal-human")
@@ -58,8 +81,7 @@ def test_refuses_when_evidence_reports_failure(tmp_path: Path) -> None:
 
 def test_refuses_when_a_required_check_has_no_evidence(tmp_path: Path) -> None:
     org, outcome_id = accepted_org(tmp_path)
-    org.db.connection.execute("DELETE FROM evidence WHERE check_id = 'cash_reconciles'")
-    org.db.connection.commit()
+    tamper(org, "DELETE FROM evidence WHERE check_id = 'cash_reconciles'")
     reopen_for_acceptance(org, outcome_id)
     # Now caught earlier and more precisely: the batch the reviewer signed off
     # is no longer the batch supporting acceptance.
@@ -84,8 +106,7 @@ def test_refuses_stale_evidence_even_when_checks_still_pass(tmp_path: Path) -> N
 
 def test_refuses_evidence_bound_to_another_execution(tmp_path: Path) -> None:
     org, outcome_id = accepted_org(tmp_path)
-    org.db.connection.execute("UPDATE evidence SET assignment_id = 'asg_SOME_OTHER_RUN'")
-    org.db.connection.commit()
+    tamper(org, "UPDATE evidence SET assignment_id = 'asg_SOME_OTHER_RUN'")
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="not bound to this execution"):
         org.accept(outcome_id, "principal-human")
@@ -94,10 +115,9 @@ def test_refuses_evidence_bound_to_another_execution(tmp_path: Path) -> None:
 def test_refuses_evidence_belonging_to_another_outcome(tmp_path: Path) -> None:
     org, outcome_id = accepted_org(tmp_path)
     other = org.create_outcome("other", "d", ["cash_reconciles"], "principal-human")
-    org.db.connection.execute(
-        "UPDATE evidence SET outcome_id = ? WHERE check_id = 'cash_reconciles'", (other.id,)
+    tamper(
+        org, "UPDATE evidence SET outcome_id = ? WHERE check_id = 'cash_reconciles'", (other.id,)
     )
-    org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="not the evidence supporting acceptance"):
         org.accept(outcome_id, "principal-human")
@@ -313,8 +333,7 @@ def test_refuses_a_receipt_belonging_to_another_execution(tmp_path: Path) -> Non
 def test_refuses_when_no_review_record_exists(tmp_path: Path) -> None:
     """A status field that once changed is not a review."""
     org, outcome_id = accepted_org(tmp_path)
-    org.db.connection.execute("DELETE FROM reviews")
-    org.db.connection.commit()
+    tamper(org, "DELETE FROM reviews")
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="no review of its current verification"):
         org.accept(outcome_id, "principal-human")
@@ -322,8 +341,7 @@ def test_refuses_when_no_review_record_exists(tmp_path: Path) -> None:
 
 def test_refuses_when_the_review_requested_changes(tmp_path: Path) -> None:
     org, outcome_id = accepted_org(tmp_path)
-    org.db.connection.execute("UPDATE reviews SET decision = 'changes_requested'")
-    org.db.connection.commit()
+    tamper(org, "UPDATE reviews SET decision = 'changes_requested'")
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="disagrees with its index on decision"):
         org.accept(outcome_id, "principal-human")
@@ -339,11 +357,11 @@ def test_the_reviewer_cannot_also_accept(tmp_path: Path) -> None:
     row = org.db.connection.execute("SELECT id, record FROM reviews").fetchone()
     record = json.loads(row["record"])
     record["reviewer_actor_id"] = "principal-human"
-    org.db.connection.execute(
+    tamper(
+        org,
         "UPDATE reviews SET reviewer_actor_id = 'principal-human', record = ? WHERE id = ?",
         (json.dumps(record), row["id"]),
     )
-    org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     with pytest.raises(Refusal, match="reviewed this work and cannot also accept"):
         org.accept(outcome_id, "principal-human")
@@ -527,7 +545,7 @@ def test_the_documented_residual_limit_is_real(tmp_path: Path) -> None:
         "UPDATE outcomes SET record = json_set(record, '$.subject', 'SKU-DECOY') WHERE id = ?",
         (outcome_id,),
     )
-    org.db.connection.execute("DELETE FROM evidence WHERE outcome_id = ?", (outcome_id,))
+    tamper(org, "DELETE FROM evidence WHERE outcome_id = ?", (outcome_id,))
     org.db.connection.commit()
     reopen_for_acceptance(org, outcome_id)
     org.verify_outcome(outcome_id, "verifier-course")

--- a/tests/test_acceptance_falsification.py
+++ b/tests/test_acceptance_falsification.py
@@ -227,3 +227,15 @@ def test_verify_and_accept_take_no_subject_argument() -> None:
 
     for method in (Organization.verify_outcome, Organization.accept):
         assert "subject" not in inspect.signature(method).parameters
+
+
+def test_an_outcome_with_no_subject_fails_closed(tmp_path: Path) -> None:
+    """A subjectless outcome must not pass; an unanswerable question is not a yes."""
+    from sovereign_agent.checks import run_check
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    outcome = org.create_outcome("no subject", "d", ["cash_reconciles"], "principal-human")
+    assert outcome.subject == ""
+    for check_id in ("inventory_at_or_above_reorder_point", "cash_reconciles"):
+        assert not run_check(org.db, check_id, "").success

--- a/tests/test_actors_and_mailbox.py
+++ b/tests/test_actors_and_mailbox.py
@@ -131,7 +131,7 @@ def test_review_refuses_before_any_evidence_exists(tmp_path: Path) -> None:
     outcome = org.create_outcome("t", "d", ["cash_reconciles"], "principal-human", "SKU-TEA")
     org.activate(outcome.id, "master-course")
     sow = org.create_sow(outcome.id, "scope", Role.OPERATOR, "master-course")
-    with pytest.raises(Refusal, match="No evidence to review"):
+    with pytest.raises(Refusal, match="No verification to review"):
         org.review(sow.id, "sparring-course")
 
 

--- a/tests/test_actors_and_mailbox.py
+++ b/tests/test_actors_and_mailbox.py
@@ -1,0 +1,153 @@
+"""An actor is not a model, and authority is not self-granted.
+
+Unit 4 built these mechanisms; this file proves they behave as claimed. The
+distinction matters most when it is inconvenient: an actor whose provider is
+swapped is still the same governed identity, with the same authority, answerable
+for the same work.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from sovereign_agent.errors import Refusal
+from sovereign_agent.ids import utc_now
+from sovereign_agent.models import MessageState, Role
+from sovereign_agent.organization import Organization
+from sovereign_agent.policy import forbid_self_approval, require_authority
+from sovereign_agent.relay import claim, complete, dead_letter, inbox, send
+
+
+def test_actor_id_is_distinct_from_role_and_provider(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    operator = org.actor("operator-course")
+    assert operator.id == "operator-course"
+    assert operator.role == Role.OPERATOR
+    assert operator.provider == "scripted"
+    # Two different actors can share a role and a provider and remain distinct.
+    assert org.actor("master-course").provider == operator.provider
+    assert org.actor("master-course").id != operator.id
+
+
+def test_rebinding_the_provider_preserves_identity_and_authority(tmp_path: Path) -> None:
+    """Swap the intelligence; the governed actor is unchanged.
+
+    This is the whole point of the actor/provider split. The organization does
+    not care which model does the thinking; it cares who is accountable.
+    """
+    org = Organization.init(tmp_path)
+    before = org.actor("operator-course")
+    identity, role, authority = before.id, before.role, list(before.authority)
+
+    rebound = org.rebind_actor("operator-course", "claude", "principal-human")
+
+    assert rebound.id == identity
+    assert rebound.role == role
+    assert rebound.authority == authority
+    assert rebound.provider == "claude"
+    reloaded = Organization(tmp_path).actor("operator-course")
+    assert reloaded.provider == "claude"
+    assert reloaded.id == identity
+
+
+def test_rebinding_requires_ruling_authority(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    with pytest.raises(Refusal):
+        org.rebind_actor("operator-course", "claude", "operator-course")
+
+
+def test_an_actor_cannot_expand_its_own_authority(tmp_path: Path) -> None:
+    """Authority comes from the role table, not from the actor record.
+
+    Editing the actor's own authority list must not grant the power to accept.
+    """
+    org = Organization.init(tmp_path)
+    operator = org.actor("operator-course")
+    operator.authority.append("accept")
+    with pytest.raises(Refusal, match="Role operator attempted accept"):
+        require_authority(operator.role, "accept")
+
+
+def test_role_separation_covers_operator_reviewer_and_principal(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    assert org.actor("operator-course").role == Role.OPERATOR
+    assert org.actor("sparring-course").role == Role.SPARRING
+    assert org.actor("principal-human").role == Role.PRINCIPAL
+    with pytest.raises(Refusal):
+        require_authority(Role.OPERATOR, "accept")
+    with pytest.raises(Refusal):
+        require_authority(Role.OPERATOR, "review")
+    with pytest.raises(Refusal):
+        require_authority(Role.SPARRING, "accept")
+    require_authority(Role.SPARRING, "review")
+    require_authority(Role.PRINCIPAL, "accept")
+
+
+def test_no_self_approval_is_policy_not_convention() -> None:
+    """The refusal is a pure function, callable without any UI in the way."""
+    with pytest.raises(Refusal, match="No self-approval"):
+        forbid_self_approval("operator-course", "operator-course")
+    forbid_self_approval("operator-course", "sparring-course")
+
+
+def test_reviewer_cannot_review_its_own_work(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    outcome = org.create_outcome("t", "d", ["cash_reconciles"], "principal-human")
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, "scope", Role.OPERATOR, "master-course")
+    with pytest.raises(Refusal, match="No self-approval"):
+        org.review(sow.id, "sparring-course", "sparring-course")
+
+
+def test_claim_lease_is_exclusive(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    message = send(org.db, "master-course", "sparring-course", "hello", "review please")
+    claimed = claim(org.db, message.id, "sparring-course")
+    assert claimed.claim_owner == "sparring-course"
+    assert claimed.claim_expires_at is not None
+    with pytest.raises(Refusal, match="cannot claim"):
+        claim(org.db, message.id, "operator-course")
+
+
+def test_expired_lease_is_reclaimable(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    message = send(org.db, "master-course", "sparring-course", "hello", "body")
+    claimed = claim(org.db, message.id, "sparring-course")
+    claimed.claim_expires_at = utc_now() - timedelta(minutes=1)
+    org.db.put("messages", claimed.id, claimed.model_dump(mode="json"))
+    org.db.connection.commit()
+
+    visible = inbox(org.db, "sparring-course")
+    assert visible and visible[0].state == MessageState.NEW, "expired lease was not reclaimed"
+    assert claim(org.db, message.id, "sparring-course").claim_owner == "sparring-course"
+
+
+def test_only_the_claimant_can_complete(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    message = send(org.db, "master-course", "sparring-course", "s", "b")
+    claim(org.db, message.id, "sparring-course")
+    with pytest.raises(Refusal, match="Only the claimant"):
+        complete(org.db, message.id, "operator-course")
+    assert complete(org.db, message.id, "sparring-course").state == MessageState.DONE
+
+
+def test_retry_then_dead_letter(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    message = send(org.db, "master-course", "sparring-course", "s", "b")
+    for expected in (1, 2, 3):
+        message = dead_letter(org.db, message)
+        assert message.retry_count == expected
+        assert message.state == MessageState.NEW
+    message = dead_letter(org.db, message)
+    assert message.state == MessageState.DEAD, "a message must stop retrying eventually"
+    kinds = [row["kind"] for row in org.db.connection.execute("SELECT kind FROM events").fetchall()]
+    assert "message.dead_lettered" in kinds
+
+
+def test_an_invented_subagent_is_not_an_actor(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    with pytest.raises(Refusal, match="Unknown actor"):
+        org.actor("a-subagent-i-just-made-up")

--- a/tests/test_actors_and_mailbox.py
+++ b/tests/test_actors_and_mailbox.py
@@ -93,13 +93,46 @@ def test_no_self_approval_is_policy_not_convention() -> None:
     forbid_self_approval("operator-course", "sparring-course")
 
 
-def test_reviewer_cannot_review_its_own_work(tmp_path: Path) -> None:
+def test_reviewer_cannot_review_work_it_performed(tmp_path: Path) -> None:
+    """Separation is derived from the ledger, not supplied by the caller.
+
+    `review()` takes no performer argument. It reads the assignments, finds who
+    actually did the work, and refuses if the reviewer is among them.
+    """
+    import inspect
+
+    from reference_organizations.store.demo import run_simulated
+
+    assert "performer_id" not in inspect.signature(Organization.review).parameters
+
+    run_simulated(tmp_path)
+    org = Organization(tmp_path)
+    outcome_id = str(org.db.connection.execute("SELECT id FROM outcomes").fetchone()["id"])
+    sow_id = org.sows_for(outcome_id)[0].id
+    assert "operator-course" in org.performers_for(outcome_id)
+    # The operator is refused on role authority alone -- defence in depth.
+    with pytest.raises(Refusal, match="Role operator attempted review"):
+        org.review(sow_id, "operator-course")
+
+    # And an actor that DOES hold review authority is still refused when the
+    # ledger shows it performed the work. This is the derivation doing the work.
+    org.db.connection.execute(
+        "UPDATE assignments SET actor_id = 'sparring-course' WHERE sow_id = ?", (sow_id,)
+    )
+    org.db.connection.commit()
+    assert "sparring-course" in org.performers_for(outcome_id)
+    with pytest.raises(Refusal, match="No self-approval"):
+        org.review(sow_id, "sparring-course")
+
+
+def test_review_refuses_before_any_evidence_exists(tmp_path: Path) -> None:
+    """A reviewer with nothing in front of them is rubber-stamping."""
     org = Organization.init(tmp_path)
-    outcome = org.create_outcome("t", "d", ["cash_reconciles"], "principal-human")
+    outcome = org.create_outcome("t", "d", ["cash_reconciles"], "principal-human", "SKU-TEA")
     org.activate(outcome.id, "master-course")
     sow = org.create_sow(outcome.id, "scope", Role.OPERATOR, "master-course")
-    with pytest.raises(Refusal, match="No self-approval"):
-        org.review(sow.id, "sparring-course", "sparring-course")
+    with pytest.raises(Refusal, match="No evidence to review"):
+        org.review(sow.id, "sparring-course")
 
 
 def test_claim_lease_is_exclusive(tmp_path: Path) -> None:

--- a/tests/test_causal_binding.py
+++ b/tests/test_causal_binding.py
@@ -1,0 +1,133 @@
+"""The accepted execution must have caused the effect it is credited with.
+
+Reported independently by both reviewers on PR #24. `apply_restock` recorded
+which assignment produced an effect; nothing read it. The store checks find
+replenishments by SKU, so the authorization graph and the acceptance graph met
+at the subject rather than the execution — and an assignment that did nothing
+inherited credit for work done a week earlier.
+
+Governed by docs/rulings/2026-08-26-outcomes-are-conditions-sows-are-work.md:
+an outcome is a standing condition, a SOW is a unit of work, and acceptance
+asserts BOTH that the condition holds and that this execution contributed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.checks import run_check
+from sovereign_agent.errors import Refusal
+from sovereign_agent.models import Role
+from sovereign_agent.organization import Organization
+
+CHECKS = [
+    "inventory_at_or_above_reorder_point",
+    "cash_reconciles",
+    "replenishment_event_exists",
+]
+
+
+def stocked_outcome(tmp_path: Path) -> tuple[Organization, str, str]:
+    """Week one: real work, real restock, accepted legitimately."""
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "Keep the tea jar stocked",
+        "On-hand tea stays at or above the reorder point.",
+        CHECKS,
+        "principal-human",
+        "SKU-TEA",
+    )
+    org.activate(outcome.id, "master-course")
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    sow = org.create_sow(outcome.id, "week one", Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    worker = org.run_assignment(org.assign(sow.id, "operator-course", "master-course").id)
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), worker.id, signal.id)
+    org.verify_outcome(outcome.id, "verifier-course")
+    org.review(sow.id, "sparring-course")
+    org.accept(outcome.id, "principal-human")
+    return org, outcome.id, worker.id
+
+
+def test_an_execution_that_did_nothing_is_refused(tmp_path: Path) -> None:
+    """Week two: an assignment runs, does nothing, and must not take credit.
+
+    Public APIs only, including a second SOW on the same outcome — the
+    multi-SOW shape that "latest assignment" could never model correctly.
+    """
+    org, outcome_id, first = stocked_outcome(tmp_path)
+
+    second_sow = org.create_sow(outcome_id, "week two", Role.OPERATOR, "master-course")
+    org.ready_sow(second_sow.id)
+    idle = org.run_assignment(org.assign(second_sow.id, "operator-course", "master-course").id)
+    assert idle.id not in org.contributing_executions(outcome_id)
+    assert first in org.contributing_executions(outcome_id)
+
+    org.db.connection.execute(
+        "UPDATE outcomes SET record = json_set(record, '$.state', 'VERIFYING') WHERE id = ?",
+        (outcome_id,),
+    )
+    org.db.connection.commit()
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(second_sow.id, "sparring-course")
+
+    # The condition genuinely holds: the tea IS stocked, from week one.
+    assert run_check(org.db, "inventory_at_or_above_reorder_point", "SKU-TEA").success
+
+    with pytest.raises(Refusal, match="produced no effect for this outcome"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_the_two_requirements_are_independent(tmp_path: Path) -> None:
+    """Condition-holds and execution-contributed must fail separately.
+
+    If one implied the other, the ruling would be describing one requirement
+    wearing two names.
+    """
+    org, outcome_id, first = stocked_outcome(tmp_path)
+
+    # Condition true, contribution false -> refused for contribution.
+    second_sow = org.create_sow(outcome_id, "idle", Role.OPERATOR, "master-course")
+    org.ready_sow(second_sow.id)
+    org.run_assignment(org.assign(second_sow.id, "operator-course", "master-course").id)
+    org.db.connection.execute(
+        "UPDATE outcomes SET record = json_set(record, '$.state', 'VERIFYING') WHERE id = ?",
+        (outcome_id,),
+    )
+    org.db.connection.commit()
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(second_sow.id, "sparring-course")
+    with pytest.raises(Refusal, match="produced no effect"):
+        org.accept(outcome_id, "principal-human")
+
+    # Contribution true, condition false -> refused for the condition.
+    org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
+    org.db.connection.commit()
+    assert not run_check(org.db, "inventory_at_or_above_reorder_point", "SKU-TEA").success
+
+
+def test_effects_carry_their_outcome_as_a_structured_column(tmp_path: Path) -> None:
+    """The edge must be queryable relationally, not buried in a JSON payload."""
+    org, outcome_id, worker = stocked_outcome(tmp_path)
+    row = org.db.connection.execute(
+        "SELECT outcome_id, assignment_id FROM effects WHERE outcome_id = ?", (outcome_id,)
+    ).fetchone()
+    assert row is not None, "the effect edge is not followable by query"
+    assert str(row["assignment_id"]) == worker
+
+
+def test_proof_selection_ignores_executions_that_never_completed(tmp_path: Path) -> None:
+    """ "Newest row" was an ordering accident, not a proof rule."""
+    org, outcome_id, worker = stocked_outcome(tmp_path)
+    org.db.connection.execute(
+        "INSERT INTO assignments(id, sow_id, actor_id, record) "
+        "SELECT 'asg_never_ran', sow_id, actor_id, "
+        "json_set(record, '$.state', 'CREATED') FROM assignments WHERE id = ?",
+        (worker,),
+    )
+    org.db.connection.commit()
+    assert org._latest_assignment_id(outcome_id) == worker  # noqa: SLF001

--- a/tests/test_causal_binding.py
+++ b/tests/test_causal_binding.py
@@ -70,6 +70,7 @@ def test_condition_true_contribution_true_accepts(tmp_path: Path) -> None:
     apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
     org.verify_outcome(outcome_id, "verifier-course")
     org.review(sow_id, "sparring-course")
+    org.verify_outcome_condition(outcome_id, "verifier-course")
     org.accept(outcome_id, "principal-human")
 
 
@@ -245,6 +246,7 @@ def test_a_sow_with_no_declared_effect_need_not_change_the_world(tmp_path: Path)
     sow_id, _assignment_id = run_sow(org, outcome_id, "investigate", None)
     org.verify_outcome(outcome_id, "verifier-course")
     org.review(sow_id, "sparring-course")
+    org.verify_outcome_condition(outcome_id, "verifier-course")
     org.accept(outcome_id, "principal-human")
 
 
@@ -321,6 +323,7 @@ def test_core_and_the_truth_verifier_agree_on_a_multi_sow_organization(
     org.verify_sow(investigation_sow, "verifier-course")
     org.review(effectful_sow, "sparring-course")
     org.review(investigation_sow, "sparring-course")
+    org.verify_outcome_condition(outcome_id, "verifier-course")
     org.accept(outcome_id, "principal-human")
     org.db.close()
 
@@ -366,38 +369,51 @@ def test_a_sow_must_produce_its_declared_deliverable(tmp_path: Path) -> None:
         org.accept(outcome_id, "principal-human")
 
 
-def test_a_forged_effect_row_does_not_credit_idle_work(tmp_path: Path) -> None:
-    """Append-only cannot stop a forged APPEND. Corroboration can.
+def test_corroboration_detects_inconsistency_but_does_not_authenticate(
+    tmp_path: Path,
+) -> None:
+    """States the LIMITATION as a fact, so nobody re-derives it as a bug.
 
-    Inserting is exactly what an append-only table permits, so a new `effects`
-    row naming an idle assignment would credit it with work it never did. Every
-    effect is committed in the same transaction as its event, so an effect with
-    no matching event is not a record of anything that happened — and rewriting
-    an existing event is refused outright.
+    Governed by docs/rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md.
+
+    An earlier version of this test was named "a forged effect row does not
+    credit idle work" and asserted only the half that passes. Both reviewers
+    showed the other half: two coordinated fresh appends are mutually consistent
+    and equally forged, and acceptance takes them. Asserting only the convenient
+    half is how a limitation gets mistaken for a defence.
     """
+    import json
+
     org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
     signal = record_sale(org.db, "SKU-TEA", 2, 400)
     real_sow, real = run_sow(org, outcome_id, "real", "replenishment")
     apply_restock(org.db, RestockProposal("SKU-TEA", 6), real, signal.id)
     idle_sow, idle = run_sow(org, outcome_id, "idle", "replenishment")
 
-    for sow_id in (real_sow, idle_sow):
-        org.verify_sow(sow_id, "verifier-course")
-    for sow_id in (real_sow, idle_sow):
-        org.review(sow_id, "sparring-course")
-
-    # A brand-new row, so no append-only trigger fires.
+    # (a) An effect with NO witnessing event is an incomplete record and is not
+    #     counted. This is what corroboration genuinely buys.
     org.db.connection.execute(
         "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at, outcome_id) "
-        "SELECT 'eff_forged', ?, kind, subject, payload, created_at, outcome_id "
+        "SELECT 'eff_orphan', ?, kind, subject, payload, created_at, outcome_id "
         "FROM effects LIMIT 1",
         (idle,),
     )
     org.db.connection.commit()
-    assert idle in org.contributing_executions(outcome_id), "precondition: the row was accepted"
     assert "replenishment" not in org.effect_kinds_for_execution(idle), (
-        "an uncorroborated effect must not count as work done"
+        "an effect with no witnessing event must not count as work done"
     )
 
-    with pytest.raises(Refusal, match="produced no replenishment effect"):
-        org.accept(outcome_id, "principal-human")
+    # (b) Add the matching event and the two agree — because they were written
+    #     to agree, not because anything happened. Corroboration cannot tell the
+    #     difference, and this asserts that plainly.
+    org.db.connection.execute(
+        "INSERT INTO events(id, kind, payload, created_at) "
+        "VALUES ('evt_forged', 'replenishment.committed', ?, 't')",
+        (json.dumps({"assignment_id": idle, "sku": "SKU-TEA"}),),
+    )
+    org.db.connection.commit()
+    assert "replenishment" in org.effect_kinds_for_execution(idle), (
+        "two coordinated fresh appends are mutually consistent; corroboration "
+        "detects inconsistency and does not authenticate. If this ever fails, "
+        "the trust boundary changed and the ruling must be re-derived."
+    )

--- a/tests/test_causal_binding.py
+++ b/tests/test_causal_binding.py
@@ -364,3 +364,40 @@ def test_a_sow_must_produce_its_declared_deliverable(tmp_path: Path) -> None:
 
     with pytest.raises(Refusal, match="promised report.json and did not produce it"):
         org.accept(outcome_id, "principal-human")
+
+
+def test_a_forged_effect_row_does_not_credit_idle_work(tmp_path: Path) -> None:
+    """Append-only cannot stop a forged APPEND. Corroboration can.
+
+    Inserting is exactly what an append-only table permits, so a new `effects`
+    row naming an idle assignment would credit it with work it never did. Every
+    effect is committed in the same transaction as its event, so an effect with
+    no matching event is not a record of anything that happened — and rewriting
+    an existing event is refused outright.
+    """
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    real_sow, real = run_sow(org, outcome_id, "real", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), real, signal.id)
+    idle_sow, idle = run_sow(org, outcome_id, "idle", "replenishment")
+
+    for sow_id in (real_sow, idle_sow):
+        org.verify_sow(sow_id, "verifier-course")
+    for sow_id in (real_sow, idle_sow):
+        org.review(sow_id, "sparring-course")
+
+    # A brand-new row, so no append-only trigger fires.
+    org.db.connection.execute(
+        "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at, outcome_id) "
+        "SELECT 'eff_forged', ?, kind, subject, payload, created_at, outcome_id "
+        "FROM effects LIMIT 1",
+        (idle,),
+    )
+    org.db.connection.commit()
+    assert idle in org.contributing_executions(outcome_id), "precondition: the row was accepted"
+    assert "replenishment" not in org.effect_kinds_for_execution(idle), (
+        "an uncorroborated effect must not count as work done"
+    )
+
+    with pytest.raises(Refusal, match="produced no replenishment effect"):
+        org.accept(outcome_id, "principal-human")

--- a/tests/test_causal_binding.py
+++ b/tests/test_causal_binding.py
@@ -250,6 +250,63 @@ def test_a_sow_with_no_declared_effect_need_not_change_the_world(tmp_path: Path)
     org.accept(outcome_id, "principal-human")
 
 
+@pytest.mark.parametrize("verify_order", [(0, 1), (1, 0)])
+@pytest.mark.parametrize("review_order", [(0, 1), (1, 0)])
+@pytest.mark.parametrize("world_moves_between", [False, True])
+def test_acceptance_is_independent_of_verify_and_review_order(
+    tmp_path: Path,
+    verify_order: tuple[int, int],
+    review_order: tuple[int, int],
+    world_moves_between: bool,
+) -> None:
+    """Enumerate the orderings instead of claiming they were enumerated.
+
+    I reported "all four permutations accept identically" from a throwaway probe
+    and shipped a test exercising ONE fixed ordering while its name said "in
+    either order". The reviewer caught the gap. This is the claim as a test, and
+    it includes the case the reviewer's reproduction needed: the world moving
+    BETWEEN the two verifications, which is what made the oracle disagree with
+    the core.
+
+    Both the core and the release oracle must agree in every combination.
+    """
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).resolve().parent.parent
+    org, outcome_id = build(tmp_path)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+
+    effectful_sow, effectful = run_sow(org, outcome_id, "replenish", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), effectful, signal.id)
+    investigation_sow, _idle = run_sow(org, outcome_id, "investigate", None)
+    sow_ids = (effectful_sow, investigation_sow)
+
+    org.verify_sow(sow_ids[verify_order[0]], "verifier-course")
+    if world_moves_between:
+        # A legitimate sale: inventory and cash change, the outcome stays true.
+        record_sale(org.db, "SKU-TEA", 1, 400)
+    org.verify_sow(sow_ids[verify_order[1]], "verifier-course")
+
+    for index in review_order:
+        org.review(sow_ids[index], "sparring-course")
+
+    org.verify_outcome_condition(outcome_id, "verifier-course")
+    org.accept(outcome_id, "principal-human")
+    org.db.close()
+
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, str(repo_root / "scripts" / "verify_store_outcome.py"), str(tmp_path)],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    assert result.returncode == 0, (
+        f"core accepted but the oracle rejected: verify={verify_order} "
+        f"review={review_order} world_moves={world_moves_between}\n" + result.stdout
+    )
+
+
 def test_two_completed_sows_are_each_verifiable_and_reviewable(tmp_path: Path) -> None:
     """Complete both SOWs first, then verify and review each, in either order.
 

--- a/tests/test_causal_binding.py
+++ b/tests/test_causal_binding.py
@@ -1,14 +1,15 @@
 """The accepted execution must have caused the effect it is credited with.
 
-Reported independently by both reviewers on PR #24. `apply_restock` recorded
-which assignment produced an effect; nothing read it. The store checks find
-replenishments by SKU, so the authorization graph and the acceptance graph met
-at the subject rather than the execution — and an assignment that did nothing
-inherited credit for work done a week earlier.
-
 Governed by docs/rulings/2026-08-26-outcomes-are-conditions-sows-are-work.md:
 an outcome is a standing condition, a SOW is a unit of work, and acceptance
-asserts BOTH that the condition holds and that this execution contributed.
+asserts BOTH that the condition holds and that the bound execution contributed
+the effect its SOW declares.
+
+The independence matrix below exists because the first version of this file did
+not prove independence. Its "contribution false" case always had an older
+contributor, so it missed the empty-contributor bypass entirely; and its
+"condition false" case only called `run_check()` and never `accept()`. Both
+reviewers found that when asked to attack it. Every case here calls `accept()`.
 """
 
 from __future__ import annotations
@@ -30,104 +31,207 @@ CHECKS = [
 ]
 
 
-def stocked_outcome(tmp_path: Path) -> tuple[Organization, str, str]:
-    """Week one: real work, real restock, accepted legitimately."""
+def build(tmp_path: Path, checks: list[str] | None = None) -> tuple[Organization, str]:
     org = Organization.init(tmp_path)
     seed(org.db)
     outcome = org.create_outcome(
         "Keep the tea jar stocked",
         "On-hand tea stays at or above the reorder point.",
-        CHECKS,
+        checks if checks is not None else CHECKS,
         "principal-human",
         "SKU-TEA",
     )
     org.activate(outcome.id, "master-course")
-    signal = record_sale(org.db, "SKU-TEA", 2, 400)
-    sow = org.create_sow(outcome.id, "week one", Role.OPERATOR, "master-course")
+    return org, outcome.id
+
+
+def run_sow(org: Organization, outcome_id: str, scope: str, effect: str | None) -> tuple[str, str]:
+    sow = org.create_sow(outcome_id, scope, Role.OPERATOR, "master-course", effect)
     org.ready_sow(sow.id)
-    worker = org.run_assignment(org.assign(sow.id, "operator-course", "master-course").id)
-    apply_restock(org.db, RestockProposal("SKU-TEA", 6), worker.id, signal.id)
-    org.verify_outcome(outcome.id, "verifier-course")
-    org.review(sow.id, "sparring-course")
-    org.accept(outcome.id, "principal-human")
-    return org, outcome.id, worker.id
+    assignment = org.run_assignment(org.assign(sow.id, "operator-course", "master-course").id)
+    return sow.id, assignment.id
 
 
-def test_an_execution_that_did_nothing_is_refused(tmp_path: Path) -> None:
-    """Week two: an assignment runs, does nothing, and must not take credit.
-
-    Public APIs only, including a second SOW on the same outcome — the
-    multi-SOW shape that "latest assignment" could never model correctly.
-    """
-    org, outcome_id, first = stocked_outcome(tmp_path)
-
-    second_sow = org.create_sow(outcome_id, "week two", Role.OPERATOR, "master-course")
-    org.ready_sow(second_sow.id)
-    idle = org.run_assignment(org.assign(second_sow.id, "operator-course", "master-course").id)
-    assert idle.id not in org.contributing_executions(outcome_id)
-    assert first in org.contributing_executions(outcome_id)
-
+def reopen(org: Organization, outcome_id: str) -> None:
     org.db.connection.execute(
         "UPDATE outcomes SET record = json_set(record, '$.state', 'VERIFYING') WHERE id = ?",
         (outcome_id,),
     )
     org.db.connection.commit()
-    org.verify_outcome(outcome_id, "verifier-course")
-    org.review(second_sow.id, "sparring-course")
 
-    # The condition genuinely holds: the tea IS stocked, from week one.
+
+# --- the matrix -------------------------------------------------------------
+
+
+def test_condition_true_contribution_true_accepts(tmp_path: Path) -> None:
+    org, outcome_id = build(tmp_path)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    sow_id, assignment_id = run_sow(org, outcome_id, "replenish", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+    org.accept(outcome_id, "principal-human")
+
+
+def test_condition_true_but_no_effects_exist_at_all_is_refused(tmp_path: Path) -> None:
+    """The empty-contributor case: nobody did anything, and the shelf was fine.
+
+    This is the case the previous guard skipped, because it was written as
+    `if contributors and execution_id not in contributors` — so zero
+    contributors, the strongest form of "this execution did nothing", made the
+    requirement vacuous.
+    """
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    sow_id, _assignment_id = run_sow(org, outcome_id, "idle", "replenishment")
+    assert org.contributing_executions(outcome_id) == set()
     assert run_check(org.db, "inventory_at_or_above_reorder_point", "SKU-TEA").success
 
-    with pytest.raises(Refusal, match="produced no effect for this outcome"):
-        org.accept(outcome_id, "principal-human")
-
-
-def test_the_two_requirements_are_independent(tmp_path: Path) -> None:
-    """Condition-holds and execution-contributed must fail separately.
-
-    If one implied the other, the ruling would be describing one requirement
-    wearing two names.
-    """
-    org, outcome_id, first = stocked_outcome(tmp_path)
-
-    # Condition true, contribution false -> refused for contribution.
-    second_sow = org.create_sow(outcome_id, "idle", Role.OPERATOR, "master-course")
-    org.ready_sow(second_sow.id)
-    org.run_assignment(org.assign(second_sow.id, "operator-course", "master-course").id)
-    org.db.connection.execute(
-        "UPDATE outcomes SET record = json_set(record, '$.state', 'VERIFYING') WHERE id = ?",
-        (outcome_id,),
-    )
-    org.db.connection.commit()
     org.verify_outcome(outcome_id, "verifier-course")
-    org.review(second_sow.id, "sparring-course")
-    with pytest.raises(Refusal, match="produced no effect"):
+    org.review(sow_id, "sparring-course")
+    with pytest.raises(Refusal, match="produced no replenishment effect"):
         org.accept(outcome_id, "principal-human")
 
-    # Contribution true, condition false -> refused for the condition.
+
+def test_condition_true_but_another_execution_contributed_is_refused(tmp_path: Path) -> None:
+    """Week one did the work; week two must not inherit the credit."""
+    org, outcome_id = build(tmp_path)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    first_sow, first = run_sow(org, outcome_id, "week one", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), first, signal.id)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(first_sow, "sparring-course")
+    org.accept(outcome_id, "principal-human")
+
+    second_sow, second = run_sow(org, outcome_id, "week two", "replenishment")
+    assert second not in org.contributing_executions(outcome_id)
+    assert run_check(org.db, "inventory_at_or_above_reorder_point", "SKU-TEA").success
+
+    reopen(org, outcome_id)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(second_sow, "sparring-course")
+    with pytest.raises(Refusal, match="produced no replenishment effect"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_condition_false_but_contribution_true_is_refused(tmp_path: Path) -> None:
+    """The execution really did restock, then the world moved against it."""
+    org, outcome_id = build(tmp_path)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    sow_id, assignment_id = run_sow(org, outcome_id, "replenish", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+
+    assert assignment_id in org.contributing_executions(outcome_id)
     org.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
     org.db.connection.commit()
+
+    with pytest.raises(Refusal, match="Checks failing at acceptance time"):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_condition_false_and_contribution_false_refuses_deterministically(
+    tmp_path: Path,
+) -> None:
+    """Both wrong: the refusal must be stable, and must name the world first.
+
+    Precedence matters for teaching. "The shelf is empty" is the fact a learner
+    can act on; "this execution contributed nothing" is only meaningful once the
+    world is right.
+    """
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    record_sale(org.db, "SKU-TEA", 2, 400)  # drops below the reorder point
+    sow_id, _assignment_id = run_sow(org, outcome_id, "idle", "replenishment")
     assert not run_check(org.db, "inventory_at_or_above_reorder_point", "SKU-TEA").success
+    assert org.contributing_executions(outcome_id) == set()
+
+    org.verify_outcome(outcome_id, "verifier-course")
+    review = org.review(sow_id, "sparring-course")
+    # The failing world is caught upstream: the review itself decides
+    # changes_requested, so the SOW never reaches an acceptable state. That is
+    # the right precedence — a learner is told the shelf is empty, which they
+    # can act on, rather than a contribution technicality they cannot.
+    assert review.decision == "changes_requested"
+    for _ in range(2):
+        with pytest.raises(Refusal, match="SOWs remain open"):
+            org.accept(outcome_id, "principal-human")
+
+
+# --- cross-SOW proof borrowing ----------------------------------------------
+
+
+def test_one_sow_cannot_borrow_another_sows_proof(tmp_path: Path) -> None:
+    """SOW A does nothing; SOW B does the work. A must not be accepted on B.
+
+    Reported at 62a8a6c: `review()` loaded the OUTCOME's latest verification and
+    never checked that its assignment belonged to the reviewed SOW.
+    """
+    org, outcome_id = build(tmp_path)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    idle_sow, _idle = run_sow(org, outcome_id, "idle", "replenishment")
+    real_sow, real = run_sow(org, outcome_id, "real", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), real, signal.id)
+
+    org.verify_outcome(outcome_id, "verifier-course")
+    verification = org.latest_verification(outcome_id)
+    assert verification is not None and verification.assignment_id == real
+
+    with pytest.raises(Refusal, match="belongs to another SOW's execution"):
+        org.review(idle_sow, "sparring-course")
+
+
+def test_every_sow_needs_its_own_completed_execution(tmp_path: Path) -> None:
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    sow_id, assignment_id = run_sow(org, outcome_id, "replenish", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+
+    # A second SOW that never ran must block acceptance of the outcome. It is
+    # caught by the SOW-state gate first, which is the earlier and clearer
+    # refusal; the no-completed-execution guard backs it up for a SOW that has
+    # been marked accepted without ever having run.
+    unrun = org.create_sow(outcome_id, "never run", Role.OPERATOR, "master-course")
+    with pytest.raises(Refusal, match="SOWs remain open"):
+        org.accept(outcome_id, "principal-human")
+
+    org.db.connection.execute(
+        "UPDATE sows SET record = json_set(record, '$.state', 'ACCEPTED') WHERE id = ?",
+        (unrun.id,),
+    )
+    org.db.connection.commit()
+    with pytest.raises(Refusal, match="has no completed execution"):
+        org.accept(outcome_id, "principal-human")
+
+
+# --- structural guarantees ---------------------------------------------------
 
 
 def test_effects_carry_their_outcome_as_a_structured_column(tmp_path: Path) -> None:
-    """The edge must be queryable relationally, not buried in a JSON payload."""
-    org, outcome_id, worker = stocked_outcome(tmp_path)
+    org, outcome_id = build(tmp_path)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    _sow_id, assignment_id = run_sow(org, outcome_id, "replenish", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
     row = org.db.connection.execute(
         "SELECT outcome_id, assignment_id FROM effects WHERE outcome_id = ?", (outcome_id,)
     ).fetchone()
-    assert row is not None, "the effect edge is not followable by query"
-    assert str(row["assignment_id"]) == worker
+    assert row is not None and str(row["assignment_id"]) == assignment_id
 
 
-def test_proof_selection_ignores_executions_that_never_completed(tmp_path: Path) -> None:
-    """ "Newest row" was an ordering accident, not a proof rule."""
-    org, outcome_id, worker = stocked_outcome(tmp_path)
-    org.db.connection.execute(
-        "INSERT INTO assignments(id, sow_id, actor_id, record) "
-        "SELECT 'asg_never_ran', sow_id, actor_id, "
-        "json_set(record, '$.state', 'CREATED') FROM assignments WHERE id = ?",
-        (worker,),
-    )
-    org.db.connection.commit()
-    assert org._latest_assignment_id(outcome_id) == worker  # noqa: SLF001
+def test_proof_selection_is_per_sow_not_row_order(tmp_path: Path) -> None:
+    """Each SOW resolves to its own execution, whatever order rows were written."""
+    org, outcome_id = build(tmp_path)
+    first_sow, first = run_sow(org, outcome_id, "one", None)
+    second_sow, second = run_sow(org, outcome_id, "two", None)
+    assert org.completed_assignment_for_sow(first_sow) == first
+    assert org.completed_assignment_for_sow(second_sow) == second
+
+
+def test_a_sow_with_no_declared_effect_need_not_change_the_world(tmp_path: Path) -> None:
+    """Not every legitimate SOW is effectful; the requirement is declared."""
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    sow_id, _assignment_id = run_sow(org, outcome_id, "investigate", None)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+    org.accept(outcome_id, "principal-human")

--- a/tests/test_causal_binding.py
+++ b/tests/test_causal_binding.py
@@ -173,11 +173,22 @@ def test_one_sow_cannot_borrow_another_sows_proof(tmp_path: Path) -> None:
     apply_restock(org.db, RestockProposal("SKU-TEA", 6), real, signal.id)
 
     org.verify_outcome(outcome_id, "verifier-course")
-    verification = org.latest_verification(outcome_id)
-    assert verification is not None and verification.assignment_id == real
 
-    with pytest.raises(Refusal, match="belongs to another SOW's execution"):
-        org.review(idle_sow, "sparring-course")
+    # Each SOW now gets its OWN verification, bound to its OWN execution, so a
+    # batch cannot be borrowed in the first place.
+    idle_verification = org.verification_for_sow(idle_sow)
+    real_verification = org.verification_for_sow(real_sow)
+    assert idle_verification is not None and real_verification is not None
+    assert idle_verification.id != real_verification.id
+    assert real_verification.assignment_id == real
+    assert idle_verification.assignment_id != real
+
+    # Both can be reviewed on their own batches; the idle SOW is then refused at
+    # acceptance for the real reason: its execution changed nothing.
+    org.review(idle_sow, "sparring-course")
+    org.review(real_sow, "sparring-course")
+    with pytest.raises(Refusal, match="produced no replenishment effect"):
+        org.accept(outcome_id, "principal-human")
 
 
 def test_every_sow_needs_its_own_completed_execution(tmp_path: Path) -> None:
@@ -235,3 +246,121 @@ def test_a_sow_with_no_declared_effect_need_not_change_the_world(tmp_path: Path)
     org.verify_outcome(outcome_id, "verifier-course")
     org.review(sow_id, "sparring-course")
     org.accept(outcome_id, "principal-human")
+
+
+def test_two_completed_sows_are_each_verifiable_and_reviewable(tmp_path: Path) -> None:
+    """Complete both SOWs first, then verify and review each, in either order.
+
+    Reported on PR #24 round 5: `verify_outcome()` picked a SOW implicitly by row
+    order — and `sows_for()` has no ordering contract — so with two completed
+    SOWs one became PERMANENTLY unreviewable, and re-verifying chose the same
+    one again. The caller could not name the work being verified.
+    """
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    first_sow, first = run_sow(org, outcome_id, "first", None)
+    second_sow, second = run_sow(org, outcome_id, "second", None)
+
+    # Verify in the opposite order to the runs, by name.
+    org.verify_sow(second_sow, "verifier-course")
+    org.verify_sow(first_sow, "verifier-course")
+
+    assert org.verification_for_sow(first_sow).assignment_id == first
+    assert org.verification_for_sow(second_sow).assignment_id == second
+
+    # Review in yet another order; neither is blocked by the other.
+    org.review(first_sow, "sparring-course")
+    org.review(second_sow, "sparring-course")
+    assert all(sow.state.value == "ACCEPTED" for sow in org.sows_for(outcome_id))
+
+
+def test_a_verification_names_the_sow_it_is_about(tmp_path: Path) -> None:
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    sow_id, assignment_id = run_sow(org, outcome_id, "work", None)
+    org.verify_sow(sow_id, "verifier-course")
+    verification = org.verification_for_sow(sow_id)
+    assert verification is not None
+    assert verification.sow_id == sow_id
+    assert verification.assignment_id == assignment_id
+    # The relational chain must close: verification -> assignment -> sow.
+    row = org.db.connection.execute(
+        "SELECT sow_id FROM assignments WHERE id = ?", (verification.assignment_id,)
+    ).fetchone()
+    assert str(row["sow_id"]) == verification.sow_id
+
+
+def test_verifying_a_sow_with_no_completed_execution_is_refused(tmp_path: Path) -> None:
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    sow = org.create_sow(outcome_id, "never run", Role.OPERATOR, "master-course")
+    with pytest.raises(Refusal, match="no completed execution to verify"):
+        org.verify_sow(sow.id, "verifier-course")
+
+
+def test_core_and_the_truth_verifier_agree_on_a_multi_sow_organization(
+    tmp_path: Path,
+) -> None:
+    """The control plane must never mint a state its own oracle calls false.
+
+    Reported on PR #24 round 5: the core permitted per-SOW executions while
+    `verify_store_outcome.py` still assumed one latest execution owned every
+    evidence row, so a legitimate two-SOW organization was ACCEPTED by the core
+    and rejected by the release gate. Whichever is right, shipping both is
+    indefensible.
+    """
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).resolve().parent.parent
+    org, outcome_id = build(tmp_path)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+
+    effectful_sow, effectful = run_sow(org, outcome_id, "replenish", "replenishment")
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), effectful, signal.id)
+    investigation_sow, _idle = run_sow(org, outcome_id, "investigate", None)
+
+    org.verify_sow(effectful_sow, "verifier-course")
+    org.verify_sow(investigation_sow, "verifier-course")
+    org.review(effectful_sow, "sparring-course")
+    org.review(investigation_sow, "sparring-course")
+    org.accept(outcome_id, "principal-human")
+    org.db.close()
+
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, str(repo_root / "scripts" / "verify_store_outcome.py"), str(tmp_path)],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    assert result.returncode == 0, (
+        "core accepted a multi-SOW organization its own verifier rejects:\n"
+        + result.stdout
+        + result.stderr
+    )
+
+
+def test_a_sow_must_produce_its_declared_deliverable(tmp_path: Path) -> None:
+    """For a non-effectful SOW the deliverable IS the proof.
+
+    Holding 2 of docs/rulings/2026-08-26-amendment-conditional-effects.md.
+    Judging an investigation by the outcome's inventory checks would be a check
+    named for one fact measuring another — this unit's signature defect, one
+    scope up.
+    """
+    org, outcome_id = build(tmp_path, ["inventory_at_or_above_reorder_point"])
+    sow_id, assignment_id = run_sow(org, outcome_id, "investigate", None)
+    org.verify_sow(sow_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    deliverable = (
+        tmp_path
+        / ".sovereign"
+        / "runs"
+        / assignment.workspace_id
+        / ".sovereign-out"
+        / "report.json"
+    )
+    assert deliverable.is_file(), "precondition: the deliverable was produced"
+    deliverable.unlink()
+
+    with pytest.raises(Refusal, match="promised report.json and did not produce it"):
+        org.accept(outcome_id, "principal-human")

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import threading
 from pathlib import Path
 
-from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from reference_organizations.store import RestockProposal, apply_restock, record_sale
 from sovereign_agent.database import Database
 from sovereign_agent.organization import Organization
 from sovereign_agent.relay import claim, send
+
+from .helpers import governed_assignment
 
 
 def _run_concurrently(root: Path, work, count: int = 2) -> list[str]:
@@ -49,13 +51,12 @@ def test_concurrent_retries_order_stock_exactly_once(tmp_path: Path) -> None:
     Before the fix, both workers passed a preflight scan of the event log and
     both committed: on_hand=14, two purchase entries, two replenishment events.
     """
-    org = Organization.init(tmp_path)
-    seed(org.db)
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path)
     signal = record_sale(org.db, "SKU-TEA", 2, 400)
     org.db.close()
 
     def work(db: Database, _index: int) -> str:
-        result = apply_restock(db, RestockProposal("SKU-TEA", 6), "asg_same", signal.id)
+        result = apply_restock(db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
         return "replay" if result.get("idempotent_replay") else "committed"
 
     results = _run_concurrently(tmp_path, work)
@@ -86,9 +87,8 @@ def test_concurrent_retries_order_stock_exactly_once(tmp_path: Path) -> None:
 
 def test_concurrent_sales_cannot_oversell(tmp_path: Path) -> None:
     """Two sales of the whole shelf must not both succeed."""
-    org = Organization.init(tmp_path)
-    seed(org.db)  # on_hand = 4
-    org.db.close()
+    org, _outcome_id, _sow_id, _assignment_id = governed_assignment(tmp_path)
+    org.db.close()  # on_hand = 4 from seed
 
     def work(db: Database, _index: int) -> str:
         record_sale(db, "SKU-TEA", 3, 400)
@@ -114,14 +114,23 @@ def test_concurrent_sales_cannot_oversell(tmp_path: Path) -> None:
     assert on_hand == 4 - 3 * results.count("sold")
 
 
-def test_a_message_lease_has_exactly_one_owner(tmp_path: Path) -> None:
-    """Two connections must not both believe they hold the same claim."""
+def test_only_one_contender_wins_a_contested_lease(tmp_path: Path) -> None:
+    """Two DISTINCT contenders: exactly one wins.
+
+    Named for what it proves. The previous name -- "exactly one owner" --
+    overclaimed: a second connection using the SAME actor id is granted the
+    claim, because `claim_owner == actor_id` short circuits. That is
+    actor-level idempotency, not process-level exclusivity, and the
+    distinction is covered by the test below.
+    """
     org = Organization.init(tmp_path)
     message = send(org.db, "master-course", "sparring-course", "s", "b")
     org.db.close()
 
-    def work(db: Database, _index: int) -> str:
-        claim(db, message.id, "sparring-course")
+    def work(db: Database, index: int) -> str:
+        # Distinct contenders: only the addressed actor may claim, so the second
+        # is a different actor attempting the same message.
+        claim(db, message.id, "sparring-course" if index == 0 else "operator-course")
         return "claimed"
 
     results = _run_concurrently(tmp_path, work)
@@ -136,3 +145,31 @@ def test_a_message_lease_has_exactly_one_owner(tmp_path: Path) -> None:
 
     assert results.count("claimed") == 1, f"two workers claimed one lease: {results}"
     assert claimed_events == 1
+
+
+def test_the_same_actor_from_two_processes_is_idempotent_not_exclusive(tmp_path: Path) -> None:
+    """State the property honestly rather than overclaiming exclusivity.
+
+    A second connection using the SAME actor id is granted the claim, because a
+    claim already held by that actor short circuits. Two processes hosting one
+    actor can therefore both proceed. That is actor-level idempotency; it is NOT
+    process-level fencing, and 1.x does not provide fencing.
+
+    The governing rule is recorded in
+    docs/rulings/2026-08-26-one-process-per-actor.md: one process may host an
+    actor, and lease fencing is deferred to Unit 8's supervisor. This test
+    exists so nobody reads the mailbox as offering a guarantee it does not.
+    """
+    org = Organization.init(tmp_path)
+    message = send(org.db, "master-course", "sparring-course", "s", "b")
+    org.db.close()
+
+    first = Database(tmp_path / ".sovereign" / "organization.db")
+    second = Database(tmp_path / ".sovereign" / "organization.db")
+    try:
+        claim(first, message.id, "sparring-course")
+        again = claim(second, message.id, "sparring-course")
+        assert again.claim_owner == "sparring-course"
+    finally:
+        first.close()
+        second.close()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,138 @@
+"""Two connections, one truth.
+
+Every test in the rest of this suite uses a single connection. That is a
+structural blind spot: a read-then-write race is invisible to sequential tests,
+and six of the seven blocking findings on PR #24 lived in it. These tests open
+real second connections and force contention with a barrier.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.database import Database
+from sovereign_agent.organization import Organization
+from sovereign_agent.relay import claim, send
+
+
+def _run_concurrently(root: Path, work, count: int = 2) -> list[str]:
+    """Run `work(db, index)` on `count` independent connections, released together."""
+    barrier = threading.Barrier(count)
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def runner(index: int) -> None:
+        db = Database(root / ".sovereign" / "organization.db")
+        db.connection.execute("PRAGMA busy_timeout = 5000")
+        barrier.wait()
+        try:
+            outcome = work(db, index)
+        except Exception as error:  # noqa: BLE001 - the refusal is the result
+            outcome = f"{type(error).__name__}"
+        with lock:
+            results.append(outcome)
+        db.close()
+
+    threads = [threading.Thread(target=runner, args=(index,)) for index in range(count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    return results
+
+
+def test_concurrent_retries_order_stock_exactly_once(tmp_path: Path) -> None:
+    """A retry must not double-order.
+
+    Before the fix, both workers passed a preflight scan of the event log and
+    both committed: on_hand=14, two purchase entries, two replenishment events.
+    """
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    org.db.close()
+
+    def work(db: Database, _index: int) -> str:
+        result = apply_restock(db, RestockProposal("SKU-TEA", 6), "asg_same", signal.id)
+        return "replay" if result.get("idempotent_replay") else "committed"
+
+    results = _run_concurrently(tmp_path, work)
+
+    db = Database(tmp_path / ".sovereign" / "organization.db")
+    on_hand = int(
+        db.connection.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'").fetchone()[
+            "on_hand"
+        ]
+    )
+    events = int(
+        db.connection.execute(
+            "SELECT COUNT(*) AS c FROM events WHERE kind = 'replenishment.committed'"
+        ).fetchone()["c"]
+    )
+    purchases = int(
+        db.connection.execute(
+            "SELECT COUNT(*) AS c FROM cash_entries WHERE amount_cents < 0"
+        ).fetchone()["c"]
+    )
+    db.close()
+
+    assert results.count("committed") == 1, f"expected exactly one commit, got {results}"
+    assert on_hand == 8, f"stock ordered more than once: on_hand={on_hand}"
+    assert events == 1
+    assert purchases == 1
+
+
+def test_concurrent_sales_cannot_oversell(tmp_path: Path) -> None:
+    """Two sales of the whole shelf must not both succeed."""
+    org = Organization.init(tmp_path)
+    seed(org.db)  # on_hand = 4
+    org.db.close()
+
+    def work(db: Database, _index: int) -> str:
+        record_sale(db, "SKU-TEA", 3, 400)
+        return "sold"
+
+    results = _run_concurrently(tmp_path, work)
+
+    db = Database(tmp_path / ".sovereign" / "organization.db")
+    on_hand = int(
+        db.connection.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'").fetchone()[
+            "on_hand"
+        ]
+    )
+    sales = int(
+        db.connection.execute(
+            "SELECT COUNT(*) AS c FROM events WHERE kind = 'sale.committed'"
+        ).fetchone()["c"]
+    )
+    db.close()
+
+    assert on_hand >= 0, "inventory went negative under concurrent sales"
+    assert sales == results.count("sold")
+    assert on_hand == 4 - 3 * results.count("sold")
+
+
+def test_a_message_lease_has_exactly_one_owner(tmp_path: Path) -> None:
+    """Two connections must not both believe they hold the same claim."""
+    org = Organization.init(tmp_path)
+    message = send(org.db, "master-course", "sparring-course", "s", "b")
+    org.db.close()
+
+    def work(db: Database, _index: int) -> str:
+        claim(db, message.id, "sparring-course")
+        return "claimed"
+
+    results = _run_concurrently(tmp_path, work)
+
+    db = Database(tmp_path / ".sovereign" / "organization.db")
+    claimed_events = int(
+        db.connection.execute(
+            "SELECT COUNT(*) AS c FROM events WHERE kind = 'message.claimed'"
+        ).fetchone()["c"]
+    )
+    db.close()
+
+    assert results.count("claimed") == 1, f"two workers claimed one lease: {results}"
+    assert claimed_events == 1

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import threading
 from pathlib import Path
 
-from reference_organizations.store import RestockProposal, apply_restock, record_sale
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
 from sovereign_agent.database import Database
 from sovereign_agent.organization import Organization
 from sovereign_agent.relay import claim, send
@@ -173,3 +173,36 @@ def test_the_same_actor_from_two_processes_is_idempotent_not_exclusive(tmp_path:
     finally:
         first.close()
         second.close()
+
+
+def test_two_connections_cannot_both_assign_one_sow(tmp_path: Path) -> None:
+    """A duplicate assignment is a durable semantic consequence of a retry.
+
+    `assign()` used to create a row from ANY state and only advance from READY
+    or CHANGES_REQUESTED, so a second call left an assignment that could never
+    run — and proof selection immediately treated it as the bound execution.
+    """
+    from sovereign_agent.models import Role
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "t", "d", ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA"
+    )
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, "s", Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    org.db.close()
+
+    def work(db: Database, _index: int) -> str:
+        organization = Organization(tmp_path)
+        organization.assign(sow.id, "operator-course", "master-course")
+        return "assigned"
+
+    results = _run_concurrently(tmp_path, work)
+
+    db = Database(tmp_path / ".sovereign" / "organization.db")
+    count = int(db.connection.execute("SELECT COUNT(*) AS c FROM assignments").fetchone()["c"])
+    db.close()
+    assert results.count("assigned") == 1, f"two workers both assigned: {results}"
+    assert count == 1, f"{count} assignments exist for one SOW"

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -36,7 +36,7 @@ def test_operator_cannot_accept(tmp_path: Path) -> None:
     outcome = org.create_outcome("t", "d", ["c"], "principal-human")
     org.activate(outcome.id, "master-course")
     with pytest.raises(Refusal):
-        org.accept(outcome.id, "operator-course", "operator-course", ["evd"])
+        org.accept(outcome.id, "operator-course")
 
 
 def test_sale_is_atomic_with_event(tmp_path: Path) -> None:
@@ -61,9 +61,36 @@ def test_mailbox_rejects_wrong_actor(tmp_path: Path) -> None:
 
 
 def test_simulated_store_reaches_accepted(tmp_path: Path) -> None:
+    """ACCEPTED must mean the business outcome is TRUE, not that a string appeared.
+
+    The previous version of this test asserted only that "ACCEPTED" was printed
+    and that a README existed. It passed against a demo that certified a false
+    outcome while the tea jar sat below its reorder point. A test that cannot
+    fail when the product lies is not a test.
+    """
     text = run_simulated(tmp_path)
     assert "ACCEPTED" in text
     org = Organization(tmp_path)
     outcome_id = text.split()[0]
     assert org._outcome(outcome_id).state.value == "ACCEPTED"  # noqa: SLF001
     assert (tmp_path / "governance" / "outcomes" / outcome_id / "README.md").exists()
+
+    row = org.db.connection.execute(
+        "SELECT on_hand, reorder_point FROM inventory WHERE sku = 'SKU-TEA'"
+    ).fetchone()
+    assert row["on_hand"] >= row["reorder_point"], "ACCEPTED while still below reorder point"
+
+    purchases = org.db.connection.execute(
+        "SELECT amount_cents FROM cash_entries WHERE amount_cents < 0"
+    ).fetchall()
+    assert purchases, "no purchasing cash entry for the replenishment"
+
+    kinds = [event.kind for event in replay(org.db)]
+    assert "replenishment.committed" in kinds, "accepted without a replenishment event"
+    assert not any(kind.startswith("pulse.") for kind in kinds), "no Pulse before Unit 9"
+
+    evidence = org.db.connection.execute(
+        "SELECT check_id, success FROM evidence WHERE outcome_id = ?", (outcome_id,)
+    ).fetchall()
+    covered = {row["check_id"] for row in evidence if row["success"] == 1}
+    assert covered == set(org._outcome(outcome_id).acceptance_checks)  # noqa: SLF001

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -514,3 +514,42 @@ def test_a_forged_effect_cannot_be_inserted_from_outside(tmp_path: Path) -> None
             outsider.commit()
     finally:
         outsider.close()
+
+
+def test_migration_12_content_is_frozen(tmp_path: Path) -> None:
+    """An applied migration's bytes must never change.
+
+    MIGRATION_12 was computed from APPEND_ONLY_TABLES, so adding a table
+    tomorrow would rewrite an already-stamped version: guards for new installs,
+    silence for every upgraded database. Raised by Sparring as the one item
+    left, and it is this PR's recurring shape — a guarantee staying put while
+    the load moves — sitting inside the fix built to stop it.
+
+    Adding a proof-bearing table means a NEW migration. This test fails if
+    version 12 is edited instead, so the rule does not depend on remembering it.
+    """
+    from sovereign_agent.database import (
+        APPEND_ONLY_TABLES,
+        MIGRATION_12,
+        MIGRATION_12_TABLES,
+    )
+
+    assert MIGRATION_12_TABLES == ("effects", "verifications", "reviews", "evidence"), (
+        "migration 12 has already been applied to real databases; add a NEW "
+        "migration for further tables instead of editing this one"
+    )
+    for table in MIGRATION_12_TABLES:
+        assert f"{table}_no_update" in MIGRATION_12
+
+    # Any table listed but not covered by 12 needs its own later migration.
+    from sovereign_agent.database import MIGRATIONS
+
+    later = set(APPEND_ONLY_TABLES) - set(MIGRATION_12_TABLES) - {"events"}
+    for table in later:
+        covered = any(
+            f"{table}_no_update" in script for version, script in MIGRATIONS if version > 12
+        )
+        assert covered, (
+            f"{table} is listed append-only but no migration after 12 guards it; "
+            "existing databases would never receive its triggers"
+        )

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -217,3 +217,43 @@ def test_idempotency_is_scoped_to_assignment_and_sku(tmp_path: Path) -> None:
 
     replay = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_shared", signal.id)
     assert replay.get("idempotent_replay") is True, "same assignment and SKU must still be a no-op"
+
+
+def test_append_only_holds_from_a_connection_without_the_pragma(tmp_path: Path) -> None:
+    """The guarantee must not depend on application code setting a PRAGMA.
+
+    `recursive_triggers` is per-connection. With only the BEFORE DELETE guard,
+    `INSERT OR REPLACE` from a plain sqlite3 connection — the exact tool
+    Chapter 1 teaches — silently overwrote an event and left the row count
+    unchanged, while verify_store_outcome still reported "ACCEPTED and true".
+
+    This test opens its OWN connection and deliberately does not set the pragma,
+    so it fails if enforcement ever moves back into application code.
+    """
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    row = org.db.connection.execute("SELECT id, kind FROM events LIMIT 1").fetchone()
+    event_id, original_kind = str(row["id"]), str(row["kind"])
+    org.db.close()
+
+    outsider = sqlite3.connect(tmp_path / ".sovereign" / "organization.db")
+    outsider.row_factory = sqlite3.Row
+    try:
+        for statement, parameters in (
+            (
+                "INSERT OR REPLACE INTO events(id, kind, payload, created_at) "
+                "VALUES (?, 'TAMPERED', '{}', 'now')",
+                (event_id,),
+            ),
+            ("UPDATE events SET kind = 'TAMPERED' WHERE id = ?", (event_id,)),
+            ("DELETE FROM events WHERE id = ?", (event_id,)),
+        ):
+            with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+                outsider.execute(statement, parameters)
+                outsider.commit()
+            outsider.rollback()
+
+        surviving = outsider.execute("SELECT kind FROM events WHERE id = ?", (event_id,)).fetchone()
+        assert surviving["kind"] == original_kind
+    finally:
+        outsider.close()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -346,3 +346,57 @@ def test_the_effect_key_cannot_collide_across_assignment_and_subject(tmp_path: P
     row = db.connection.execute("SELECT COUNT(*) AS c FROM effects").fetchone()
     assert int(row["c"]) == 2, "structured columns must keep these pairs distinct"
     db.close()
+
+
+def test_a_migration_that_cannot_preserve_the_ledger_refuses_to_run(tmp_path: Path) -> None:
+    """Fail closed. Never decide which history was worth keeping.
+
+    Migration 10 rebuilds `effects` with a NOT NULL outcome_id. Its first
+    version carried `WHERE COALESCE(...) IS NOT NULL` so the rebuild would always
+    succeed — silently dropping every legacy row it could not attribute, then
+    DROPping the old table, destroying an operational record from an append-only
+    ledger while reporting success. Reported on PR #24 round 5.
+    """
+    import sovereign_agent.database as database_module
+
+    path = tmp_path / "legacy.db"
+    connection = sqlite3.connect(path)
+    for version, script in database_module.MIGRATIONS:
+        if version > 9:
+            break
+        for statement in database_module._split_statements(script):  # noqa: SLF001
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, datetime('now'))",
+            (version,),
+        )
+    connection.execute("INSERT INTO actors(id, record) VALUES ('op', '{}')")
+    connection.execute("INSERT INTO outcomes(id, record) VALUES ('out', '{}')")
+    connection.execute("INSERT INTO sows(id, outcome_id, record) VALUES ('sow', 'out', '{}')")
+    connection.execute(
+        "INSERT INTO assignments(id, sow_id, actor_id, record) VALUES ('a', 'sow', 'op', '{}')"
+    )
+    # An effect with no attribution in the column and none in the payload.
+    connection.execute(
+        "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at) "
+        "VALUES ('e_legacy', 'a', 'replenishment', 'SKU-TEA', '{}', 't')"
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(sqlite3.IntegrityError, match="NOT NULL"):
+        Database(path)
+
+    inspector = sqlite3.connect(path)
+    try:
+        surviving = inspector.execute("SELECT COUNT(*) FROM effects").fetchone()[0]
+        assert surviving == 1, "the migration destroyed an operational record"
+        stamped = [
+            int(row[0]) for row in inspector.execute("SELECT version FROM schema_migrations")
+        ]
+        assert 10 not in stamped, "a failed migration was stamped as applied"
+        assert inspector.execute(
+            "SELECT name FROM sqlite_master WHERE name = 'effects'"
+        ).fetchone(), "the original table was dropped despite the failure"
+    finally:
+        inspector.close()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -307,3 +307,42 @@ def test_migration_statement_splitting_keeps_trigger_bodies_intact() -> None:
     assert len(statements) == 1
     assert statements[0].startswith("CREATE TRIGGER")
     assert statements[0].rstrip().endswith("END;")
+
+
+def test_the_effect_key_cannot_collide_across_assignment_and_subject(tmp_path: Path) -> None:
+    """Structured columns, not a concatenated string.
+
+    Raised by Sparring: the key was `f"restock:{assignment_id}:{sku}"`, so
+    (assignment='asg_A', sku='TEA:X') and (assignment='asg_A:TEA', sku='X')
+    produced the same string. A colliding pair returned idempotent_replay=True
+    — a restock that never happened, reported as success. That made structured
+    columns a correctness fix rather than a schema preference.
+    """
+    db = Database(tmp_path / "collide.db")
+    db.connection.execute("INSERT INTO actors(id, record) VALUES ('op', '{}')")
+    db.connection.execute("INSERT INTO outcomes(id, record) VALUES ('out', '{}')")
+    db.connection.execute("INSERT INTO sows(id, outcome_id, record) VALUES ('sow', 'out', '{}')")
+    for assignment_id in ("asg_A", "asg_A:TEA"):
+        db.connection.execute(
+            "INSERT INTO assignments(id, sow_id, actor_id, record) VALUES (?, 'sow', 'op', '{}')",
+            (assignment_id,),
+        )
+    db.connection.commit()
+
+    legacy_key = "restock:asg_A:TEA:X"
+    assert f"restock:asg_A:{'TEA:X'}" == legacy_key
+    assert f"restock:{'asg_A:TEA'}:X" == legacy_key, "precondition: the old scheme collided"
+
+    for evidence_id, assignment_id, subject in (
+        ("e1", "asg_A", "TEA:X"),
+        ("e2", "asg_A:TEA", "X"),
+    ):
+        db.connection.execute(
+            "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at) "
+            "VALUES (?, ?, 'replenishment', ?, '{}', 't')",
+            (evidence_id, assignment_id, subject),
+        )
+    db.connection.commit()
+    row = db.connection.execute("SELECT COUNT(*) AS c FROM effects").fetchone()
+    assert int(row["c"]) == 2, "structured columns must keep these pairs distinct"
+    db.close()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -183,3 +183,37 @@ def test_signal_is_recorded_with_the_sale(tmp_path: Path) -> None:
         "SELECT COUNT(*) AS c FROM signals WHERE id = ?", (signal.id,)
     ).fetchone()
     assert row["c"] == 1
+
+
+def test_idempotency_is_scoped_to_assignment_and_sku(tmp_path: Path) -> None:
+    """Replay protection must not silently swallow a different product's restock.
+
+    Keyed on the assignment alone, a replenishment of SKU-B would make a later
+    restock of SKU-TEA under the same assignment return "already done" while the
+    tea shelf stayed empty.
+    """
+    import json
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    org.db.connection.execute(
+        "INSERT OR REPLACE INTO products(sku, record) VALUES ('SKU-B', ?)",
+        (json.dumps({"sku": "SKU-B", "name": "b", "unit_cost_cents": 10, "price_cents": 20}),),
+    )
+    org.db.connection.execute(
+        "INSERT OR REPLACE INTO inventory(sku, on_hand, reserved, reorder_point, record) "
+        "VALUES ('SKU-B', 0, 0, 1, '{}')"
+    )
+    org.db.connection.commit()
+
+    apply_restock(org.db, RestockProposal("SKU-B", 3), "asg_shared")
+    result = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_shared", signal.id)
+    assert result.get("idempotent_replay") is None, "a different SKU was treated as a replay"
+    row = org.db.connection.execute(
+        "SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'"
+    ).fetchone()
+    assert int(row["on_hand"]) == 8
+
+    replay = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_shared", signal.id)
+    assert replay.get("idempotent_replay") is True, "same assignment and SKU must still be a no-op"

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -338,8 +338,8 @@ def test_the_effect_key_cannot_collide_across_assignment_and_subject(tmp_path: P
         ("e2", "asg_A:TEA", "X"),
     ):
         db.connection.execute(
-            "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at) "
-            "VALUES (?, ?, 'replenishment', ?, '{}', 't')",
+            "INSERT INTO effects(id, assignment_id, kind, subject, payload, created_at, "
+            "outcome_id) VALUES (?, ?, 'replenishment', ?, '{}', 't', 'out')",
             (evidence_id, assignment_id, subject),
         )
     db.connection.commit()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -587,5 +587,3 @@ def test_migration_12_does_not_depend_on_the_shared_helper() -> None:
     assert "_append_only_triggers" not in assignment, (
         "MIGRATION_12 is generated again; an applied migration must be a literal"
     )
-
-

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -402,35 +402,82 @@ def test_a_migration_that_cannot_preserve_the_ledger_refuses_to_run(tmp_path: Pa
         inspector.close()
 
 
-def test_every_proof_bearing_table_is_append_only(tmp_path: Path) -> None:
-    """The guarantee must sit where the load is, and stay there.
+def test_append_only_guards_exist_on_fresh_and_upgraded_databases(tmp_path: Path) -> None:
+    """The guards must reach EXISTING databases, not just new ones.
 
-    Append-only was added to `events` because acceptance rested on events. It
-    then came to rest on `effects`, `verifications`, `reviews` and `evidence` —
-    and the guards stayed put. An outside INSERT into `effects` flipped a
-    correctly-refused outcome to ACCEPTED. Raised by Sparring, who counted it as
-    the seventh time on this PR that a guarantee stayed while the load moved.
-
-    This asserts the SET, not one table, so a future proof-bearing table added
-    without guards fails here rather than shipping unguarded.
+    MIGRATION_12's body is computed from the table list, so adding a table would
+    change the bytes of an already-stamped version: fresh installs would be
+    guarded and every upgraded database silently skipped. Raised by Sparring,
+    who noted the original test built a fresh database and therefore passed in
+    both worlds.
     """
-    from sovereign_agent.database import PROOF_TABLES
+    import sovereign_agent.database as database_module
+    from sovereign_agent.database import APPEND_ONLY_TABLES
 
-    db = Database(tmp_path / "guards.db")
+    def guards(db: Database, table: str) -> set[str]:
+        return {
+            str(row["name"])
+            for row in db.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?",
+                (table,),
+            )
+        }
+
+    fresh = Database(tmp_path / "fresh.db")
     try:
-        for table in PROOF_TABLES:
-            triggers = {
-                str(row["name"])
-                for row in db.connection.execute(
-                    "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?",
-                    (table,),
-                )
-            }
-            assert triggers == {
+        for table in APPEND_ONLY_TABLES:
+            assert guards(fresh, table) == {
                 f"{table}_no_update",
                 f"{table}_no_delete",
                 f"{table}_no_replace",
-            }, f"{table} carries proof but is not append-only: {sorted(triggers)}"
+            }, f"{table} is listed append-only but is unguarded on a fresh database"
+    finally:
+        fresh.close()
+
+    # Build a database stamped up to the version BEFORE the guards, then upgrade.
+    path = tmp_path / "upgraded.db"
+    connection = sqlite3.connect(path)
+    for version, script in database_module.MIGRATIONS:
+        if version >= 12:
+            break
+        for statement in database_module._split_statements(script):  # noqa: SLF001
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, datetime('now'))",
+            (version,),
+        )
+    connection.commit()
+    connection.close()
+
+    upgraded = Database(path)
+    try:
+        for table in APPEND_ONLY_TABLES:
+            assert guards(upgraded, table) == {
+                f"{table}_no_update",
+                f"{table}_no_delete",
+                f"{table}_no_replace",
+            }, f"{table} is unguarded after an UPGRADE; the guards only reach new installs"
+    finally:
+        upgraded.close()
+
+
+def test_receipts_are_deliberately_not_append_only(tmp_path: Path) -> None:
+    """Absence from the list must be a decision, not an oversight.
+
+    `put_serialized` rewrites a receipt in place while an assignment runs, so
+    receipts cannot be append-only. Acceptance guards them differently, by
+    requiring the canonical record and the indexed columns to agree.
+    """
+    from sovereign_agent.database import APPEND_ONLY_TABLES
+
+    assert "receipts" not in APPEND_ONLY_TABLES
+    db = Database(tmp_path / "receipts.db")
+    try:
+        triggers = db.connection.execute(
+            "SELECT COUNT(*) AS c FROM sqlite_master WHERE type = 'trigger' "
+            "AND tbl_name = 'receipts'"
+        ).fetchone()
+        assert int(triggers["c"]) == 0
     finally:
         db.close()
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,185 @@
+"""Transactions, migrations, and append-only enforcement.
+
+These prove properties of the DATABASE, not of Python politeness. A rule that
+lives only in a convention is a rule that a tired contributor removes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import reference_organizations.store as store
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.database import MIGRATION_1, MIGRATIONS, Database
+from sovereign_agent.organization import Organization
+
+
+def store_state(org: Organization) -> tuple[int, int, int]:
+    on_hand = int(
+        org.db.connection.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'").fetchone()[
+            "on_hand"
+        ]
+    )
+    events = int(
+        org.db.connection.execute(
+            "SELECT COUNT(*) AS c FROM events WHERE kind = 'replenishment.committed'"
+        ).fetchone()["c"]
+    )
+    purchases = int(
+        org.db.connection.execute(
+            "SELECT COUNT(*) AS c FROM cash_entries WHERE amount_cents < 0"
+        ).fetchone()["c"]
+    )
+    return on_hand, events, purchases
+
+
+def test_rollback_after_inventory_write_leaves_nothing_behind(tmp_path: Path) -> None:
+    """Fail AFTER the inventory UPDATE but before the event commits."""
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    before = store_state(org)
+    with patch.object(store, "append_event", side_effect=RuntimeError("injected failure")):
+        with pytest.raises(RuntimeError, match="injected failure"):
+            apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_fault", signal.id)
+    assert store_state(org) == before, "partial business mutation survived a rollback"
+
+
+def test_rollback_leaves_no_orphan_cash_entry(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    with patch.object(store, "append_event", side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError):
+            apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_fault", signal.id)
+    row = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM cash_entries WHERE amount_cents < 0"
+    ).fetchone()
+    assert row["c"] == 0
+
+
+def test_successful_sale_and_replenishment_keep_cash_reconciled(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    assert store.cash_balance_cents(org.db) == 10_800
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_ok", signal.id)
+    # 10000 opening + 800 sale - (6 * 120) purchase
+    assert store.cash_balance_cents(org.db) == 10_080
+
+
+def test_inventory_never_goes_negative(tmp_path: Path) -> None:
+    from sovereign_agent.errors import Refusal
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    with pytest.raises(Refusal, match="negative"):
+        record_sale(org.db, "SKU-TEA", 99, 400)
+
+
+def test_events_reject_update_and_delete(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    for statement in (
+        "UPDATE events SET kind = 'TAMPERED'",
+        "DELETE FROM events",
+    ):
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            org.db.connection.execute(statement)
+        org.db.connection.rollback()
+
+
+def test_insert_or_replace_cannot_bypass_the_append_only_guard(tmp_path: Path) -> None:
+    """Without PRAGMA recursive_triggers, REPLACE deletes a row silently.
+
+    SQLite does not fire BEFORE DELETE triggers for the implicit delete inside
+    INSERT OR REPLACE unless recursive triggers are on. A guard that misses this
+    is decorative.
+    """
+    org = Organization.init(tmp_path)
+    row = org.db.connection.execute("SELECT id, kind FROM events LIMIT 1").fetchone()
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        org.db.connection.execute(
+            "INSERT OR REPLACE INTO events(id, kind, payload, created_at) "
+            "VALUES (?, 'SNEAKY', '{}', 't')",
+            (row["id"],),
+        )
+    org.db.connection.rollback()
+    after = org.db.connection.execute(
+        "SELECT kind FROM events WHERE id = ?", (row["id"],)
+    ).fetchone()
+    assert after["kind"] == row["kind"]
+
+
+def test_fresh_database_applies_every_migration(tmp_path: Path) -> None:
+    db = Database(tmp_path / "fresh.db")
+    assert db.applied_versions() == {version for version, _ in MIGRATIONS}
+    triggers = {
+        row["name"]
+        for row in db.connection.execute("SELECT name FROM sqlite_master WHERE type = 'trigger'")
+    }
+    assert {"events_no_update", "events_no_delete"} <= triggers
+
+
+def test_upgrade_from_prior_schema_preserves_data(tmp_path: Path) -> None:
+    """A database released at version 1 upgrades forward without losing rows."""
+    path = tmp_path / "legacy.db"
+    legacy = sqlite3.connect(path)
+    legacy.executescript(MIGRATION_1)
+    legacy.execute("INSERT INTO schema_migrations(version, applied_at) VALUES (1, datetime('now'))")
+    legacy.execute(
+        "INSERT INTO events(id, kind, payload, created_at) "
+        "VALUES ('evt_legacy', 'legacy.kind', '{}', '2026-01-01T00:00:00Z')"
+    )
+    legacy.commit()
+    legacy.close()
+
+    db = Database(path)
+    assert db.applied_versions() == {version for version, _ in MIGRATIONS}
+    row = db.connection.execute(
+        "SELECT COUNT(*) AS c FROM events WHERE id = 'evt_legacy'"
+    ).fetchone()
+    assert row["c"] == 1, "the upgrade destroyed pre-existing history"
+    columns = {row[1] for row in db.connection.execute("PRAGMA table_info(evidence)")}
+    assert {"outcome_id", "check_id", "success", "state_digest"} <= columns
+
+
+def test_reopening_does_not_reapply_migrations(tmp_path: Path) -> None:
+    """migrate() runs on every open, so it must be a no-op once applied."""
+    path = tmp_path / "twice.db"
+    first = Database(path)
+    stamps = first.connection.execute(
+        "SELECT version, applied_at FROM schema_migrations ORDER BY version"
+    ).fetchall()
+    second = Database(path)
+    again = second.connection.execute(
+        "SELECT version, applied_at FROM schema_migrations ORDER BY version"
+    ).fetchall()
+    assert [tuple(row) for row in stamps] == [tuple(row) for row in again]
+    triggers = {
+        row["name"]
+        for row in second.connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+        )
+    }
+    assert {"events_no_update", "events_no_delete"} <= triggers
+
+
+def test_migrations_are_forward_only_and_ordered() -> None:
+    versions = [version for version, _ in MIGRATIONS]
+    assert versions == sorted(versions), "migrations must apply in ascending order"
+    assert len(set(versions)) == len(versions), "duplicate migration version"
+
+
+def test_signal_is_recorded_with_the_sale(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    row = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM signals WHERE id = ?", (signal.id,)
+    ).fetchone()
+    assert row["c"] == 1

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -400,3 +400,70 @@ def test_a_migration_that_cannot_preserve_the_ledger_refuses_to_run(tmp_path: Pa
         ).fetchone(), "the original table was dropped despite the failure"
     finally:
         inspector.close()
+
+
+def test_every_proof_bearing_table_is_append_only(tmp_path: Path) -> None:
+    """The guarantee must sit where the load is, and stay there.
+
+    Append-only was added to `events` because acceptance rested on events. It
+    then came to rest on `effects`, `verifications`, `reviews` and `evidence` —
+    and the guards stayed put. An outside INSERT into `effects` flipped a
+    correctly-refused outcome to ACCEPTED. Raised by Sparring, who counted it as
+    the seventh time on this PR that a guarantee stayed while the load moved.
+
+    This asserts the SET, not one table, so a future proof-bearing table added
+    without guards fails here rather than shipping unguarded.
+    """
+    from sovereign_agent.database import PROOF_TABLES
+
+    db = Database(tmp_path / "guards.db")
+    try:
+        for table in PROOF_TABLES:
+            triggers = {
+                str(row["name"])
+                for row in db.connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?",
+                    (table,),
+                )
+            }
+            assert triggers == {
+                f"{table}_no_update",
+                f"{table}_no_delete",
+                f"{table}_no_replace",
+            }, f"{table} carries proof but is not append-only: {sorted(triggers)}"
+    finally:
+        db.close()
+
+
+def test_a_forged_effect_cannot_be_inserted_from_outside(tmp_path: Path) -> None:
+    """The concrete attack: re-attributing an effect to credit idle work."""
+    from sovereign_agent.models import Role
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "t", "d", ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA"
+    )
+    org.activate(outcome.id, "master-course")
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    sow = org.create_sow(outcome.id, "w", Role.OPERATOR, "master-course", "replenishment")
+    org.ready_sow(sow.id)
+    assignment = org.run_assignment(org.assign(sow.id, "operator-course", "master-course").id)
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment.id, signal.id)
+    org.db.close()
+
+    outsider = sqlite3.connect(tmp_path / ".sovereign" / "organization.db")
+    outsider.row_factory = sqlite3.Row
+    try:
+        row = outsider.execute("SELECT id FROM effects LIMIT 1").fetchone()
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            outsider.execute(
+                "UPDATE effects SET assignment_id = 'asg_FORGED' WHERE id = ?", (row["id"],)
+            )
+            outsider.commit()
+        outsider.rollback()
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            outsider.execute("DELETE FROM effects WHERE id = ?", (row["id"],))
+            outsider.commit()
+    finally:
+        outsider.close()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -257,3 +257,52 @@ def test_append_only_holds_from_a_connection_without_the_pragma(tmp_path: Path) 
         assert surviving["kind"] == original_kind
     finally:
         outsider.close()
+
+
+def test_a_failed_migration_rolls_back_schema_and_stamp(tmp_path: Path) -> None:
+    """A migration that fails part way through must leave nothing behind.
+
+    `executescript()` COMMITs any open transaction before running, so the first
+    version of this code left a half-created schema behind, unstamped, and
+    reopening re-ran the migration and failed forever. Reported on PR #24.
+    """
+    import sovereign_agent.database as database_module
+
+    path = tmp_path / "broken.db"
+    broken = "CREATE TABLE partial_survivor (id TEXT);\nTHIS IS INVALID SQL;\n"
+    original = database_module.MIGRATIONS
+    database_module.MIGRATIONS = original + ((99, broken),)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            Database(path)
+    finally:
+        database_module.MIGRATIONS = original
+
+    inspector = sqlite3.connect(path)
+    try:
+        leaked = inspector.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='partial_survivor'"
+        ).fetchall()
+        assert leaked == [], "a failed migration left schema behind"
+        stamped = [
+            int(row[0]) for row in inspector.execute("SELECT version FROM schema_migrations")
+        ]
+        assert 99 not in stamped, "a failed migration was stamped as applied"
+        assert sorted(stamped) == [version for version, _ in original]
+    finally:
+        inspector.close()
+
+    # The database must still be openable afterwards.
+    recovered = Database(path)
+    assert recovered.applied_versions() == {version for version, _ in original}
+    recovered.close()
+
+
+def test_migration_statement_splitting_keeps_trigger_bodies_intact() -> None:
+    """Trigger bodies contain semicolons; splitting must not cut them in half."""
+    from sovereign_agent.database import MIGRATION_3, _split_statements
+
+    statements = _split_statements(MIGRATION_3)
+    assert len(statements) == 1
+    assert statements[0].startswith("CREATE TRIGGER")
+    assert statements[0].rstrip().endswith("END;")

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -37,37 +37,34 @@ def store_state(org: Organization) -> tuple[int, int, int]:
     return on_hand, events, purchases
 
 
-def test_rollback_after_inventory_write_leaves_nothing_behind(tmp_path: Path) -> None:
+def test_rollback_after_inventory_write_leaves_nothing_behind(tmp_path: Path, governed) -> None:
     """Fail AFTER the inventory UPDATE but before the event commits."""
-    org = Organization.init(tmp_path)
-    seed(org.db)
+    org, _outcome_id, _sow_id, assignment_id = governed
     signal = record_sale(org.db, "SKU-TEA", 2, 400)
     before = store_state(org)
     with patch.object(store, "append_event", side_effect=RuntimeError("injected failure")):
         with pytest.raises(RuntimeError, match="injected failure"):
-            apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_fault", signal.id)
+            apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
     assert store_state(org) == before, "partial business mutation survived a rollback"
 
 
-def test_rollback_leaves_no_orphan_cash_entry(tmp_path: Path) -> None:
-    org = Organization.init(tmp_path)
-    seed(org.db)
+def test_rollback_leaves_no_orphan_cash_entry(tmp_path: Path, governed) -> None:
+    org, _outcome_id, _sow_id, assignment_id = governed
     signal = record_sale(org.db, "SKU-TEA", 2, 400)
     with patch.object(store, "append_event", side_effect=RuntimeError("boom")):
         with pytest.raises(RuntimeError):
-            apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_fault", signal.id)
+            apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
     row = org.db.connection.execute(
         "SELECT COUNT(*) AS c FROM cash_entries WHERE amount_cents < 0"
     ).fetchone()
     assert row["c"] == 0
 
 
-def test_successful_sale_and_replenishment_keep_cash_reconciled(tmp_path: Path) -> None:
-    org = Organization.init(tmp_path)
-    seed(org.db)
+def test_successful_sale_and_replenishment_keep_cash_reconciled(tmp_path: Path, governed) -> None:
+    org, _outcome_id, _sow_id, assignment_id = governed
     signal = record_sale(org.db, "SKU-TEA", 2, 400)
     assert store.cash_balance_cents(org.db) == 10_800
-    apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_ok", signal.id)
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
     # 10000 opening + 800 sale - (6 * 120) purchase
     assert store.cash_balance_cents(org.db) == 10_080
 
@@ -194,8 +191,12 @@ def test_idempotency_is_scoped_to_assignment_and_sku(tmp_path: Path) -> None:
     """
     import json
 
-    org = Organization.init(tmp_path)
-    seed(org.db)
+    # No declared subject, so the outcome does not constrain which SKU the
+    # effect may touch. That is what lets this test exercise the (assignment,
+    # kind, subject) key across two products under one assignment.
+    from .helpers import governed_assignment
+
+    org, _outcome_id, _sow_id, assignment_id = governed_assignment(tmp_path, subject="")
     signal = record_sale(org.db, "SKU-TEA", 2, 400)
     org.db.connection.execute(
         "INSERT OR REPLACE INTO products(sku, record) VALUES ('SKU-B', ?)",
@@ -207,15 +208,15 @@ def test_idempotency_is_scoped_to_assignment_and_sku(tmp_path: Path) -> None:
     )
     org.db.connection.commit()
 
-    apply_restock(org.db, RestockProposal("SKU-B", 3), "asg_shared")
-    result = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_shared", signal.id)
+    apply_restock(org.db, RestockProposal("SKU-B", 3), assignment_id)
+    result = apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
     assert result.get("idempotent_replay") is None, "a different SKU was treated as a replay"
     row = org.db.connection.execute(
         "SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'"
     ).fetchone()
     assert int(row["on_hand"]) == 8
 
-    replay = apply_restock(org.db, RestockProposal("SKU-TEA", 6), "asg_shared", signal.id)
+    replay = apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment_id, signal.id)
     assert replay.get("idempotent_replay") is True, "same assignment and SKU must still be a no-op"
 
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -516,34 +516,43 @@ def test_a_forged_effect_cannot_be_inserted_from_outside(tmp_path: Path) -> None
         outsider.close()
 
 
-def test_migration_12_content_is_frozen(tmp_path: Path) -> None:
-    """An applied migration's bytes must never change.
+def test_migration_12_content_is_frozen() -> None:
+    """An applied migration's BYTES must never change — not just its table list.
 
-    MIGRATION_12 was computed from APPEND_ONLY_TABLES, so adding a table
-    tomorrow would rewrite an already-stamped version: guards for new installs,
-    silence for every upgraded database. Raised by Sparring as the one item
-    left, and it is this PR's recurring shape — a guarantee staying put while
-    the load moves — sitting inside the fix built to stop it.
+    The first attempt at this froze `MIGRATION_12_TABLES` and left the body
+    flowing through the shared `_append_only_triggers()` helper, so editing the
+    helper still rewrote an applied migration while this test passed. Reported
+    on PR #24 round 9, with the digest below independently computed by the
+    reviewer.
 
-    Adding a proof-bearing table means a NEW migration. This test fails if
-    version 12 is edited instead, so the rule does not depend on remembering it.
+    Fresh installs would take the new bytes; databases that already stamped 12
+    would not. Same code, two schemas.
     """
+    import hashlib
+
     from sovereign_agent.database import (
         APPEND_ONLY_TABLES,
         MIGRATION_12,
+        MIGRATION_12_SHA256,
         MIGRATION_12_TABLES,
+        MIGRATIONS,
     )
 
-    assert MIGRATION_12_TABLES == ("effects", "verifications", "reviews", "evidence"), (
-        "migration 12 has already been applied to real databases; add a NEW "
-        "migration for further tables instead of editing this one"
+    digest = hashlib.sha256(MIGRATION_12.encode()).hexdigest()
+    assert digest == MIGRATION_12_SHA256, (
+        "migration 12 has been applied to real databases; its bytes are history. "
+        "Add a NEW migration instead of editing this one."
     )
+    assert MIGRATION_12_SHA256 == (
+        "cb5483b35e4ef78d761381dc9a1ac940c59b574f7716c17c84bf9b6c89392a5e"
+    ), "the pinned digest itself was edited"
+
+    assert MIGRATION_12_TABLES == ("effects", "verifications", "reviews", "evidence")
     for table in MIGRATION_12_TABLES:
         assert f"{table}_no_update" in MIGRATION_12
 
-    # Any table listed but not covered by 12 needs its own later migration.
-    from sovereign_agent.database import MIGRATIONS
-
+    # Any append-only table not covered by 12 needs its own later migration,
+    # or existing databases never receive its triggers.
     later = set(APPEND_ONLY_TABLES) - set(MIGRATION_12_TABLES) - {"events"}
     for table in later:
         covered = any(
@@ -551,5 +560,32 @@ def test_migration_12_content_is_frozen(tmp_path: Path) -> None:
         )
         assert covered, (
             f"{table} is listed append-only but no migration after 12 guards it; "
-            "existing databases would never receive its triggers"
+            "add a NEW migration for further tables"
         )
+
+
+def test_migration_12_does_not_depend_on_the_shared_helper() -> None:
+    """Editing the helper must not be able to rewrite an applied migration.
+
+    The helper stays for building FUTURE migrations. Version 12 is a literal, so
+    this asserts the independence directly rather than trusting the reading:
+    a helper whose output changed would no longer match the frozen bytes.
+    """
+    from sovereign_agent.database import MIGRATION_12, MIGRATION_12_TABLES, _append_only_triggers
+
+    generated = "".join(_append_only_triggers(table) for table in MIGRATION_12_TABLES)
+    assert generated == MIGRATION_12, (
+        "the helper and the shipped migration have diverged. That is ALLOWED — "
+        "version 12 is frozen and the helper may evolve for future migrations — "
+        "but update this test deliberately rather than by accident."
+    )
+    import pathlib
+
+    source = pathlib.Path(__file__).resolve().parent.parent / "src/sovereign_agent/database.py"
+    body = source.read_text(encoding="utf-8")
+    assignment = body.split("MIGRATION_12 = ", 1)[1][:120]
+    assert "_append_only_triggers" not in assignment, (
+        "MIGRATION_12 is generated again; an applied migration must be a literal"
+    )
+
+

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,113 @@
+"""Governed failure must be recoverable.
+
+If `changes_requested` is terminal, the book teaches Andrea that the recovery
+from a refusal is to delete the organization and start over — the opposite of
+what Chapter 2 says refusal is for. Reported on PR #24 round 2.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.errors import Refusal
+from sovereign_agent.models import Role, SowState
+from sovereign_agent.organization import Organization
+
+
+def failing_outcome(tmp_path: Path) -> tuple[Organization, str, str, str]:
+    """A store where the work has run but the shelf was never restocked."""
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "Keep the tea jar stocked",
+        "On-hand tea stays at or above the reorder point.",
+        ["inventory_at_or_above_reorder_point"],
+        "principal-human",
+        "SKU-TEA",
+    )
+    org.activate(outcome.id, "master-course")
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    assignment = org.assign(sow.id, "operator-course", "master-course")
+    assignment = org.run_assignment(assignment.id)
+    return org, outcome.id, sow.id, signal.id
+
+
+def test_red_repair_reassign_verify_review_accept(tmp_path: Path) -> None:
+    """The whole recovery cycle, end to end."""
+    org, outcome_id, sow_id, signal_id = failing_outcome(tmp_path)
+
+    org.verify_outcome(outcome_id, "verifier-course")
+    first = org.review(sow_id, "sparring-course")
+    assert first.decision == "changes_requested"
+    assert org._sow(sow_id).state == SowState.CHANGES_REQUESTED  # noqa: SLF001
+
+    # Recovery is a NEW assignment: repaired work is new work, and the ledger
+    # should say so rather than quietly reusing the failed execution.
+    second = org.assign(sow_id, "operator-course", "master-course")
+    second = org.run_assignment(second.id)
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), second.id, signal_id)
+
+    org.verify_outcome(outcome_id, "verifier-course")
+    again = org.review(sow_id, "sparring-course")
+    assert again.decision == "accepted"
+    assert again.verification_id != first.verification_id
+
+    org.accept(outcome_id, "principal-human")
+    row = org.db.connection.execute(
+        "SELECT on_hand, reorder_point FROM inventory WHERE sku = 'SKU-TEA'"
+    ).fetchone()
+    assert int(row["on_hand"]) >= int(row["reorder_point"])
+
+
+def test_failed_evidence_does_not_poison_later_reviews(tmp_path: Path) -> None:
+    """Review reads the CURRENT batch only.
+
+    Scanning every historical evidence row meant one failed check made every
+    later review fail forever, however thoroughly the world was repaired.
+    """
+    org, outcome_id, sow_id, signal_id = failing_outcome(tmp_path)
+    org.verify_outcome(outcome_id, "verifier-course")
+    assert org.review(sow_id, "sparring-course").decision == "changes_requested"
+
+    second = org.run_assignment(org.assign(sow_id, "operator-course", "master-course").id)
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), second.id, signal_id)
+    org.verify_outcome(outcome_id, "verifier-course")
+
+    failed_rows = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM evidence WHERE success = 0"
+    ).fetchone()
+    assert int(failed_rows["c"]) > 0, "the failed evidence must still be on the record"
+    assert org.review(sow_id, "sparring-course").decision == "accepted"
+
+
+def test_acceptance_is_refused_while_changes_are_outstanding(tmp_path: Path) -> None:
+    org, outcome_id, sow_id, _signal_id = failing_outcome(tmp_path)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+    with pytest.raises(Refusal):
+        org.accept(outcome_id, "principal-human")
+
+
+def test_history_is_preserved_across_recovery(tmp_path: Path) -> None:
+    """Recovery supersedes; it never deletes."""
+    org, outcome_id, sow_id, signal_id = failing_outcome(tmp_path)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+    second = org.run_assignment(org.assign(sow_id, "operator-course", "master-course").id)
+    apply_restock(org.db, RestockProposal("SKU-TEA", 6), second.id, signal_id)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+
+    verifications = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM verifications WHERE outcome_id = ?", (outcome_id,)
+    ).fetchone()
+    reviews = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM reviews WHERE outcome_id = ?", (outcome_id,)
+    ).fetchone()
+    assert int(verifications["c"]) == 2
+    assert int(reviews["c"]) == 2, "the changes_requested review must remain on the record"

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -57,6 +57,7 @@ def test_red_repair_reassign_verify_review_accept(tmp_path: Path) -> None:
     assert again.decision == "accepted"
     assert again.verification_id != first.verification_id
 
+    org.verify_outcome_condition(outcome_id, "verifier-course")
     org.accept(outcome_id, "principal-human")
     row = org.db.connection.execute(
         "SELECT on_hand, reorder_point FROM inventory WHERE sku = 'SKU-TEA'"
@@ -109,7 +110,9 @@ def test_history_is_preserved_across_recovery(tmp_path: Path) -> None:
     reviews = org.db.connection.execute(
         "SELECT COUNT(*) AS c FROM reviews WHERE outcome_id = ?", (outcome_id,)
     ).fetchone()
-    assert int(verifications["c"]) == 2
+    # Two SOW batches plus any outcome-level observations; the point is that the
+    # first, failing batch is still there.
+    assert int(verifications["c"]) >= 2
     assert int(reviews["c"]) == 2, "the changes_requested review must remain on the record"
 
 

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -135,3 +135,22 @@ def test_recovery_does_not_leave_an_orphan_assignment(tmp_path: Path) -> None:
     assert after == recovery.id != before
     record = org._assignment(after)  # noqa: SLF001
     assert record.state.value == "COMPLETED", "the bound execution must have actually run"
+
+
+def test_assigning_an_already_assigned_sow_is_refused(tmp_path: Path) -> None:
+    """A double-click must not create an execution that can never run."""
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "t", "d", ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA"
+    )
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, "s", Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    org.assign(sow.id, "operator-course", "master-course")
+
+    with pytest.raises(Refusal, match="cannot be assigned"):
+        org.assign(sow.id, "operator-course", "master-course")
+
+    row = org.db.connection.execute("SELECT COUNT(*) AS c FROM assignments").fetchone()
+    assert int(row["c"]) == 1

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -111,3 +111,27 @@ def test_history_is_preserved_across_recovery(tmp_path: Path) -> None:
     ).fetchone()
     assert int(verifications["c"]) == 2
     assert int(reviews["c"]) == 2, "the changes_requested review must remain on the record"
+
+
+def test_recovery_does_not_leave_an_orphan_assignment(tmp_path: Path) -> None:
+    """A partially-succeeding recovery would manufacture a false identity.
+
+    Raised by Sparring: `assign()` on a CHANGES_REQUESTED SOW used to succeed,
+    write an assignment row, and NOT advance the state — so `run_assignment`
+    then failed and left an orphan that had never run. `_latest_assignment_id`
+    picks the most recent assignment, so the orphan immediately became the
+    identity evidence and receipts bound to.
+    """
+    org, outcome_id, sow_id, _signal_id = failing_outcome(tmp_path)
+    org.verify_outcome(outcome_id, "verifier-course")
+    org.review(sow_id, "sparring-course")
+    before = org._latest_assignment_id(outcome_id)  # noqa: SLF001
+
+    recovery = org.assign(sow_id, "operator-course", "master-course")
+    assert org._sow(sow_id).state == SowState.ASSIGNED  # noqa: SLF001
+    org.run_assignment(recovery.id)
+
+    after = org._latest_assignment_id(outcome_id)  # noqa: SLF001
+    assert after == recovery.id != before
+    record = org._assignment(after)  # noqa: SLF001
+    assert record.state.value == "COMPLETED", "the bound execution must have actually run"

--- a/tests/test_verifier_scripts.py
+++ b/tests/test_verifier_scripts.py
@@ -1,0 +1,125 @@
+"""The verifiers must be able to FAIL, and must not repair while verifying.
+
+A verifier that only ever passes tells you nothing. A verifier that edits the
+thing it is checking tells you something false. Both were true on PR #24.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from reference_organizations.store.demo import run_simulated
+from sovereign_agent.organization import Organization
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERIFY_OUTCOME = REPO_ROOT / "scripts" / "verify_store_outcome.py"
+VERIFY_PROJECTIONS = REPO_ROOT / "scripts" / "verify_projections.py"
+
+
+def run_script(script: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, str(script), *arguments], capture_output=True, text=True, cwd=REPO_ROOT
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    run_simulated(tmp_path)
+    return tmp_path
+
+
+def test_verifier_passes_a_truthful_store(store: Path) -> None:
+    result = run_script(VERIFY_OUTCOME, str(store))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ACCEPTED and true" in result.stdout
+
+
+def test_verifier_fails_closed_on_an_empty_subject(store: Path) -> None:
+    """`outcome.subject or SKU` silently re-pointed a subjectless outcome at tea."""
+    org = Organization(store)
+    org.db.connection.execute("UPDATE outcomes SET record = json_set(record, '$.subject', '')")
+    org.db.connection.commit()
+    org.db.close()
+    result = run_script(VERIFY_OUTCOME, str(store))
+    assert result.returncode == 1
+    assert "declares no subject" in result.stdout
+
+
+def test_verifier_requires_a_review_record(store: Path) -> None:
+    org = Organization(store)
+    org.db.connection.execute("DELETE FROM reviews")
+    org.db.connection.commit()
+    org.db.close()
+    result = run_script(VERIFY_OUTCOME, str(store))
+    assert result.returncode == 1
+    assert "no review record" in result.stdout
+
+
+def test_verifier_requires_the_receipt_digest_sidecar(store: Path) -> None:
+    """Checking the sidecar only when present made deleting it a non-event."""
+    for sidecar in store.rglob("receipt.json.sha256"):
+        sidecar.unlink()
+    result = run_script(VERIFY_OUTCOME, str(store))
+    assert result.returncode == 1
+    assert "receipt.json.sha256 is missing" in result.stdout
+
+
+def test_verifier_detects_a_receipt_whose_column_and_record_disagree(store: Path) -> None:
+    org = Organization(store)
+    org.db.connection.execute("UPDATE receipts SET status = 'failed'")
+    org.db.connection.commit()
+    org.db.close()
+    result = run_script(VERIFY_OUTCOME, str(store))
+    assert result.returncode == 1
+    assert "column says failed" in result.stdout
+
+
+def test_verifier_compares_every_projected_file(store: Path) -> None:
+    """It previously compared only `state`, so a falsified SOW scope passed."""
+    sow_path = next((store / "governance" / "outcomes").glob("*/sows/*.json"))
+    record = json.loads(sow_path.read_text(encoding="utf-8"))
+    record["scope"] = "HAND EDITED FALSE SCOPE"
+    sow_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+    result = run_script(VERIFY_OUTCOME, str(store))
+    assert result.returncode == 1
+    assert "does not match the ledger" in result.stdout
+
+
+def test_projection_verification_is_pure(store: Path) -> None:
+    """Verification must REPORT drift, never silently repair it."""
+    sow_path = next((store / "governance" / "outcomes").glob("*/sows/*.json"))
+    record = json.loads(sow_path.read_text(encoding="utf-8"))
+    record["scope"] = "HAND EDITED FALSE SCOPE"
+    tampered = json.dumps(record, indent=2)
+    sow_path.write_text(tampered, encoding="utf-8")
+
+    result = run_script(VERIFY_PROJECTIONS, str(store))
+    assert result.returncode == 1
+    assert "does not match the ledger" in result.stdout
+    assert sow_path.read_text(encoding="utf-8") == tampered, "verification rewrote the file"
+
+
+def test_reconcile_repairs_only_when_asked(store: Path) -> None:
+    sow_path = next((store / "governance" / "outcomes").glob("*/sows/*.json"))
+    record = json.loads(sow_path.read_text(encoding="utf-8"))
+    record["scope"] = "HAND EDITED FALSE SCOPE"
+    sow_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+
+    repaired = run_script(VERIFY_PROJECTIONS, str(store), "--reconcile")
+    assert repaired.returncode == 0
+    assert "reconciled" in repaired.stdout
+    assert run_script(VERIFY_PROJECTIONS, str(store)).returncode == 0
+    assert "HAND EDITED" not in sow_path.read_text(encoding="utf-8")
+
+
+def test_projection_verification_detects_an_extra_sow_file(store: Path) -> None:
+    directory = next((store / "governance" / "outcomes").glob("*")) / "sows"
+    (directory / "sow_GHOST.json").write_text('{"id": "sow_GHOST"}', encoding="utf-8")
+    result = run_script(VERIFY_PROJECTIONS, str(store))
+    assert result.returncode == 1
+    assert "not in the ledger" in result.stdout

--- a/tests/test_verifier_scripts.py
+++ b/tests/test_verifier_scripts.py
@@ -52,6 +52,10 @@ def test_verifier_fails_closed_on_an_empty_subject(store: Path) -> None:
 
 def test_verifier_requires_a_review_record(store: Path) -> None:
     org = Organization(store)
+    # reviews are append-only at the database boundary; drop the guard for this
+    # one statement to test the VERIFIER, not the trigger.
+    for guard in ("update", "delete", "replace"):
+        org.db.connection.execute(f"DROP TRIGGER IF EXISTS reviews_no_{guard}")
     org.db.connection.execute("DELETE FROM reviews")
     org.db.connection.commit()
     org.db.close()

--- a/tests/test_verifier_scripts.py
+++ b/tests/test_verifier_scripts.py
@@ -57,7 +57,7 @@ def test_verifier_requires_a_review_record(store: Path) -> None:
     org.db.close()
     result = run_script(VERIFY_OUTCOME, str(store))
     assert result.returncode == 1
-    assert "no review record" in result.stdout
+    assert "has no review of its current verification" in result.stdout
 
 
 def test_verifier_requires_the_receipt_digest_sidecar(store: Path) -> None:
@@ -76,7 +76,7 @@ def test_verifier_detects_a_receipt_whose_column_and_record_disagree(store: Path
     org.db.close()
     result = run_script(VERIFY_OUTCOME, str(store))
     assert result.returncode == 1
-    assert "column says failed" in result.stdout
+    assert "receipt column and record disagree" in result.stdout
 
 
 def test_verifier_compares_every_projected_file(store: Path) -> None:


### PR DESCRIPTION
# Unit 6.5 — Cumulative Conformance and Andrea Alpha

Corrective cumulative unit. **Not Unit 7.** No workspaces, supervisor, or pulse.

## The defect this fixes

At `907c6f26`, with 59 tests, ruff, and mypy all green:

```console
$ sovereign-agent demo store --mode simulated --root /tmp/store
outcome ACCEPTED

$ sqlite3 /tmp/store/.sovereign/organization.db "SELECT sku,on_hand,reorder_point FROM inventory;"
SKU-TEA|2|3        # BELOW the reorder point
```

The shelf was empty. There was no purchase entry and no replenishment event. The
single evidence row was named `inventory_non_negative` while its exit code was
computed from `cash_balance_cents(...) >= 0` — a check named for one fact,
measuring another. `verify_outcome()` advanced a status field and executed **no
checks**. `accept()` required only a non-empty list of evidence ids, which it
never looked up: acceptance succeeded with `["evd_TOTALLY_FABRICATED"]`, a
performer who never worked, and zero SOWs.

Every governance record existed. The paperwork was perfect and the claim was
false.

## What changed

**Truthful store loop.** `apply_restock` commits inventory increase, purchasing
cash entry, signal resolution, and `replenishment.committed` in one SQLite
transaction, idempotent per `(assignment, sku)`. The provider *proposes* a
quantity; deterministic Python validates SKU existence, bounds, and cash, and
reads unit cost from the product record. `RestockProposal` carries no price
field, so there is no number a provider can inflate.

**Real verification.** Every declared check executes through an explicit
registry. Unknown, malformed, and erroring checks fail closed.

**Independent acceptance.** `accept()` **re-executes** the declared checks
against current state, then requires successful evidence for every declared
check, bound to this outcome and execution, whose state digest still matches.
`performer_id`, `--performer`, `--evidence`, and the `subject` parameter are all
**removed** — performers are derived from assignments in the ledger.

**Append-only at the schema level.** Triggers refuse `UPDATE`, `DELETE`, and an
`INSERT` whose id already exists. Forward-only numbered migrations; migration 1
byte-unchanged. Evidence gains a foreign key.

**Curriculum.** Chapters 1 and 2 written; 0 and 3 completed. Four verification
scripts, each confirmed able to **fail**.

## Truth proof

| | Before | After |
|---|---|---|
| SKU-TEA | `on_hand=2 / reorder=3` **FALSE** | `on_hand=8 / reorder=3` **TRUE** |
| Cash | `10000, +800` | `10000, +800, −720` |
| Replenishment event | none | 1 |
| Evidence | 1 row, name ≠ measurement | 3 rows, one per declared check, bound |

Mutation-proven: remove `apply_restock` and the system **refuses acceptance**.

## Falsification

Acceptance is refused when inventory is below reorder point, evidence is
missing, failed, unrelated, unbound, stale, or fabricated (blocked by FK at the
database), when SOWs are open, when operator and approver are the same, when the
provider report is malformed, and when the transaction rolls back. 103 tests, up
from 59.

## Reviewed

Sparring **withheld co-sign twice** and was right both times — first on an
event-seq staleness watermark that could not detect a silent `UPDATE`, then on
`INSERT OR REPLACE` defeating append-only from a plain `sqlite3` shell (the tool
Chapter 1 teaches) while the verifier still reported "ACCEPTED and true". Both
reproduced and fixed. **CO-SIGN at `65cca0e`.**

I found three more attacking my own fix, most seriously that I had reintroduced
this unit's defect by letting the caller choose the `subject` — accepting a tea
outcome against a well-stocked decoy while the real shelf sat at zero.

## Known limits, named rather than hidden

- `outcomes` has no triggers. Raw database write access can retarget
  `outcome.subject` and make all three checks pass coherently. Recorded in
  `docs/persistence-boundary.md`; the durable fix (binding subject into the
  evidence digest) is identified as the next step and **not claimed as done**.
- SQLite and the filesystem cannot be written in one transaction. Governance
  projections may lag the ledger. The ledger is authoritative.

## Not claimed

**The credentialed provider smokes have not run.** They remain a Unit 12 gate.
All three CLIs are installed locally — installed is not authenticated. The 9
deselected tests are exactly those smokes, gated behind an env var; the default
suite passes with API keys unset.

## Verification

Full gate passes from a **clean checkout**: pytest (103), ruff format, ruff
check, mypy, runtime deps, source budget (23/40 modules, 2661/6000 lines),
curriculum, doctor, demo, `verify_store_outcome`, `verify_projections`,
`evaluate_andrea_alpha`.

CI now asserts the outcome is **true** rather than that the demo exits 0, fails
the build if an emptied shelf still verifies, and checks append-only from its
own connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns
