### PR TITLE
Acceptance remediation for Units 0-6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
           cache: pip
       - name: Install package and development tools
         run: python -m pip install -e . --group dev
+      - name: Verify the lockfile matches pyproject
+        # A dependency group added to pyproject but never locked installs fine
+        # for whoever ran `uv run` locally and fails for everyone else.
+        run: |
+          python -m pip install --upgrade uv
+          uv lock --check
       - name: Format
         run: ruff format --check src tests scripts book
       - name: Lint

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,14 +6,19 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least privilege at the top level: a PR build only reads the repository.
+# The deploy job elevates for itself.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
+# Scoped PER REF, not globally. A single `group: pages` serialised EVERY
+# Documentation run behind the last one, so turning the build on for pull
+# requests put PR builds in the deploy queue -- and a run for a superseded SHA
+# sat queued for forty minutes, blocking the check the merge was waiting on.
+# Making a gate run more often must not make it run later.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -43,6 +48,15 @@ jobs:
     # broken docs build would first appear after the merge that caused it -- a
     # gate that cannot run on the change it gates.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Only the deploy needs Pages rights, and only it serialises on the single
+    # Pages deployment.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Documentation
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -21,20 +22,27 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
       - name: Install package and documentation tools
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e . --group dev
+          python -m pip install -e . --group docs
       - name: Build documentation
         run: mkdocs build --strict
       - uses: actions/configure-pages@v5
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           path: site
 
   deploy:
+    # Build runs on every PR so a docs break is caught BEFORE merge; deploying
+    # is main-only. The previous workflow ran on pushes to main alone, so a
+    # broken docs build would first appear after the merge that caused it -- a
+    # gate that cannot run on the change it gates.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/book/ch00_first_shift.md
+++ b/docs/book/ch00_first_shift.md
@@ -156,4 +156,4 @@ observations above — the answers are all visible in the database.
 
 `solution.py` imports the production demo rather than copying it.
 
-Next: [Chapter 1 — The organization remembers](../ch01_organization_remembers/README.md)
+Next: [Chapter 1 — The organization remembers](ch01_organization_remembers.md)

--- a/docs/book/ch01_organization_remembers.md
+++ b/docs/book/ch01_organization_remembers.md
@@ -1,0 +1,209 @@
+# Chapter 1 — The organization remembers
+
+## Learning objective
+
+Understand where a Zero-Employee Organization keeps its memory, why some of that
+memory is allowed to change and some is not, and what a transaction actually
+buys you.
+
+By the end you should be able to say, for any piece of data in this system,
+**which file or table is the authority for it** — and defend the answer.
+
+## Why memory is the first hard problem
+
+An organization that forgets cannot be held to anything. If the tea order can
+vanish because a process died halfway through, then "we ordered the tea" is a
+hope, not a fact.
+
+So the first question is not "how does the AI decide" — it is "where does the
+truth live, and what happens when the power goes out mid-sentence".
+
+## Exercise 1: look at the operational state
+
+```bash
+sovereign-agent demo store --mode simulated --root /tmp/andrea-memory
+sqlite3 /tmp/andrea-memory/.sovereign/organization.db ".tables"
+```
+
+Expected: sixteen tables listed. The ones to care about now:
+
+| Table | Holds |
+| --- | --- |
+| `inventory` | how much stock exists, and the reorder point |
+| `cash_entries` | every movement of money, as signed amounts |
+| `events` | an append-only history of what happened |
+| `signals` | durable "something needs attention" facts |
+| `schema_migrations` | which schema versions have been applied |
+
+```bash
+sqlite3 -header -column /tmp/andrea-memory/.sovereign/organization.db \
+  "SELECT * FROM inventory; SELECT id, amount_cents FROM cash_entries;"
+```
+
+Cash is a **ledger of movements**, not a single balance field. The balance is
+`SUM(amount_cents)`: `10000` opening, `+800` from the sale, `-720` for the
+purchase. Nothing overwrites a balance, so nothing can quietly lose money.
+
+## Exercise 2: prove the events are append-only
+
+The event log is the organization's memory of what it did. Try to rewrite it.
+
+```bash
+sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+  "UPDATE events SET kind='NOTHING_HAPPENED' WHERE kind='sale.committed';"
+```
+
+Expected:
+
+```text
+Error: stepping, events are append-only: update refused (19)
+```
+
+Now try deleting:
+
+```bash
+sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+  "DELETE FROM events WHERE kind='replenishment.committed';"
+```
+
+Also refused. Now try the sneaky third variant — overwriting a row instead of
+editing it:
+
+```bash
+sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+  "INSERT OR REPLACE INTO events(id,kind,payload,created_at)
+   SELECT id,'NOTHING_HAPPENED',payload,created_at FROM events LIMIT 1;"
+```
+
+Also refused: `events are append-only: replace refused`.
+
+All three are enforced by **database triggers**, not by Python being careful.
+That distinction matters: a rule enforced in application code protects you from
+bugs, but a rule enforced in the database protects you from *everything else
+that can reach the database* — including you, at 2am, with a REPL open.
+
+That third case is worth dwelling on, because getting it right took two
+attempts. The first version of this guard relied on a SQLite setting called
+`recursive_triggers`, which the application switched on when it opened the
+database. It worked perfectly — from the application. From the `sqlite3` command
+above, the one this chapter just told you to use, the overwrite **succeeded
+silently** and the row count did not change. The lesson claimed the database
+enforced the rule while the guarantee actually lived in Python.
+
+The fix is the guard you just triggered: a `BEFORE INSERT` trigger that refuses
+an id which already exists. It needs no setting, so it holds from any client.
+Enforcement now matches the claim — which is the entire subject of Chapter 2.
+
+## Exercise 3: watch a transaction roll back
+
+A restock has to change three things: inventory goes up, cash goes down, and an
+event records it. If only some of those happen, the organization is lying to
+itself.
+
+```bash
+python - <<'PY'
+import tempfile, pathlib
+from unittest.mock import patch
+import reference_organizations.store as store
+from reference_organizations.store import RestockProposal, apply_restock, record_sale, seed
+from sovereign_agent.models import Role
+from sovereign_agent.organization import Organization
+
+org = Organization.init(pathlib.Path(tempfile.mkdtemp()))
+seed(org.db)
+
+# An effect needs a real completed assignment behind it. Chapter 2 explains why.
+outcome = org.create_outcome(
+    "Keep the tea jar stocked", "stocked",
+    ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA")
+org.activate(outcome.id, "master-course")
+sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
+org.ready_sow(sow.id)
+assignment = org.run_assignment(org.assign(sow.id, "operator-course", "master-course").id)
+
+signal = record_sale(org.db, "SKU-TEA", 2, 400)
+
+def state():
+    on_hand = org.db.connection.execute(
+        "SELECT on_hand FROM inventory WHERE sku='SKU-TEA'").fetchone()["on_hand"]
+    cash = org.db.connection.execute(
+        "SELECT COUNT(*) c FROM cash_entries WHERE amount_cents<0").fetchone()["c"]
+    return f"on_hand={on_hand} purchase_entries={cash}"
+
+print("before: ", state())
+with patch.object(store, "append_event", side_effect=RuntimeError("power cut")):
+    try:
+        apply_restock(org.db, RestockProposal("SKU-TEA", 6), assignment.id, signal.id)
+    except RuntimeError as error:
+        print("failed: ", error)
+print("after:  ", state())
+PY
+```
+
+Expected: `before` and `after` are identical. The failure was injected *after*
+inventory had already been written — and the rollback took it back. Either all
+three changes happen, or none do.
+
+## Exercise 4: find the boundary between governance and operations
+
+```bash
+sovereign-agent demo store --mode simulated --root /tmp/andrea-boundary
+cat /tmp/andrea-boundary/sovereign.toml
+ls /tmp/andrea-boundary/governance/outcomes/*/
+```
+
+Two kinds of file, and they behave differently:
+
+- **`sovereign.toml`** is read every time the organization opens. Edit an actor's
+  `provider = ` line, reopen, and the change takes effect. It is *canonical*.
+- **`governance/outcomes/*/outcome.json` and `README.md`** are written and never
+  read back. Delete the whole `governance/` directory and the organization keeps
+  working perfectly. They are *projections*.
+
+Try it:
+
+```bash
+python -c "
+import shutil, sys; sys.path.insert(0,'src')
+shutil.rmtree('/tmp/andrea-boundary/governance')
+from sovereign_agent.organization import Organization
+o = Organization('/tmp/andrea-boundary')
+print(o.status_text(o.db.connection.execute('select id from outcomes').fetchone()['id']))
+"
+```
+
+It still prints the outcome. Nothing was lost, because SQLite held the truth.
+
+Markdown is one step further out: it is generated for *humans* and is never
+authoritative for anything. If it disagrees with the database, the database is
+right and the Markdown is stale.
+
+The full boundary — and the one thing this design cannot honestly promise — is
+written up in [docs/persistence-boundary.md](../persistence-boundary.md).
+Read the section titled "The limit you must not lie about".
+
+## Learner verification command
+
+```bash
+python -m pytest tests/test_persistence.py -q
+```
+
+Expected: all tests pass. They prove rollback, append-only enforcement,
+migrations applying in order, and a v1 database upgrading to v2 without losing
+its history.
+
+## Explain it back
+
+1. Cash is stored as a list of signed movements instead of one balance number.
+   Name one specific bug that choice makes impossible.
+2. The event triggers refuse `UPDATE` and `DELETE`. Why enforce that in SQLite
+   instead of just not writing such code?
+3. You delete `governance/` and nothing breaks. You delete
+   `.sovereign/organization.db` and everything is gone. Explain the difference
+   in one sentence.
+4. A restock fails after inventory is written but before the event. What does
+   the shelf look like afterwards, and why?
+5. The docs say SQLite and the filesystem cannot be updated in one transaction.
+   Describe a state the organization can end up in because of that.
+
+Next: [Chapter 2 — Work needs governance](ch02_work_needs_governance.md)

--- a/docs/book/ch02_work_needs_governance.md
+++ b/docs/book/ch02_work_needs_governance.md
@@ -206,7 +206,7 @@ database does not hold — a signature key kept outside it — which is a differ
 subject and out of scope here.
 
 So the honest statement, which
-[the ruling](../../docs/rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md)
+[the ruling](../rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md)
 records: **anyone who can write arbitrary rows can rewrite the organization's
 memory.** Everything in this chapter protects the ledger from mistakes and
 ordinary tools. Knowing exactly which door is open is worth more than believing
@@ -282,4 +282,4 @@ above, and that authority cannot be self-granted.
    accepting on. Describe the lie that would be possible if it accepted any
    review of the outcome instead.
 
-Next: [Chapter 3 — The actor is not a model](../ch03_actor_is_not_a_model/README.md)
+Next: [Chapter 3 — The actor is not a model](ch03_actor_is_not_a_model.md)

--- a/docs/book/ch03_actor_is_not_a_model.md
+++ b/docs/book/ch03_actor_is_not_a_model.md
@@ -1,0 +1,147 @@
+# Chapter 3 — The actor is not a model
+
+## Learning objective
+
+Understand why swapping the intelligence behind an actor does not change who is
+accountable — and why a provider therefore cannot approve its own work.
+
+An **actor** is a governed identity with a role and authority. A **provider**
+is an external intelligence CLI: `scripted`, `claude`, `codex`, or `cursor`.
+Changing intelligence must not silently change who may act.
+
+## Exercise
+
+1. Inspect `operator-course` in `sovereign.toml`. Record its id, role,
+   authority, and provider.
+2. Run the exercise with a provider you have installed:
+
+   ```bash
+   python book/ch03_actor_is_not_a_model/solution.py \
+     --root /tmp/andrea-ch03 --provider claude
+   ```
+
+3. Inspect the first scripted receipt under
+   `/tmp/andrea-ch03/.sovereign/runs/*/receipt.json`.
+4. Observe the governed `actor.provider_rebound` event. The Principal changes
+   the provider binding; the actor id, role, and authority remain unchanged.
+5. If the live CLI is absent or cannot prove required print/stream flags, read
+   the refusal. Installing a model does not bypass the gate.
+6. If it runs, inspect `provider_session_ref`, `provider_usage`, normalized
+   events, and the validated `.sovereign-out/report.json`.
+7. Replace `--provider claude` with `codex` or `cursor`. Cursor is an equal
+   adapter, not a documentation bridge.
+
+The provider receives one production-built assignment envelope containing the
+actor, authority, SOW, disposable workspace boundary, output paths, and exact
+`ActorReport` schema. The adapter only translates that envelope into its CLI.
+
+## Expected observations
+
+Running the exercise prints a JSON summary. The line that matters:
+
+```text
+"identity_unchanged": true
+```
+
+Before and after the rebind, `operator-course` keeps the same id, the same
+role, and the same authority list. Only `provider` changes — from `scripted`
+to `claude`, `codex`, or `cursor`.
+
+Confirm the governed record of the change:
+
+```bash
+sqlite3 /tmp/andrea-ch03/.sovereign/organization.db \
+  "SELECT kind FROM events WHERE kind = 'actor.provider_rebound';"
+```
+
+Expected: one row. Rebinding is an act the organization records, performed by an
+actor with ruling authority — not a config edit that happens quietly.
+
+If a live CLI is missing or cannot prove its required flags, you will see a
+refusal instead of a run. That is the correct outcome: capability claims come
+from probing the installed CLI, and an unprovable capability fails closed.
+
+## Why a provider cannot approve its own work
+
+The provider that proposed the restock in Chapter 0 runs *behind*
+`operator-course`. Acceptance is refused for every actor that performed work,
+and performers are derived from the assignments in the ledger — not supplied by
+the caller. So the intelligence that did the work cannot become the authority
+that blesses it, no matter which model is bound to the actor.
+
+Swap `claude` for `codex` and the governance does not move. That is the point.
+
+## Learner verification command
+
+```bash
+python -m pytest tests/test_actors_and_mailbox.py tests/test_providers.py -q
+```
+
+Expected: all pass. These prove actor identity survives a provider rebind, that
+authority cannot be self-granted, and that adapters build argument arrays rather
+than shell strings.
+
+## Isolation warning
+
+`--workspace` selects a directory; it is not a sandbox. Cursor's CLI has file
+and shell tools. Chapter 3 relies on a disposable Sovereign Agent run
+workspace, not an invented provider security guarantee. Stronger workspace
+lifecycle policies arrive in Unit 7.
+
+Codex receives `--sandbox workspace-write` when the actor has
+`write_workspace` authority because even a domain-read-only assignment must
+write its mandatory report. The live read-only smoke verifies that tracked
+domain files remain unchanged; it does not make the report directory
+unwritable.
+
+The same authority becomes Claude `--permission-mode acceptEdits` and Cursor
+`--force`, but only when those exact controls are present in the installed
+CLI's help output. These flags authorize writes inside the disposable run
+workspace; they do not expand the actor's organizational authority.
+
+## Explain it back
+
+1. Which fields stayed constant after rebinding the provider?
+2. Why is a provider session id evidence about continuity but not actor
+   identity?
+3. What should happen if a CLI exits zero but omits its terminal event or
+   `report.json`?
+4. Why may an unknown valid event be retained while malformed JSON must fail
+   the receipt?
+5. In your own words: what is the difference between an actor and a provider?
+6. `operator-course` is rebound from `scripted` to `claude`. Who is accountable
+   for the work afterwards, and how would you show that from the ledger?
+7. Why does deriving the performer from assignments — rather than accepting it
+   as an argument — matter for keeping a provider from approving itself?
+
+## Production correspondence
+
+| Textbook concept | Production responsibility |
+| --- | --- |
+| Actor id, role, authority | Governed organizational identity and policy |
+| Provider binding | Replaceable intelligence runtime |
+| Assignment envelope | Bounded work contract and output schema |
+| Disposable run directory | Isolation boundary owned by Sovereign Agent |
+| Provider session reference | Runtime continuity evidence, never identity |
+| Terminal event + report | Protocol completion plus validated work claim |
+| Receipt and SHA-256 sidecar | Canonical durable execution evidence |
+
+## Live smoke tests
+
+Default tests use faithful, redacted fixtures and fake executables. Probes are
+opt-in and submit no work:
+
+```bash
+python -m pytest -q -m live
+```
+
+Credentialed assignment smokes require a second explicit gate. They run one
+read-only and one workspace-write assignment per installed provider and may
+consume provider credits (typically a short prompt each):
+
+```bash
+SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1 python -m pytest -q -m live
+```
+
+The fixture repository is disposable, and each test proves its trunk commit
+did not move.

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -1,0 +1,35 @@
+# Sovereign Agent: the executable textbook
+
+The book grows with the implementation. Each chapter uses the production
+package; it does not copy or fork it.
+
+Read them in order. Each one takes apart something the previous chapter asked
+you to take on faith.
+
+- [Chapter 0: Andrea's first shift](ch00_first_shift.md) — run one
+  complete piece of work and learn that `ACCEPTED` is a proved claim
+- [Chapter 1: The organization remembers](ch01_organization_remembers.md) —
+  SQLite, transactions, append-only events, and what is canonical versus derived
+- [Chapter 2: Work needs governance](ch02_work_needs_governance.md) —
+  outcomes, SOWs, evidence, verification, review, and no-self-approval
+- [Chapter 3: The actor is not a model](ch03_actor_is_not_a_model.md) —
+  providers are probed CLIs; Cursor is equal to Claude and Codex
+
+## What is not here yet
+
+Pulse — the organization waking itself up — is Unit 9. Nothing in these chapters
+simulates a Pulse event, and the store demo is explicitly manually dispatched. A
+chapter that promised proactive behaviour before the code could do it would be
+the same kind of lie this book spends Chapter 2 teaching you to catch.
+
+## Every chapter contains
+
+- a concrete learning objective
+- a runnable exercise
+- expected observations
+- a learner verification command
+- an "explain it back" section
+- a `solution.py` that imports the production package
+
+Run `python scripts/verify_curriculum.py` to check that all of that is actually
+present and that the chapters' imports still work.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,152 +1,111 @@
 # Quickstart
 
-This guide verifies the installation offline, runs a deterministic agent, then
-connects a model and gives it one typed capability. You need basic Python, a
-terminal, and Python 3.13 or newer.
+Ten minutes, no API keys, no network. You will run a small organization through
+one complete piece of work and then check whether it told you the truth.
+
+You need Python **3.14 or newer** and a terminal.
 
 ## 1. Install
 
 === "macOS and Linux"
 
     ```bash
-    python3.13 -m venv .venv
+    python3.14 -m venv .venv
     source .venv/bin/activate
-    python -m pip install "sovereign-agent~=0.7.0"
+    pip install sovereign-agent
     ```
 
-=== "Windows PowerShell"
+=== "Windows"
 
     ```powershell
-    py -3.13 -m venv .venv
-    .venv\Scripts\Activate.ps1
-    python -m pip install "sovereign-agent~=0.7.0"
+    py -3.14 -m venv .venv
+    .venv\Scripts\activate
+    pip install sovereign-agent
     ```
 
-Confirm the package and local environment without credentials or network calls:
+Check the install:
 
 ```bash
-sovereign-agent version
-sovereign-agent doctor --skip-llm
-```
-
-`doctor --skip-llm` checks Python, configuration, disk space, and writable
-runtime paths. It intentionally does not require an API key.
-
-## 2. See an agent work offline
-
-The repository includes scripted model responses so you can observe the full
-planner/executor flow without spending money:
-
-```bash
-git clone https://github.com/zeroemployeeorg/sovereign-agent.git
-cd sovereign-agent
-python -m pip install -e .
-python -m examples.research_assistant.run
-```
-
-The example plans a research task, calls a deterministic lookup capability,
-writes a report, and audits that every cited paper came from the lookup result.
-The final output tells you where artifacts were written.
-
-!!! note
-    Offline examples run from a source checkout because their scripted fixtures
-    are teaching material, not part of the installed wheel.
-
-## 3. Configure a model
-
-Nebius is the default OpenAI-compatible provider:
-
-```bash
-export NEBIUS_KEY="your-key"
+sovereign-agent --version
 sovereign-agent doctor
 ```
 
-For another OpenAI-compatible provider, set the endpoint, key variable name,
-and models:
+`doctor` reports your Python and Pydantic versions and lists which provider CLIs
+you happen to have. **You do not need any of them.** The quickstart runs on the
+`scripted` provider, which is a deterministic fixture.
+
+## 2. Run one shift
 
 ```bash
-export OPENAI_API_KEY="..."
-export SOVEREIGN_AGENT_LLM_BASE_URL="https://api.openai.com/v1/"
-export SOVEREIGN_AGENT_LLM_API_KEY_ENV="OPENAI_API_KEY"
-export SOVEREIGN_AGENT_LLM_PLANNER_MODEL="gpt-4o"
-export SOVEREIGN_AGENT_LLM_EXECUTOR_MODEL="gpt-4o-mini"
+sovereign-agent demo store --mode simulated --root /tmp/andrea-shift
 ```
 
-See [Configuration and providers](how-to/configuration.md), including local
-Ollama setup. A normal `doctor` call makes one small model request.
+Expected, ending with:
 
-## 4. Give the agent a capability
-
-Create `weather_agent.py`:
-
-```python
-from pydantic import BaseModel
-from sovereign_agent import Config, run_task
-from zeo_core.contracts import CapabilityResult, EffectKind
-from zeo_core.tools import ToolContext, bound_capability_of, capability
-
-
-class WeatherQuery(BaseModel):
-    city: str
-
-
-@capability(
-    id="tutorial.weather.get@1.0.0",
-    description="Get the current weather for a city.",
-    effects={EffectKind.READ},
-)
-def get_weather(request: WeatherQuery, ctx: ToolContext) -> CapabilityResult:
-    # Replace this fixture with an API call after the flow works.
-    return CapabilityResult.ok(
-        data={"city": request.city, "temperature_c": 18, "condition": "rainy"},
-        msg="Weather fixture returned.",
-    )
-
-
-result = run_task(
-    "What is the weather in Edinburgh?",
-    config=Config.from_env(),
-    extra_capabilities=[bound_capability_of(get_weather)],
-)
-
-print(result.summary)
-print(f"Session: {result.session_id}")
-print(f"Files: {result.session_dir}")
+```text
+outcome ACCEPTED
 ```
 
-Run it:
+A customer bought tea, stock fell below the reorder point, the organization
+raised a signal, wrote a statement of work, assigned it to an operator actor
+whose provider proposed a restock, validated that proposal in ordinary Python,
+committed the purchase, verified the result, had it reviewed by a different
+actor, and accepted it.
+
+## 3. Check whether it is telling the truth
+
+This is the part that matters. `ACCEPTED` is a claim; here is how you audit it.
 
 ```bash
-python weather_agent.py
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "SELECT sku, on_hand, reorder_point FROM inventory;"
 ```
 
-The model can call only capabilities and runtime commands exposed to it. The
-description helps it choose an action; the typed request validates arguments;
-the effect classification becomes policy and evidence.
-
-## 5. Inspect the run
+Expected `SKU-TEA|8|3` — on-hand is at or above the reorder point, so the tea jar
+really is full.
 
 ```bash
-sovereign-agent sessions list
-sovereign-agent sessions show <session-id>
-sovereign-agent report <session-id> --output report.md
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "SELECT id, amount_cents FROM cash_entries;"
 ```
 
-Or inspect the files directly:
+Expected three rows: `10000` opening, `+800` for the sale, `-720` for the
+purchase. Six boxes at 120 cents is exactly 720.
+
+## 4. Break it on purpose
 
 ```bash
-ls sessions/<session-id>
-cat sessions/<session-id>/logs/trace.jsonl
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA';"
+
+sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+  "SELECT json_extract(record,'$.state') FROM outcomes;"
 ```
 
-Every run has lifecycle state, task context, workspace artifacts, tickets,
-manifests, and a JSONL trace. See
-[Sessions and traces](tutorials/sessions-and-traces.md).
+The stored state still reads `ACCEPTED`, because that records a decision that was
+made. But the shelf is empty.
 
-## What next?
+If you cloned the repository rather than installing from PyPI, the release gate
+that catches exactly this is one command:
 
-- [Build a complete first agent](tutorials/first-agent.md).
-- [Learn to author capabilities](tutorials/capabilities.md).
-- [Test an agent deterministically](tutorials/testing.md).
-- Browse all [nine examples](https://github.com/zeroemployeeorg/sovereign-agent/tree/main/examples).
-- Learn the architecture through the [five chapters](chapters/index.md).
+```bash
+python scripts/verify_store_outcome.py /tmp/andrea-shift
+```
+
+It exits non-zero and names every claim that no longer holds.
+
+An earlier version of this very demo printed `ACCEPTED` while the jar held two
+boxes against a reorder point of three. Every governance record existed and the
+shelf was still empty. That gap is what the book is about.
+
+## Where next
+
+- [The book](book/index.md) — Chapter 0 is this shift, explained.
+- [Persistence boundary](persistence-boundary.md) — what is canonical, what is
+  derived, and what this design does *not* promise.
+
+## What this version does not do
+
+The organization does not wake itself up. You ran a command and work happened.
+Proactive waking is called Pulse and it does not exist yet; nothing here
+simulates it.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,10 @@
 # Quickstart
 
-Ten minutes, no API keys, no network. You will run a small organization through
+Ten minutes and no API keys. You will run a small organization through
 one complete piece of work and then check whether it told you the truth.
 
 You need Python **3.14 or newer**, `git`, and a terminal. Nothing else — no
-API key, no network after the clone, and no database tools.
+API key, no network after installation, and no database tools.
 
 ## 1. Install
 
@@ -107,8 +107,7 @@ Read it as three separate claims:
 Change the world behind the organization's back:
 
 ```bash
-python -c "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute(\"UPDATE inventory SET on_hand=0 WHERE sku='SKU-TEA'\"); c.commit()" /tmp/andrea-shift/.sovereign/organization.db
-
+python scripts/empty_the_shelf.py /tmp/andrea-shift
 sovereign-agent inspect --root /tmp/andrea-shift
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,7 @@ API key, no network after installation, and no database tools.
     git clone https://github.com/zeroemployeeorg/sovereign-agent.git
     cd sovereign-agent
     py -3.14 -m venv .venv
-    .venv\Scripts\activate
+    .\.venv\Scripts\Activate.ps1
     pip install -e .
     ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,24 +3,36 @@
 Ten minutes, no API keys, no network. You will run a small organization through
 one complete piece of work and then check whether it told you the truth.
 
-You need Python **3.14 or newer** and a terminal.
+You need Python **3.14 or newer**, `git`, and a terminal. Nothing else — no
+API key, no network after the clone, and no database tools.
 
 ## 1. Install
+
+!!! warning "Install from the repository, not from PyPI"
+
+    PyPI still serves the **0.x** framework, which is a different product with a
+    different API and a lower Python floor. Publishing 1.x is deferred to
+    Unit 12. Until then, `pip install sovereign-agent` would give you the old
+    package while this page teaches the new one.
 
 === "macOS and Linux"
 
     ```bash
+    git clone https://github.com/zeroemployeeorg/sovereign-agent.git
+    cd sovereign-agent
     python3.14 -m venv .venv
     source .venv/bin/activate
-    pip install sovereign-agent
+    pip install -e .
     ```
 
 === "Windows"
 
     ```powershell
+    git clone https://github.com/zeroemployeeorg/sovereign-agent.git
+    cd sovereign-agent
     py -3.14 -m venv .venv
     .venv\Scripts\activate
-    pip install sovereign-agent
+    pip install -e .
     ```
 
 Check the install:
@@ -40,6 +52,11 @@ you happen to have. **You do not need any of them.** The quickstart runs on the
 sovereign-agent demo store --mode simulated --root /tmp/andrea-shift
 ```
 
+!!! note "Windows"
+
+    Use a path that exists on your machine, for example
+    `--root C:\Users\you\andrea-shift`, and substitute it below.
+
 Expected, ending with:
 
 ```text
@@ -57,36 +74,49 @@ actor, and accepted it.
 This is the part that matters. `ACCEPTED` is a claim; here is how you audit it.
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
-  "SELECT sku, on_hand, reorder_point FROM inventory;"
+sovereign-agent inspect --root /tmp/andrea-shift
 ```
 
-Expected `SKU-TEA|8|3` — on-hand is at or above the reorder point, so the tea jar
-really is full.
+Expected, in three parts:
 
-```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
-  "SELECT id, amount_cents FROM cash_entries;"
+```text
+inventory
+  OK  SKU-TEA: on_hand=8 reserved=0 reorder_point=3
+cash
+     10000  cash-opening
+       800  cash_...
+      -720  cash_...
+     10080  = balance
+events
+    ...
+    1  replenishment.committed
+    ...
 ```
 
-Expected three rows: `10000` opening, `+800` for the sale, `-720` for the
-purchase. Six boxes at 120 cents is exactly 720.
+Read it as three separate claims:
+
+- **`OK`** — available stock is at or above the reorder point. The tea jar
+  really is full. `LOW` would mean it is not, whatever the outcome says.
+- **`-720`** — money actually left the organization to buy stock. Six boxes at
+  120 cents is exactly 720, and the balance still adds up.
+- **`replenishment.committed`** — a restock is on the append-only ledger, not
+  merely implied by the inventory number.
 
 ## 4. Break it on purpose
 
-```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
-  "UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA';"
+Change the world behind the organization's back:
 
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
-  "SELECT json_extract(record,'$.state') FROM outcomes;"
+```bash
+python -c "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute(\"UPDATE inventory SET on_hand=0 WHERE sku='SKU-TEA'\"); c.commit()" /tmp/andrea-shift/.sovereign/organization.db
+
+sovereign-agent inspect --root /tmp/andrea-shift
 ```
 
-The stored state still reads `ACCEPTED`, because that records a decision that was
-made. But the shelf is empty.
+Inventory now reads `LOW`, and the outcome still reads `ACCEPTED` — because that
+records a decision that was made, while the shelf is empty.
 
-If you cloned the repository rather than installing from PyPI, the release gate
-that catches exactly this is one command:
+If you want the machine-checked version of that judgement, the repository ships
+the release gate that catches exactly this:
 
 ```bash
 python scripts/verify_store_outcome.py /tmp/andrea-shift

--- a/docs/rulings/2026-08-26-deferral-unit4-fencing.md
+++ b/docs/rulings/2026-08-26-deferral-unit4-fencing.md
@@ -1,0 +1,55 @@
+# Deferral: multi-process fencing is Unit 8, not Unit 4
+
+- **id:** `ruling-2026-08-26-deferral-unit4-fencing`
+- **decided:** 2026-08-26
+- **authority:** principal
+- **applies_to:** Unit 4 mailbox leases; Unit 8 supervisor
+- **status:** ACTIVE
+
+## What Unit 4 provides
+
+A durable addressed mailbox with claim leases. Claiming is a compare-and-set:
+`UPDATE ... WHERE state = 'NEW' OR the lease has expired`, which must affect
+exactly one row. Two **distinct** actors contending for one message produce
+exactly one winner, verified by a two-connection barrier test.
+
+## What it does not provide
+
+A second connection using the **same** actor id is granted the claim, because a
+claim already held by that actor short-circuits and returns it. That is
+actor-level idempotency — it is what makes a retried worker harmless — and it is
+**not** process-level exclusivity. Two processes hosting one actor can both
+proceed.
+
+## Holdings
+
+1. **One process may host an actor.** Running the same actor id concurrently in
+   two processes is outside the 1.x contract and is not defended against.
+2. **Fencing is deferred to Unit 8.** A fencing token — a distinct lease/attempt
+   id required at completion, so a resumed worker cannot commit under a lease it
+   no longer holds — belongs with the supervisor that owns process lifecycle.
+   Building it in Unit 4 would mean inventing process lifecycle in a unit that
+   has no supervisor to own it.
+3. **The property must not be overstated.** No document or test name may
+   describe this as "exactly one worker". What is proved is one winner among
+   *distinct contenders*.
+
+## Named limit: F-U4-1
+
+Reclaiming an expired lease works through the `inbox()` sweep, which resets an
+expired `CLAIMED` message to `NEW`. Calling `claim()` directly on your own
+expired lease hits the same-owner short-circuit and returns the stale lease
+without renewing it, so the compare-and-set's expired branch is unreachable by
+the owner.
+
+Benign under holding 1 — only the addressed recipient can reach that path, so no
+other actor can steal a lease — but it is dead code implying an intent the code
+does not have. Recorded rather than silently fixed, because the fix belongs with
+the fencing work in Unit 8.
+
+## Verification
+
+`tests/test_concurrency.py::test_only_one_contender_wins_a_contested_lease` and
+`::test_the_same_actor_from_two_processes_is_idempotent_not_exclusive`. The
+second asserts the current behaviour precisely so that a future change to it is
+visible rather than silent.

--- a/docs/rulings/2026-08-26-deferral-unit6-smokes.md
+++ b/docs/rulings/2026-08-26-deferral-unit6-smokes.md
@@ -1,0 +1,51 @@
+# Deferral: credentialed provider smokes are Unit 12
+
+- **id:** `ruling-2026-08-26-deferral-unit6-smokes`
+- **decided:** 2026-08-26
+- **authority:** principal
+- **applies_to:** Unit 6 provider adapters; Unit 12 release
+- **status:** ACTIVE
+
+## The distinction this ruling exists to keep
+
+**Installed is not authenticated.** `sovereign-agent doctor` reports Claude Code,
+Codex and Cursor as available on a machine where all three are on `PATH`. That
+establishes the executable exists and answers `--help`. It establishes nothing
+about whether a credential works, whether a real session completes, or whether a
+live provider honours the workspace boundary.
+
+Conflating the two would be the defect this line spent Unit 6.5 removing: a
+green signal standing in for a fact it does not measure.
+
+## Holdings
+
+1. **Unit 6 is accepted on offline evidence.** Adapters implement
+   `probe` / `build_invocation` / `parse_event`; invocations are `argv` arrays
+   with no shell string anywhere; capability claims come from probing the
+   installed CLI and fail closed when unprovable; fixtures are deterministic and
+   integration tests use fake executables.
+2. **The credentialed smokes have not run.** Nine tests are collected under the
+   `live` marker and deselected by default: three installed-CLI probes that
+   submit no work, and six assignment smokes (read-only and workspace-write for
+   each provider) gated behind `SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1`.
+3. **Default CI must never need a credential** or a commercial CLI. Verified by
+   running the suite with provider environment variables unset.
+4. **Nothing may report these as passing.** Not the CHANGELOG, not a chapter,
+   not a release note, not a PR description. They are a Unit 12 release gate.
+
+## Why deferred rather than run
+
+Running them requires credentials this environment does not hold, and they
+consume provider credits. A smoke that cannot be run is honestly deferred; a
+smoke reported as passing because the CLI is installed is a lie of exactly the
+kind this project teaches learners to detect.
+
+## How to run them when Unit 12 arrives
+
+```bash
+python -m pytest -q -m live                                   # probes only
+SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1 python -m pytest -q -m live  # + assignments
+```
+
+Each assignment smoke uses a disposable fixture repository and proves its trunk
+commit did not move.

--- a/docs/rulings/index.md
+++ b/docs/rulings/index.md
@@ -1,0 +1,14 @@
+# Rulings
+
+Binding decisions for the 1.x line. A ruling the code contradicts is
+worse than no ruling, so each names how to check it against the repository.
+
+- [Ruling: Sovereign Agent 1.x educational reset](2026-08-25-educational-reset.md)
+- [Ruling amendment: `main` is the 1.x educational integration line](2026-08-25-main-is-the-1x-line.md)
+- [Ruling amendment: effects are required where a SOW declares them](2026-08-26-amendment-conditional-effects.md)
+- [Deferral: multi-process fencing is Unit 8, not Unit 4](2026-08-26-deferral-unit4-fencing.md)
+- [Deferral: credentialed provider smokes are Unit 12](2026-08-26-deferral-unit6-smokes.md)
+- [Ruling: one process per actor in 1.x; lease fencing is Unit 8](2026-08-26-one-process-per-actor.md)
+- [Ruling: an outcome is a standing condition; a SOW is a unit of work](2026-08-26-outcomes-are-conditions-sows-are-work.md)
+- [Ruling: the persistence boundary, refined](2026-08-26-persistence-boundary-refinement.md)
+- [Ruling: SQLite writers are inside the trust boundary](2026-08-26-sqlite-writers-are-inside-the-boundary.md)

--- a/docs/tutorials/first-agent.md
+++ b/docs/tutorials/first-agent.md
@@ -1,5 +1,13 @@
 # Build your first agent
 
+!!! warning "Legacy — describes software removed in 1.0"
+
+    This page documents the v0.7 API (`Config`, `run_task`, `Half`, …), which
+    Sovereign Agent 1.x does not provide. It is kept for readers still pinning
+    `sovereign-agent<1`. For the current package start at the
+    [Quickstart](../quickstart.md) and [the book](../book/index.md).
+
+
 In this tutorial you will build a small agent that turns a topic into a study
 plan. The agent receives one read-only capability and writes its final answer
 into an auditable session.
@@ -15,7 +23,7 @@ python -m pip install "sovereign-agent~=0.7.0"
 sovereign-agent doctor --skip-llm
 ```
 
-Configure a model as described in the [Quickstart](../quickstart.md#3-configure-a-model).
+Configure a model as described in the [v0.7 quickstart](../quickstart.md).
 
 ## Write the agent
 

--- a/docs/units-0-6-contract.md
+++ b/docs/units-0-6-contract.md
@@ -1,0 +1,122 @@
+# Units 0–6: the contract, and how it was accepted
+
+- **status:** RATIFIED, 2026-08-26
+- **authority:** principal
+- **applies to:** Sovereign Agent 1.x, Units 0 through 6
+- **acceptance target:** `9c242828a99f469896de940878ae3bf735257800`
+
+## Why this document exists
+
+The 1.x SOW is a design memo. It records the decision, three resolved open
+questions, and seven sequencing amendments — and then says:
+
+> The full design memo lives with the originating stream.
+
+That memo is not in this repository. Every earlier line had per-unit requirement
+documents in `docs/` (`v0.3-unit1…`, `v0.4-unit1…`, `v0.5-unit1…`,
+`v0.7-unit1…`); the 1.x line had none. So an acceptance audit of Units 0–6 had
+nothing in-tree to audit against, and any verdict would have graded the code
+against its own CHANGELOG — which establishes internal consistency and never
+that a unit met a contract someone else set.
+
+**An acceptance record that points at a document not in the tree is the same
+defect this project exists to remove, one level up.** This document retires that
+external dependency. It is the contract from here on.
+
+## The contract
+
+### Unit 0 — reset and coherent published documentation
+
+Educational reset ruling; `v0.7.0` frozen at its tag; migration and removal
+records for users pinning `<1`; and **documentation that describes the software
+that exists**. A published site is part of the reset, not separate from it.
+
+### Unit 1 — the skeleton that runs
+
+Python `>=3.14`. Exactly one runtime dependency: Pydantic. An `argparse` CLI
+whose every advertised subcommand responds. A wheel that installs clean into a
+bare interpreter. `doctor`. Module, line and export budgets enforced by script.
+
+### Unit 2 — memory that does not lie
+
+Strict Pydantic records with `extra="forbid"`. Sortable ids and UTC time.
+Forward-only numbered SQLite migrations whose applied bytes are frozen.
+Append-only events, enforced by the database rather than by convention.
+Transactional store state: inventory, cash, signals.
+
+### Unit 3 — governance that refuses
+
+Outcomes, statements of work, rulings, evidence, verification, review,
+acceptance. Separation of duties and no self-approval, derived from the ledger
+rather than supplied by the caller. A canonical persistence boundary with
+generated projections and drift detection. `ACCEPTED` means the declared outcome
+is true now.
+
+### Unit 4 — actors and their mailbox
+
+Actor configuration in committed TOML. Identity separate from role and provider;
+rebinding a provider changes neither identity nor authority. Durable addressed
+mailbox with claim leases, expiry and reclaim, retry and dead-letter.
+**Multi-process fencing is deferred to Unit 8** — see the deferral record.
+
+### Unit 5 — execution that fails closed
+
+`argv`-only subprocess invocation; never a shell string. The Scripted provider
+protocol: assignment envelope in, `report.json` out. Timeouts, malformed streams,
+malformed and invalid reports, provider failure and **catchable interruption**
+must each produce a durable failed receipt and a non-running terminal state.
+Nothing is ever a guessed success. A hard kill cannot be caught and belongs to
+Unit 8 recovery: a process cannot record its own death.
+
+### Unit 6 — providers behind one boundary
+
+Claude Code, Codex and Cursor as adapters implementing `probe` /
+`build_invocation` / `parse_event`. Capability claims come from probing the
+installed CLI and fail closed when unprovable. Deterministic offline fixtures and
+fake-executable integration tests. Default CI needs no credential and no
+commercial CLI. **Credentialed smokes are deferred to Unit 12** — see the
+deferral record.
+
+## Cross-cutting
+
+**Curriculum.** Chapters and exercises for implemented behaviour land with their
+unit. Every required chapter exercise must *execute*, not merely import. Unit 10
+expands, reorganises and polishes Chapters 0–7; it is not where the book first
+becomes runnable.
+
+**Checkpoints.** Checkpoint tags name commits and are preserved in `main`'s
+ancestry. A tag whose triggering behaviour already works is owed now.
+
+## Acceptance at `9c242828`
+
+Audited read-only. Every finding below was reproduced by descent before it was
+recorded; findings that came from an agent or a reviewer were re-run rather than
+accepted.
+
+| Unit | Verdict | Grounds |
+| --- | --- | --- |
+| 0 | `CHANGES_REQUESTED` | site published a legacy curriculum whose directory and drift-tool do not exist, while `book/` was unpublished; quickstart specified Python 3.13 and three nonexistent commands; 26 of 28 documented imports did not resolve |
+| 1 | `ACCEPTED` | 12/12 subcommands respond; fresh 3.14 wheel installs and runs; runtime requires exactly `pydantic<3,>=2`; budgets 23/40 modules, 3631/6000 lines, 7/30 exports |
+| 2 | `ACCEPTED` | migrations forward-only and byte-frozen; append-only enforced from an outside connection; transactional store state with rollback proven by fault injection |
+| 3 | `ACCEPTED` | per-SOW proof chains; causal binding through the effect edge; separation derived from the ledger; falsification suite refuses every known lie |
+| 4 | `ACCEPTED_WITH_EXPLICIT_DEFERRALS` | identity, authority, leases and concurrency verified; fencing deferred to Unit 8; `F-U4-1` recorded as a named limit |
+| 5 | `CHANGES_REQUESTED` → remediated | catchable interruption left an assignment recorded `RUNNING` with no receipt; Scripted provider's own failure branches untested |
+| 6 | `CHANGES_REQUESTED` (curriculum execution) | adapters, probing and fixtures verified; Chapter 3's exercise was required but never executed; credentialed smokes deferred to Unit 12 |
+
+## Deferrals, on the record rather than as absences
+
+- [Unit 4 multi-process fencing → Unit 8](rulings/2026-08-26-deferral-unit4-fencing.md)
+- [Unit 6 credentialed provider smokes → Unit 12](rulings/2026-08-26-deferral-unit6-smokes.md)
+
+## How to check this document against the repository
+
+```bash
+python -m pytest -q
+python scripts/verify_curriculum.py
+python scripts/verify_runtime_dependencies.py
+python scripts/verify_source_budget.py
+sovereign-agent demo store --mode simulated --root /tmp/contract-check
+python scripts/verify_store_outcome.py /tmp/contract-check
+```
+
+A contract nobody can check against the code is the thing this document replaces.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,29 +56,40 @@ nav:
   - Home: index.md
   - Get started:
       - Quickstart: quickstart.md
+  - The book:
+      - Overview: book/index.md
+      - "Chapter 0: Andrea's first shift": book/ch00_first_shift.md
+      - "Chapter 1: The organization remembers": book/ch01_organization_remembers.md
+      - "Chapter 2: Work needs governance": book/ch02_work_needs_governance.md
+      - "Chapter 3: The actor is not a model": book/ch03_actor_is_not_a_model.md
+  - Concepts (1.x):
+      - Persistence boundary: persistence-boundary.md
+      - Rulings: rulings/index.md
+      - Andrea Alpha evaluation: andrea-alpha-evaluation.md
+      - Units 0-6 contract: units-0-6-contract.md
+  - Legacy (v0.7 and earlier — describes REMOVED software):
       - Configuration and providers: how-to/configuration.md
       - Common problems: how-to/troubleshooting.md
-  - Tutorials:
+  - Legacy tutorials (v0.7 — removed API):
       - Learning path: tutorials/index.md
       - Build your first agent: tutorials/first-agent.md
       - Author typed capabilities: tutorials/capabilities.md
       - Inspect sessions and traces: tutorials/sessions-and-traces.md
       - Test without tokens: tutorials/testing.md
       - Rules and human approval: tutorials/structured-and-approval.md
-      - Build from scratch: chapters/index.md
       - Teaching surface: teaching-surface.md
-  - How-to:
+  - Legacy how-to (v0.7 — removed API):
       - CLI and sessions: how-to/cli-sessions.md
       - Debug a run: how-to/debugging.md
       - Approvals and resume: how-to/approvals-and-resume.md
       - Worker isolation: how-to/worker-isolation.md
       - Deploy a service: deployment.md
-  - Concepts:
+  - Legacy concepts (v0.7):
       - Core concepts: concepts/index.md
       - Architecture: architecture.md
       - Threat model: threat-model.md
       - Non-goals: non-goals.md
-  - Reference:
+  - Legacy reference (v0.7 — removed API):
       - API overview: api_reference.md
       - Generated Python API: reference/index.md
       - API stability: API.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ Repository = "https://github.com/zeroemployeeorg/sovereign-agent"
 Issues = "https://github.com/zeroemployeeorg/sovereign-agent/issues"
 
 [dependency-groups]
+docs = [
+  "mkdocs>=1.6",
+  "mkdocs-material>=9.5",
+  "mkdocstrings[python]>=0.26",
+]
 dev = [
   "build>=1.3",
   "mypy>=1.18",

--- a/scripts/empty_the_shelf.py
+++ b/scripts/empty_the_shelf.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Set a SKU's on-hand stock to zero, behind the organization's back.
+
+The quickstart uses this to show that `ACCEPTED` records a decision that was
+made, while the world can move afterwards. It exists as a script because the
+inline one-liner it replaced used Bash quoting on a page that also gives Windows
+instructions — a command that cannot be pasted on the platform it is shown to.
+
+    python scripts/empty_the_shelf.py <organization-root> [SKU]
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    if not 2 <= len(argv) <= 3:
+        print(__doc__)
+        return 2
+    root = Path(argv[1]).resolve()
+    sku = argv[2] if len(argv) == 3 else "SKU-TEA"
+    database = root / ".sovereign" / "organization.db"
+    if not database.is_file():
+        print(f"no organization at {root}")
+        return 2
+    connection = sqlite3.connect(database)
+    try:
+        changed = connection.execute(
+            "UPDATE inventory SET on_hand = 0 WHERE sku = ?", (sku,)
+        ).rowcount
+        connection.commit()
+    finally:
+        connection.close()
+    if not changed:
+        print(f"no inventory row for {sku}")
+        return 1
+    print(f"{sku} on_hand set to 0 — now run: sovereign-agent inspect --root {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/publish_book.py
+++ b/scripts/publish_book.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Regenerate the published copies of book/ under docs/book/.
+
+book/ is the source of truth. docs/book/ is a projection for the site, exactly
+as governance Markdown is a projection of the ledger: generated, never
+hand-edited, and verified by scripts/verify_curriculum.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from verify_curriculum import BOOK, PUBLISHED, render_published  # noqa: E402
+
+
+def main() -> int:
+    out = REPO_ROOT / "docs" / "book"
+    out.mkdir(parents=True, exist_ok=True)
+    for source_rel, published_rel in PUBLISHED.items():
+        text = (BOOK / source_rel).read_text(encoding="utf-8")
+        (out / published_rel).write_text(render_published(text), encoding="utf-8")
+    print(f"published {len(PUBLISHED)} chapter page(s) into docs/book/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_curriculum.py
+++ b/scripts/verify_curriculum.py
@@ -32,10 +32,23 @@ REQUIRED_CHAPTERS = (
 )
 
 # Chapter solutions that take a root path and run the exercise end to end.
+# EVERY required chapter's exercise must EXECUTE, not merely import. ch03 was
+# required but absent here, so the gate reported "3 exercises executed" across
+# four required chapters -- a gate overstating its own coverage, which is the
+# defect this project exists to remove. It runs offline on the scripted
+# provider; no credential is needed, so nothing justified the exclusion.
 RUNNABLE = {
     "ch00_first_shift": "run_simulated",
     "ch01_organization_remembers": "observe_memory",
     "ch02_work_needs_governance": "explore_governance",
+    "ch03_actor_is_not_a_model": "run_exercise",
+}
+
+# Exercises whose entry point needs an argument beyond the root path.
+RUNNABLE_ARGS: dict[str, tuple[object, ...]] = {
+    # Offline by default: the chapter teaches provider REBINDING, and the
+    # scripted provider proves identity survives it without any credential.
+    "ch03_actor_is_not_a_model": ("scripted",),
 }
 
 REQUIRED_SECTIONS = (
@@ -108,7 +121,7 @@ def check_chapter(name: str) -> list[str]:
             else:
                 with tempfile.TemporaryDirectory() as scratch:
                     try:
-                        function(Path(scratch) / "root")
+                        function(Path(scratch) / "root", *RUNNABLE_ARGS.get(name, ()))
                     except Exception as error:  # noqa: BLE001 - broken exercise, broken chapter
                         problems.append(
                             f"{name}: {entry_point}() failed to run: "
@@ -127,8 +140,51 @@ def check_chapter(name: str) -> list[str]:
     return problems
 
 
+PUBLISHED = {
+    "README.md": "index.md",
+    "ch00_first_shift/README.md": "ch00_first_shift.md",
+    "ch01_organization_remembers/README.md": "ch01_organization_remembers.md",
+    "ch02_work_needs_governance/README.md": "ch02_work_needs_governance.md",
+    "ch03_actor_is_not_a_model/README.md": "ch03_actor_is_not_a_model.md",
+}
+
+
+def check_published_copies() -> list[str]:
+    """The site copy of a chapter must not drift from the source of truth.
+
+    Publishing book/ into docs/ creates two copies, and two copies of anything
+    is the shape of every defect this project has spent its life removing. The
+    published page is a PROJECTION of book/, so it is regenerated and compared,
+    never hand-edited -- the same rule the governance projections follow.
+    """
+    problems: list[str] = []
+    for source_rel, published_rel in PUBLISHED.items():
+        source = BOOK / source_rel
+        published = REPO_ROOT / "docs" / "book" / published_rel
+        if not published.is_file():
+            problems.append(f"docs/book/{published_rel} is missing; run scripts/publish_book.py")
+            continue
+        expected = render_published(source.read_text(encoding="utf-8"))
+        if published.read_text(encoding="utf-8") != expected:
+            problems.append(
+                f"docs/book/{published_rel} has drifted from book/{source_rel}; "
+                "regenerate with scripts/publish_book.py"
+            )
+    return problems
+
+
+def render_published(text: str) -> str:
+    """Source chapter -> published page. Pure; used to publish AND to verify."""
+    text = re.sub(r"\]\(\.\./ch(\d\d)_([a-z_]+)/README\.md\)", r"](ch\1_\2.md)", text)
+    text = re.sub(r"\]\(ch(\d\d)_([a-z_]+)/README\.md\)", r"](ch\1_\2.md)", text)
+    text = text.replace("](../../docs/", "](../")
+    text = text.replace("](../README.md)", "](index.md)")
+    return text
+
+
 def main() -> int:
     problems: list[str] = []
+    problems.extend(check_published_copies())
 
     index = BOOK / "README.md"
     if not index.is_file():

--- a/src/sovereign_agent/cli.py
+++ b/src/sovereign_agent/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from sovereign_agent import __version__
 from sovereign_agent.errors import Refusal
-from sovereign_agent.models import Role
+from sovereign_agent.models import Outcome, Role
 from sovereign_agent.organization import Organization
 from sovereign_agent.providers import PROVIDERS
 
@@ -116,6 +116,48 @@ def _status(namespace: argparse.Namespace) -> int:
     return 0
 
 
+def _inspect(namespace: argparse.Namespace) -> int:
+    """Show the operational facts a reader needs to audit an ACCEPTED claim.
+
+    Auditing an outcome should not require the `sqlite3` binary or any SQL. The
+    quickstart told a learner they needed "Python and a terminal" and then asked
+    for a database client they may not have. Checking whether the organization
+    told the truth is the central act of this book; it gets a first-class
+    command.
+    """
+    org = Organization(_root(namespace))
+    connection = org.db.connection
+    print("inventory")
+    for row in connection.execute(
+        "SELECT sku, on_hand, reserved, reorder_point FROM inventory ORDER BY sku"
+    ):
+        enough = (
+            "OK "
+            if int(row["on_hand"]) - int(row["reserved"]) >= int(row["reorder_point"])
+            else "LOW"
+        )
+        print(
+            f"  {enough} {row['sku']}: on_hand={row['on_hand']} "
+            f"reserved={row['reserved']} reorder_point={row['reorder_point']}"
+        )
+    print("cash")
+    total = 0
+    for row in connection.execute("SELECT id, amount_cents FROM cash_entries ORDER BY rowid"):
+        total += int(row["amount_cents"])
+        print(f"  {int(row['amount_cents']):>8}  {row['id']}")
+    print(f"  {total:>8}  = balance")
+    print("events")
+    for row in connection.execute(
+        "SELECT kind, COUNT(*) AS n FROM events GROUP BY kind ORDER BY kind"
+    ):
+        print(f"  {int(row['n']):>3}  {row['kind']}")
+    print("outcomes")
+    for row in connection.execute("SELECT record FROM outcomes"):
+        outcome = Outcome.model_validate_json(row["record"])
+        print(f"  {outcome.state} {outcome.id}  {outcome.title}")
+    return 0
+
+
 def _inbox(namespace: argparse.Namespace) -> int:
     for message in Organization(_root(namespace)).inbox(namespace.actor_id):
         print(f"{message.id} {message.state} {message.subject}")
@@ -215,6 +257,11 @@ def build_parser() -> argparse.ArgumentParser:
     status = subparsers.add_parser("status", parents=[shared], help="explain outcome and SOW state")
     status.add_argument("outcome_id")
     status.set_defaults(handler=_status)
+
+    inspect_parser = subparsers.add_parser(
+        "inspect", parents=[shared], help="show inventory, cash, events and outcomes"
+    )
+    inspect_parser.set_defaults(handler=_inspect)
 
     inbox = subparsers.add_parser("inbox", parents=[shared], help="list an actor's durable mailbox")
     inbox.add_argument("actor_id")

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -248,7 +248,7 @@ class Organization:
         assignment.state = AssignmentState.RUNNING
         self._save_assignment(assignment, sow, "assignment.running")
         started_at = utc_now()
-        failure: Exception | None = None
+        failure: BaseException | None = None
         try:
             receipt, report = invoke_actor(
                 worker, sow, workspace, output, assignment_id=assignment.id
@@ -269,6 +269,28 @@ class Organization:
                 worker,
                 workspace,
                 "internal_error",
+                f"{type(error).__name__}: {error}",
+                started_at,
+                assignment_id=assignment.id,
+            )
+            report = None
+            failure = error
+        except BaseException as error:
+            # KeyboardInterrupt and SystemExit are NOT Exception. They used to
+            # escape here, skipping the persistence block below and leaving the
+            # assignment recorded as RUNNING with no receipt at all -- a ledger
+            # saying work is in progress that is not. Fail-open, in a system
+            # whose whole subject is that a status must not outrun the world.
+            #
+            # An interruption is recorded like any other failure and then
+            # RE-RAISED: the caller still learns it was interrupted, and the
+            # organization no longer lies about what is running. A hard kill
+            # (SIGKILL) cannot be caught and stays Unit 8 recovery territory --
+            # a process cannot record its own death.
+            receipt = write_failed_receipt(
+                worker,
+                workspace,
+                "interrupted",
                 f"{type(error).__name__}: {error}",
                 started_at,
                 assignment_id=assignment.id,

--- a/tests/test_scripted_execution_matrix.py
+++ b/tests/test_scripted_execution_matrix.py
@@ -1,0 +1,206 @@
+"""The Scripted provider's own failure matrix.
+
+Every learner runs the Scripted provider; none of them need credentials for it.
+Yet the provider integration matrix parametrized ["claude", "codex", "cursor"]
+only, so the one provider a reader actually exercises was the one whose failure
+paths had no test. Reported in the Units 0-6 acceptance audit as F-U5-2.
+
+Every case below asserts the SAME property from a different direction: a run
+that did not succeed must leave a DURABLE FAILED RECEIPT and a non-running
+terminal state. Never a guessed success, never a silent orphan.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import sovereign_agent.organization as organization_module
+from reference_organizations.store import seed
+from sovereign_agent.errors import Refusal
+from sovereign_agent.models import AssignmentState, Role
+from sovereign_agent.organization import Organization
+
+
+def dispatched(tmp_path: Path, scope: str = "replenish") -> tuple[Organization, str]:
+    """An organization with one assignment created and ready to run."""
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "Keep the tea jar stocked",
+        "On-hand tea stays at or above the reorder point.",
+        ["inventory_at_or_above_reorder_point"],
+        "principal-human",
+        "SKU-TEA",
+    )
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, scope, Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    assignment = org.assign(sow.id, "operator-course", "master-course")
+    return org, assignment.id
+
+
+def receipts(org: Organization) -> list[dict]:
+    return [
+        json.loads(row["record"])
+        for row in org.db.connection.execute("SELECT record FROM receipts").fetchall()
+    ]
+
+
+def assert_failed_closed(org: Organization, assignment_id: str, category: str) -> None:
+    """The invariant every non-success case must satisfy."""
+    state = org._assignment(assignment_id).state  # noqa: SLF001
+    assert state is not AssignmentState.RUNNING, "left recorded as RUNNING: the ledger lies"
+    assert state in {AssignmentState.FAILED, AssignmentState.BLOCKED}
+    written = receipts(org)
+    assert written, "no durable receipt: the failure left no record"
+    assert written[-1]["status"] != "completed", "a failure was recorded as success"
+    assert written[-1]["failure_category"] == category
+    assert written[-1]["assignment_id"] == assignment_id
+
+
+# --- 1. success -------------------------------------------------------------
+
+
+def test_scripted_success_records_a_completed_receipt(tmp_path: Path) -> None:
+    org, assignment_id = dispatched(tmp_path)
+    org.run_assignment(assignment_id)
+    assert org._assignment(assignment_id).state is AssignmentState.COMPLETED  # noqa: SLF001
+    written = receipts(org)
+    assert written[-1]["status"] == "completed"
+    assert written[-1]["failure_category"] is None
+
+
+# --- 2. provider reports its own failure ------------------------------------
+
+
+def test_scripted_provider_reported_failure(tmp_path: Path) -> None:
+    """The Scripted fixture fails deliberately when its scope says so.
+
+    That branch exists in providers/scripted.py and was never asserted.
+    """
+    org, assignment_id = dispatched(tmp_path, scope="please fail this run")
+    org.run_assignment(assignment_id)
+    assert_failed_closed(org, assignment_id, "actor_reported_failure")
+
+
+# --- 3. timeout -------------------------------------------------------------
+
+
+def test_scripted_timeout_is_not_completion(tmp_path: Path) -> None:
+    org, assignment_id = dispatched(tmp_path)
+    timeout = Refusal(
+        "Provider timed out.",
+        "A hung provider must not be treated as completion.",
+        "logs",
+        "Retry.",
+        category="timeout",
+    )
+    with patch.object(organization_module, "invoke_actor", side_effect=timeout):
+        with pytest.raises(Refusal):
+            org.run_assignment(assignment_id)
+    assert_failed_closed(org, assignment_id, "timeout")
+
+
+# --- 4. catchable interruption ----------------------------------------------
+
+
+@pytest.mark.parametrize("interruption", [KeyboardInterrupt, SystemExit])
+def test_catchable_interruption_never_leaves_a_running_assignment(
+    tmp_path: Path, interruption: type[BaseException]
+) -> None:
+    """KeyboardInterrupt and SystemExit are NOT Exception.
+
+    They escaped `run_assignment` entirely, skipping the persistence block and
+    leaving the assignment recorded as RUNNING with no receipt — a ledger
+    asserting work in progress that was not. Fail-open, in the unit whose
+    subject is that a status must not outrun the world. Audit finding F-U5-1.
+
+    A hard kill (SIGKILL) is deliberately NOT covered: a process cannot record
+    its own death, and that is Unit 8 recovery territory.
+    """
+    org, assignment_id = dispatched(tmp_path)
+    with patch.object(organization_module, "invoke_actor", side_effect=interruption("stop")):
+        with pytest.raises(interruption):
+            org.run_assignment(assignment_id)
+    assert_failed_closed(org, assignment_id, "interrupted")
+
+
+# --- 5. malformed JSONL stream ----------------------------------------------
+
+
+def test_malformed_event_stream_fails_closed(tmp_path: Path) -> None:
+    org, assignment_id = dispatched(tmp_path)
+    malformed = Refusal(
+        "Provider emitted a malformed stream.",
+        "Unparseable output is not evidence of work.",
+        "provider-raw/events.jsonl",
+        "Inspect the raw stream.",
+        category="malformed_stream",
+    )
+    with patch.object(organization_module, "invoke_actor", side_effect=malformed):
+        with pytest.raises(Refusal):
+            org.run_assignment(assignment_id)
+    assert_failed_closed(org, assignment_id, "malformed_stream")
+
+
+# --- 6. malformed report (unparseable) --------------------------------------
+
+
+def test_malformed_report_is_refused(tmp_path: Path) -> None:
+    from reference_organizations.store.demo import propose_restock_from_report
+
+    bad = tmp_path / "report.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(Refusal, match="not valid JSON"):
+        propose_restock_from_report(bad, "SKU-TEA")
+
+
+# --- 7. invalid report (parses, violates the schema) ------------------------
+
+
+def test_invalid_report_fails_closed(tmp_path: Path) -> None:
+    """Valid JSON that is not a valid ActorReport is still a failure."""
+    org, assignment_id = dispatched(tmp_path)
+    invalid = Refusal(
+        "Provider report did not match the contract.",
+        "A report that violates its schema proves nothing.",
+        ".sovereign-out/report.json",
+        "Fix the provider.",
+        category="invalid_report",
+    )
+    with patch.object(organization_module, "invoke_actor", side_effect=invalid):
+        with pytest.raises(Refusal):
+            org.run_assignment(assignment_id)
+    assert_failed_closed(org, assignment_id, "invalid_report")
+
+
+# --- 8. no guessed success --------------------------------------------------
+
+
+def test_no_failure_mode_is_ever_recorded_as_success(tmp_path: Path) -> None:
+    """Sweep every category: none may yield status=completed.
+
+    This is the property the other seven cases each demonstrate once. Asserting
+    it as a set means a NEW failure path added later without a receipt fails
+    here rather than shipping as a silent success.
+    """
+    categories = [
+        "timeout",
+        "malformed_stream",
+        "invalid_report",
+        "nonzero_exit",
+        "missing_report",
+        "missing_terminal",
+        "provider_error",
+    ]
+    for category in categories:
+        org, assignment_id = dispatched(tmp_path / category)
+        refusal = Refusal("failed", "why", "where", "next", category=category)
+        with patch.object(organization_module, "invoke_actor", side_effect=refusal):
+            with pytest.raises(Refusal):
+                org.run_assignment(assignment_id)
+        assert_failed_closed(org, assignment_id, category)

--- a/tests/test_scripted_execution_matrix.py
+++ b/tests/test_scripted_execution_matrix.py
@@ -1,18 +1,26 @@
-"""The Scripted provider's own failure matrix.
+"""The Scripted provider's failure matrix, driven through the REAL code path.
 
-Every learner runs the Scripted provider; none of them need credentials for it.
-Yet the provider integration matrix parametrized ["claude", "codex", "cursor"]
-only, so the one provider a reader actually exercises was the one whose failure
-paths had no test. Reported in the Units 0-6 acceptance audit as F-U5-2.
+Every learner runs the Scripted provider and none of them need a credential for
+it, yet the provider integration matrix parametrized ["claude","codex","cursor"]
+only -- the one provider a reader actually exercises had no failure tests.
 
-Every case below asserts the SAME property from a different direction: a run
-that did not succeed must leave a DURABLE FAILED RECEIPT and a non-running
-terminal state. Never a guessed success, never a silent orphan.
+The first version of this file was worse than that gap. Five of its nine tests
+patched `invoke_actor` with an ALREADY-CLASSIFIED `Refusal`, so they asserted
+that `run_assignment` persists a refusal and never that timeout detection, JSONL
+parsing or report validation happen at all. A test named for one property while
+exercising another -- the exact defect this project exists to remove, committed
+inside the fix for it. Reported on PR #25.
+
+So every case here runs a REAL subprocess. The provider's `build_invocation` is
+pointed at a scenario script that misbehaves in one specific way; everything
+downstream -- process launch, stream capture, report parsing, receipt writing,
+state transition -- is the production path.
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -22,12 +30,106 @@ import sovereign_agent.organization as organization_module
 from reference_organizations.store import seed
 from sovereign_agent.errors import Refusal
 from sovereign_agent.models import AssignmentState, Role
-from sovereign_agent.organization import Organization
+from sovereign_agent.providers.base import InvocationSpec
+from sovereign_agent.providers.scripted import ScriptedProvider
+
+# --- scenario scripts: real programs, each misbehaving in exactly one way -----
+
+SCENARIOS: dict[str, str] = {
+    # Writes a valid completed report, like the real fixture.
+    "success": r"""
+import json, pathlib, sys
+out = pathlib.Path(sys.argv[1]); out.mkdir(parents=True, exist_ok=True)
+(out / "report.json").write_text(json.dumps({
+    "schema_version": 1, "status": "completed", "changed_artifacts": [],
+    "proposed_restock_units": 6, "proposed_checks": [], "questions": [], "notes": "ok"}))
+""",
+    # Reports its own failure honestly.
+    "provider_failure": r"""
+import json, pathlib, sys
+out = pathlib.Path(sys.argv[1]); out.mkdir(parents=True, exist_ok=True)
+(out / "report.json").write_text(json.dumps({
+    "schema_version": 1, "status": "failed", "changed_artifacts": [],
+    "questions": [], "notes": "the shelf was locked"}))
+""",
+    # Emits unparseable JSONL on stdout, then a valid report.
+    "malformed_stream": r"""
+import json, pathlib, sys
+sys.stdout.write("{this is not json\n")
+sys.stdout.write("{\"also\": \"unterminated\"\n")
+out = pathlib.Path(sys.argv[1]); out.mkdir(parents=True, exist_ok=True)
+(out / "report.json").write_text(json.dumps({
+    "schema_version": 1, "status": "completed", "changed_artifacts": [],
+    "questions": [], "notes": ""}))
+""",
+    # report.json exists but is not JSON at all.
+    "malformed_report": r"""
+import pathlib, sys
+out = pathlib.Path(sys.argv[1]); out.mkdir(parents=True, exist_ok=True)
+(out / "report.json").write_text("{not json at all")
+""",
+    # Valid JSON that violates the ActorReport contract.
+    "invalid_report": r"""
+import json, pathlib, sys
+out = pathlib.Path(sys.argv[1]); out.mkdir(parents=True, exist_ok=True)
+(out / "report.json").write_text(json.dumps({"status": "banana", "surprise": True}))
+""",
+    # Exits non-zero, writing nothing.
+    "nonzero_exit": r"""
+import sys
+sys.stderr.write("provider crashed\n")
+raise SystemExit(3)
+""",
+    # Succeeds silently but never writes the mandatory report.
+    "missing_report": r"""
+import pathlib, sys
+pathlib.Path(sys.argv[1]).mkdir(parents=True, exist_ok=True)
+""",
+    # Hangs, so the timeout must fire.
+    "hang": r"""
+import time
+time.sleep(30)
+""",
+}
 
 
-def dispatched(tmp_path: Path, scope: str = "replenish") -> tuple[Organization, str]:
-    """An organization with one assignment created and ready to run."""
-    org = Organization.init(tmp_path)
+@pytest.fixture
+def scenario(tmp_path_factory: pytest.TempPathFactory):
+    """Point the Scripted provider at a real script that misbehaves on cue."""
+    scripts = tmp_path_factory.mktemp("scenarios")
+    for name, body in SCENARIOS.items():
+        (scripts / f"{name}.py").write_text(body, encoding="utf-8")
+
+    def use(name: str, timeout: float = 60.0):
+        script = scripts / f"{name}.py"
+
+        def build(self: ScriptedProvider, request):  # noqa: ANN001
+            return InvocationSpec(
+                argv=[sys.executable, str(script), str(request.output), request.prompt],
+                cwd=request.workspace,
+            )
+
+        # invoke_actor calls run_spec(spec) with no timeout argument, so the
+        # 60s default is what production uses. Shorten it for the hang case by
+        # wrapping the real run_spec rather than replacing it -- the timeout
+        # that fires is still subprocess's, not a stub's.
+        import sovereign_agent.execution as execution_module
+
+        real_run_spec = execution_module.run_spec
+
+        def shortened(spec, timeout_seconds: float = timeout):  # noqa: ANN001
+            return real_run_spec(spec, timeout=timeout_seconds)
+
+        return (
+            patch.object(ScriptedProvider, "build_invocation", build),
+            patch.object(execution_module, "run_spec", shortened),
+        )
+
+    return use
+
+
+def dispatched(root: Path) -> tuple[organization_module.Organization, str]:
+    org = organization_module.Organization.init(root)
     seed(org.db)
     outcome = org.create_outcome(
         "Keep the tea jar stocked",
@@ -37,71 +139,71 @@ def dispatched(tmp_path: Path, scope: str = "replenish") -> tuple[Organization, 
         "SKU-TEA",
     )
     org.activate(outcome.id, "master-course")
-    sow = org.create_sow(outcome.id, scope, Role.OPERATOR, "master-course")
+    sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
     org.ready_sow(sow.id)
-    assignment = org.assign(sow.id, "operator-course", "master-course")
-    return org, assignment.id
+    return org, org.assign(sow.id, "operator-course", "master-course").id
 
 
-def receipts(org: Organization) -> list[dict]:
+def receipts(org) -> list[dict]:  # noqa: ANN001
     return [
         json.loads(row["record"])
         for row in org.db.connection.execute("SELECT record FROM receipts").fetchall()
     ]
 
 
-def assert_failed_closed(org: Organization, assignment_id: str, category: str) -> None:
-    """The invariant every non-success case must satisfy."""
+def assert_failed_closed(org, assignment_id: str, category: str | None = None) -> None:  # noqa: ANN001
+    """The invariant every non-success case must satisfy, whatever went wrong."""
     state = org._assignment(assignment_id).state  # noqa: SLF001
     assert state is not AssignmentState.RUNNING, "left recorded as RUNNING: the ledger lies"
     assert state in {AssignmentState.FAILED, AssignmentState.BLOCKED}
     written = receipts(org)
     assert written, "no durable receipt: the failure left no record"
     assert written[-1]["status"] != "completed", "a failure was recorded as success"
-    assert written[-1]["failure_category"] == category
     assert written[-1]["assignment_id"] == assignment_id
+    assert written[-1]["failure_category"], "a failure with no category"
+    if category is not None:
+        assert written[-1]["failure_category"] == category
+    return written[-1]["failure_category"]
+
+
+def run(org, assignment_id: str, patches) -> BaseException | None:  # noqa: ANN001
+    build_patch, timeout_patch = patches
+    with build_patch, timeout_patch:
+        try:
+            org.run_assignment(assignment_id)
+        except BaseException as error:  # noqa: BLE001 - the refusal IS the result
+            return error
+    return None
 
 
 # --- 1. success -------------------------------------------------------------
 
 
-def test_scripted_success_records_a_completed_receipt(tmp_path: Path) -> None:
+def test_success_records_a_completed_receipt(tmp_path: Path, scenario) -> None:  # noqa: ANN001
     org, assignment_id = dispatched(tmp_path)
-    org.run_assignment(assignment_id)
+    assert run(org, assignment_id, scenario("success")) is None
     assert org._assignment(assignment_id).state is AssignmentState.COMPLETED  # noqa: SLF001
-    written = receipts(org)
-    assert written[-1]["status"] == "completed"
-    assert written[-1]["failure_category"] is None
+    assert receipts(org)[-1]["status"] == "completed"
+    assert receipts(org)[-1]["failure_category"] is None
 
 
-# --- 2. provider reports its own failure ------------------------------------
+# --- 2. the provider reports its own failure --------------------------------
 
 
-def test_scripted_provider_reported_failure(tmp_path: Path) -> None:
-    """The Scripted fixture fails deliberately when its scope says so.
-
-    That branch exists in providers/scripted.py and was never asserted.
-    """
-    org, assignment_id = dispatched(tmp_path, scope="please fail this run")
-    org.run_assignment(assignment_id)
+def test_provider_reported_failure(tmp_path: Path, scenario) -> None:  # noqa: ANN001
+    org, assignment_id = dispatched(tmp_path)
+    run(org, assignment_id, scenario("provider_failure"))
     assert_failed_closed(org, assignment_id, "actor_reported_failure")
 
 
-# --- 3. timeout -------------------------------------------------------------
+# --- 3. timeout: a real hang, a real timeout --------------------------------
 
 
-def test_scripted_timeout_is_not_completion(tmp_path: Path) -> None:
+def test_a_hanging_provider_times_out(tmp_path: Path, scenario) -> None:  # noqa: ANN001
+    """The scenario really sleeps; run_spec's timeout really fires."""
     org, assignment_id = dispatched(tmp_path)
-    timeout = Refusal(
-        "Provider timed out.",
-        "A hung provider must not be treated as completion.",
-        "logs",
-        "Retry.",
-        category="timeout",
-    )
-    with patch.object(organization_module, "invoke_actor", side_effect=timeout):
-        with pytest.raises(Refusal):
-            org.run_assignment(assignment_id)
+    error = run(org, assignment_id, scenario("hang", timeout=1.0))
+    assert isinstance(error, Refusal)
     assert_failed_closed(org, assignment_id, "timeout")
 
 
@@ -114,13 +216,13 @@ def test_catchable_interruption_never_leaves_a_running_assignment(
 ) -> None:
     """KeyboardInterrupt and SystemExit are NOT Exception.
 
-    They escaped `run_assignment` entirely, skipping the persistence block and
-    leaving the assignment recorded as RUNNING with no receipt — a ledger
-    asserting work in progress that was not. Fail-open, in the unit whose
-    subject is that a status must not outrun the world. Audit finding F-U5-1.
+    They escaped `run_assignment`, skipped the persistence block, and left the
+    assignment recorded RUNNING with no receipt. Fail-open, in the unit whose
+    subject is that a status must not outrun the world.
 
-    A hard kill (SIGKILL) is deliberately NOT covered: a process cannot record
-    its own death, and that is Unit 8 recovery territory.
+    This one legitimately injects at the boundary: the point is what the
+    ORGANIZATION does when the interpreter interrupts it, not what a subprocess
+    emits. A hard kill stays Unit 8 -- a process cannot record its own death.
     """
     org, assignment_id = dispatched(tmp_path)
     with patch.object(organization_module, "invoke_actor", side_effect=interruption("stop")):
@@ -132,75 +234,54 @@ def test_catchable_interruption_never_leaves_a_running_assignment(
 # --- 5. malformed JSONL stream ----------------------------------------------
 
 
-def test_malformed_event_stream_fails_closed(tmp_path: Path) -> None:
+def test_malformed_event_stream_fails_closed(tmp_path: Path, scenario) -> None:  # noqa: ANN001
+    """Real unparseable lines on stdout, parsed by the real stream reader."""
     org, assignment_id = dispatched(tmp_path)
-    malformed = Refusal(
-        "Provider emitted a malformed stream.",
-        "Unparseable output is not evidence of work.",
-        "provider-raw/events.jsonl",
-        "Inspect the raw stream.",
-        category="malformed_stream",
-    )
-    with patch.object(organization_module, "invoke_actor", side_effect=malformed):
-        with pytest.raises(Refusal):
-            org.run_assignment(assignment_id)
-    assert_failed_closed(org, assignment_id, "malformed_stream")
+    run(org, assignment_id, scenario("malformed_stream"))
+    category = assert_failed_closed(org, assignment_id)
+    assert category in {"malformed_stream", "missing_terminal", "provider_error"}
 
 
-# --- 6. malformed report (unparseable) --------------------------------------
+# --- 6. malformed report (not JSON) -----------------------------------------
 
 
-def test_malformed_report_is_refused(tmp_path: Path) -> None:
-    from reference_organizations.store.demo import propose_restock_from_report
-
-    bad = tmp_path / "report.json"
-    bad.write_text("{not json", encoding="utf-8")
-    with pytest.raises(Refusal, match="not valid JSON"):
-        propose_restock_from_report(bad, "SKU-TEA")
-
-
-# --- 7. invalid report (parses, violates the schema) ------------------------
-
-
-def test_invalid_report_fails_closed(tmp_path: Path) -> None:
-    """Valid JSON that is not a valid ActorReport is still a failure."""
+def test_malformed_report_fails_closed(tmp_path: Path, scenario) -> None:  # noqa: ANN001
+    """The earlier version called a store helper and asserted no receipt at all."""
     org, assignment_id = dispatched(tmp_path)
-    invalid = Refusal(
-        "Provider report did not match the contract.",
-        "A report that violates its schema proves nothing.",
-        ".sovereign-out/report.json",
-        "Fix the provider.",
-        category="invalid_report",
-    )
-    with patch.object(organization_module, "invoke_actor", side_effect=invalid):
-        with pytest.raises(Refusal):
-            org.run_assignment(assignment_id)
+    run(org, assignment_id, scenario("malformed_report"))
+    assert_failed_closed(org, assignment_id, "invalid_report")
+
+
+# --- 7. invalid report (valid JSON, violates the contract) ------------------
+
+
+def test_invalid_report_fails_closed(tmp_path: Path, scenario) -> None:  # noqa: ANN001
+    org, assignment_id = dispatched(tmp_path)
+    run(org, assignment_id, scenario("invalid_report"))
     assert_failed_closed(org, assignment_id, "invalid_report")
 
 
 # --- 8. no guessed success --------------------------------------------------
 
 
-def test_no_failure_mode_is_ever_recorded_as_success(tmp_path: Path) -> None:
-    """Sweep every category: none may yield status=completed.
-
-    This is the property the other seven cases each demonstrate once. Asserting
-    it as a set means a NEW failure path added later without a receipt fails
-    here rather than shipping as a silent success.
-    """
-    categories = [
-        "timeout",
+@pytest.mark.parametrize(
+    "name",
+    [
+        "provider_failure",
         "malformed_stream",
+        "malformed_report",
         "invalid_report",
         "nonzero_exit",
         "missing_report",
-        "missing_terminal",
-        "provider_error",
-    ]
-    for category in categories:
-        org, assignment_id = dispatched(tmp_path / category)
-        refusal = Refusal("failed", "why", "where", "next", category=category)
-        with patch.object(organization_module, "invoke_actor", side_effect=refusal):
-            with pytest.raises(Refusal):
-                org.run_assignment(assignment_id)
-        assert_failed_closed(org, assignment_id, category)
+    ],
+)
+def test_no_failure_mode_is_ever_recorded_as_success(tmp_path: Path, scenario, name: str) -> None:  # noqa: ANN001
+    """Sweep every REAL misbehaviour: none may yield status=completed.
+
+    Parametrized over scenario scripts rather than over injected refusals, so a
+    new failure path that forgets to write a receipt fails here instead of
+    shipping as a silent success.
+    """
+    org, assignment_id = dispatched(tmp_path / name)
+    run(org, assignment_id, scenario(name))
+    assert_failed_closed(org, assignment_id)

--- a/tests/test_verifier_scripts.py
+++ b/tests/test_verifier_scripts.py
@@ -212,11 +212,20 @@ def test_inspect_reports_the_facts_a_learner_audits_with(store: Path) -> None:
     assert "replenishment.committed" in healthy, "the restock must appear on the ledger"
     assert "ACCEPTED" in healthy
 
-    # Empty the shelf behind the organization's back.
-    organization = Organization(store)
-    organization.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
-    organization.db.connection.commit()
-    organization.db.close()
+    # Empty the shelf using THE SCRIPT THE QUICKSTART TELLS THE READER TO RUN,
+    # not a private copy of its SQL. Duplicating the statement here left the
+    # script itself unguarded: turning it into a no-op kept all 191 tests green.
+    # One test now proves the exact learner sequence --
+    #     demo -> inspect OK -> empty_the_shelf.py -> inspect LOW + ACCEPTED
+    # -- so the page, the script and the command cannot drift apart.
+    emptied_result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, str(repo_root / "scripts" / "empty_the_shelf.py"), str(store)],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    assert emptied_result.returncode == 0, emptied_result.stdout + emptied_result.stderr
+    assert "on_hand set to 0" in emptied_result.stdout
 
     emptied = inspect()
     assert "LOW SKU-TEA" in emptied, "an empty shelf must read LOW"

--- a/tests/test_verifier_scripts.py
+++ b/tests/test_verifier_scripts.py
@@ -127,3 +127,41 @@ def test_projection_verification_detects_an_extra_sow_file(store: Path) -> None:
     result = run_script(VERIFY_PROJECTIONS, str(store))
     assert result.returncode == 1
     assert "not in the ledger" in result.stdout
+
+
+def test_the_published_quickstart_uses_only_commands_that_exist(tmp_path: Path) -> None:
+    """A quickstart is executable instructions, so its commands must exist.
+
+    The published quickstart told a learner to use Python 3.13 against a 3.14
+    floor and to run `version`, `sessions` and `report` -- none of which are
+    subcommands. Reported on PR #25 and #24. This pins the surface so the page
+    cannot drift back.
+    """
+    import re
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).resolve().parent.parent
+    text = (repo_root / "docs" / "quickstart.md").read_text(encoding="utf-8")
+
+    listing = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, "-m", "sovereign_agent", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    ).stdout
+    declared = set(re.search(r"\{([a-z,]+)\}", listing).group(1).split(","))
+
+    used = {
+        match.group(1) for match in re.finditer(r"^\s*sovereign-agent ([a-z][a-z-]*)", text, re.M)
+    }
+    unknown = {name for name in used if name not in declared}
+    assert not unknown, f"quickstart uses commands that do not exist: {sorted(unknown)}"
+
+    assert "3.13" not in text, "quickstart names a Python version below the package floor"
+    assert "python3.14" in text or "3.14" in text
+
+    # It must not require a database client it never told the reader to install.
+    assert not re.search(r"^\s*sqlite3 ", text, re.M), (
+        "quickstart shells out to the sqlite3 binary, which it does not declare"
+    )

--- a/tests/test_verifier_scripts.py
+++ b/tests/test_verifier_scripts.py
@@ -165,3 +165,64 @@ def test_the_published_quickstart_uses_only_commands_that_exist(tmp_path: Path) 
     assert not re.search(r"^\s*sqlite3 ", text, re.M), (
         "quickstart shells out to the sqlite3 binary, which it does not declare"
     )
+
+    # Nor may it paste shell-quoted one-liners onto a page that also gives
+    # Windows instructions: `python -c "...\"...\""` is not valid PowerShell.
+    assert not re.search(r'python -c "', text), (
+        "quickstart uses a shell-quoted one-liner; it is shown to Windows "
+        "readers too, so use a repository script instead"
+    )
+
+    # Every repository script the page tells the reader to run must exist.
+    for script in re.findall(r"(scripts/[\w_]+\.py)", text):
+        assert (repo_root / script).is_file(), f"quickstart references missing {script}"
+
+    # `pip install -e .` downloads Pydantic, so "no network after the clone"
+    # was false. The honest claim is after installation.
+    assert "no network after the clone" not in text
+
+
+def test_inspect_reports_the_facts_a_learner_audits_with(store: Path) -> None:
+    """`inspect` is the quickstart's audit step, so its output is a contract.
+
+    It was added to remove an undeclared `sqlite3` dependency and shipped with
+    only a `--help` assertion behind it: changing `_inspect` to always print
+    `OK` left all 190 tests green. Presence is not coverage — reported on PR #25
+    and the same failure, one layer down, as the matrix that named a property it
+    did not exercise.
+    """
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).resolve().parent.parent
+
+    def inspect() -> str:
+        result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            [sys.executable, "-m", "sovereign_agent", "inspect", "--root", str(store)],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        return result.stdout
+
+    healthy = inspect()
+    assert "OK  SKU-TEA" in healthy, "a stocked shelf must read OK"
+    assert "10080  = balance" in healthy, "the cash ledger must total 10080"
+    assert "replenishment.committed" in healthy, "the restock must appear on the ledger"
+    assert "ACCEPTED" in healthy
+
+    # Empty the shelf behind the organization's back.
+    organization = Organization(store)
+    organization.db.connection.execute("UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA'")
+    organization.db.connection.commit()
+    organization.db.close()
+
+    emptied = inspect()
+    assert "LOW SKU-TEA" in emptied, "an empty shelf must read LOW"
+    assert "OK  SKU-TEA" not in emptied
+    # The historical decision is still on the record: that is the whole lesson.
+    assert "ACCEPTED" in emptied, (
+        "the outcome's recorded state must survive; inspect reports the world "
+        "changing, it does not rewrite what was decided"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -80,6 +80,28 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/56/4744bcd0c82184e80c52b0ac4076c261a8ffa1f1b343ff2f6e89ce0e1cef/backrefs-8.0.tar.gz", hash = "sha256:b556cd7d36c3a3a2f256b89590b176b8eddfb73bcfaee3a3ddd84ea66d21ce50", size = 7013081, upload-time = "2026-07-26T19:54:24.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/fd/9bf53b6a6f6f519ffaac765df2f2a25e5c2fc6d32cfd2b2747099e72c911/backrefs-8.0-py310-none-any.whl", hash = "sha256:4a627b817fd2dce43b79ab48da63613340509381cd8ce0897078a0bce79a2ab8", size = 380377, upload-time = "2026-07-26T19:54:17.457Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/29/4bd7ae72a2634da00379c2b3bcc5439e7c94620235c6afea8af15229a973/backrefs-8.0-py311-none-any.whl", hash = "sha256:f0c35cf0102ba6b6070c12a492be3c1c1d3f5839529784b9a9565d6d04569a01", size = 392169, upload-time = "2026-07-26T19:54:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/29/13/232505664e8e2a0c7a2eb0c505cfade9d715538f89a5d62bc4c272968f62/backrefs-8.0-py312-none-any.whl", hash = "sha256:87f0fae8c5f207fe9f4b2887efc71d42f4900ac78faa1af08d675ef303692dc5", size = 398084, upload-time = "2026-07-26T19:54:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/69/47a3dc20abc4fa5486655fde681bd55e63211b46c886d8c02223d6468431/backrefs-8.0-py313-none-any.whl", hash = "sha256:601ce68ca12385dbda06ce264406b4c4210cf5b79fd0fd627592365c92f29a88", size = 400040, upload-time = "2026-07-26T19:54:21.194Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/e5f9b68a5b0e939a2fb933a66c20180d0c9241bf8927f7a47fa48c1675e9/backrefs-8.0-py314-none-any.whl", hash = "sha256:9ec96efa080938be92323e8e730e57718c9c88eb15ad70bbef4e1766df591408", size = 411903, upload-time = "2026-07-26T19:54:23.221Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -94,6 +116,118 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/cd/2b812ce5e888f1ce69a5350281e58aab07ae64a958ecae8912f30865718e/charset_normalizer-3.5.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:774d157f112367ff4abd29019f38f023c24e00e56edc7829c20e358a5a913ad8", size = 212318, upload-time = "2026-08-15T08:18:04.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/a6ee107430768a5334e6d63f31f148a04a1a491ef161a1ac9415a73f2fa8/charset_normalizer-3.5.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:26422d45fd13551cf564c58932f7d72b4f58b93b0fcf18c35ba6be12b46bb102", size = 224897, upload-time = "2026-08-15T08:18:05.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/35ae3f64f29d0179c35c3baefe575904df2913dde519129c7f75995a2b1d/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:09a7bba9f739468c8e78c36a75c33768e53cb1959fc638f510454c14683f00d5", size = 194848, upload-time = "2026-08-15T08:18:07.397Z" },
+    { url = "https://files.pythonhosted.org/packages/74/76/f2fc7380f056cc273a53af37f50d08ad54b2c59f61078f31432edcf1c2bd/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4c9548dc78002099910abaebc0a72ac58b7d30931869e0351c09b507dff4ece3", size = 198163, upload-time = "2026-08-15T08:18:08.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c", size = 341823, upload-time = "2026-08-15T08:18:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0", size = 242458, upload-time = "2026-08-15T08:18:11.989Z" },
+    { url = "https://files.pythonhosted.org/packages/22/95/b4618ce912e6db0b1aae89ba788e38e8a7eba0f3025cc66e8c0699f977b2/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b7430cf5728e68f6c462254009a6ef4086e1bea43cf2f57aa9c55fb4f50ff96", size = 226717, upload-time = "2026-08-15T08:18:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/c681192bbda3d55356db5dadd64381d5202b37c6b598fcda5282e88b5d3d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab743e9bc90c1f73552ec33e10e3331315acd2c397b36065b591b0181de533cc", size = 266111, upload-time = "2026-08-15T08:18:14.961Z" },
+    { url = "https://files.pythonhosted.org/packages/88/be/55127bfca72c0cff6c022488d140d7c5b04c771e3b72e9bdb4836d54979d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6f7deae3feb4edfa2efaf7c574fe88cbf055038a6abdb40188e4fff66d5699f", size = 263128, upload-time = "2026-08-15T08:18:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90", size = 251240, upload-time = "2026-08-15T08:18:18.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a5/cbe418bbc6ecdfc3e05a0116002897c4b403a5e838d697e64c78e9f0190d/charset_normalizer-3.5.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:823f82903d189af463d7df250ef1f7f696f3cee08cc8d91deb565e8d425f6506", size = 245282, upload-time = "2026-08-15T08:18:19.625Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a4/689bb42e8e7cd492f3cb64907c6bc00ad247ec9a3628cd3f8eed126e8ae1/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01e93745f7f219b703b60ba7afead36cfc4242782be5af484673fc500df12da5", size = 244597, upload-time = "2026-08-15T08:18:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/9962938e179cf9f699d3f1e7b3114b5d7642dee6a893745229f9dd04f274/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329fc3ccb63ad22d867d84c2adea759a64079a37ba4a343433b02c7a2816871e", size = 231376, upload-time = "2026-08-15T08:18:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/46000450ada53bd9eac5429a2c8c54cd2d9b39c0c255f229aea9af0948a5/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb57753e36e4855b8ca375069482250a6246372331a3e4f3407eaebb007443f5", size = 266715, upload-time = "2026-08-15T08:18:24.235Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bb/618749d70f792b44252a777bf89bfb86823b9bbc1ea13fe8ce759b07f38a/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fce8cbd4997efeb450bd298b54f755dcdff18d496f7a5ddbb4867c6d7c88fdc3", size = 245848, upload-time = "2026-08-15T08:18:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3f/ffb64458527c7668031d5eb095d978de561958dc9f5b53f8e488a533e603/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6c9cdde8becb25a7fde49924511aa2644d6f8081cc8df8e9452724303348d8e3", size = 264521, upload-time = "2026-08-15T08:18:27.193Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ab/74a55fd803916a35ac461daf002708191aac19b546b80dc8cabfedc63d98/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9ac4444d8d4fd4c4bd08bf451ed3167aa9e7ec6cdb41b648794f1d1103652e36", size = 253054, upload-time = "2026-08-15T08:18:28.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/6a9034b7d3c60b17499afb482df5878bf9fa20b50cc3887d5ef017a833db/charset_normalizer-3.5.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f03ac127268b43ef4fe9e6ab6794a6794b49485a0cc0c1db79876d2f33f75bc7", size = 140580, upload-time = "2026-08-15T08:18:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/46/1d362e1a00d035d66b9869e1281eee115907f7e390a16a07824ab5737360/charset_normalizer-3.5.1-cp314-cp314-win32.whl", hash = "sha256:1f5883d77fd409a261abb5dc8ccbe335720d798b1de4abb3b1d47ccbbc76b53b", size = 180325, upload-time = "2026-08-15T08:18:31.877Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b", size = 204175, upload-time = "2026-08-15T08:18:33.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/eeb384dbd8dec570661354592f4f2e1b2fcc92585624d146a000caf53841/charset_normalizer-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:4bea7f8ebe90bbd7f0e4a2de42ca6924ba23e3e76418c408ff82f1d46fabd687", size = 184123, upload-time = "2026-08-15T08:18:34.913Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/6c/c73fa9d5a85f6ab05395de61c5f6984e0a9ff40bb5ff888d46dff02526c6/charset_normalizer-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbc597639158fd7c14d55e808718848319540f51b0e6746e3eefa59723a4a348", size = 381682, upload-time = "2026-08-15T08:18:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/63565f860921457feba93bae6c86fb7746deb4cffeed2f375cb845318146/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71c909f353863b2b89c83de2ebed71ea6d0df8a6ef65a128193c5e650766bef", size = 240826, upload-time = "2026-08-15T08:18:37.887Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ae/7ae8807410dfa33f8e6f1715740adeaafa8a816cc4cb33508f54b1f7c896/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7ac76cf9afd34929d76eb7fcb63be476a4853d8a96f0dcf2d0db68a0cbdf9885", size = 227861, upload-time = "2026-08-15T08:18:39.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/887c1642f0da26000b0e0652d91071113c0e72cea33952e225cf589f49a9/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3a370082ce34d0612f421e15fe011c53bb1feff21a26d06ad4fb244dab5a375", size = 260758, upload-time = "2026-08-15T08:18:40.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/e6f5b9a3d0e55b0ef7505cd3765cdd48f22db89994c947b316f52f801fd8/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:256dd4d85d9e4dc595e2bc983c980e73f62ddeb3165c58b4c3dfe78c5c8548c1", size = 259950, upload-time = "2026-08-15T08:18:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ee/e4e10a94d51cd1ee638aa7e00b65399e6b2a4e8376ab6d2eac9f95586671/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58d4aa13a59c969dbfdf9e6a9560e242cbfd9e8a8f50c2747714df1a423adf65", size = 249329, upload-time = "2026-08-15T08:18:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/d5f4198819e6059735a84e8d0bfb72dc33976da67b97adcd3fb5a5e07ec6/charset_normalizer-3.5.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c6dfb5ca6723eeed15aa8e564a014d69fcb8812f94eef11fe3631e0508199f5", size = 243137, upload-time = "2026-08-15T08:18:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e925ca7569cf9fb9701fd82503fee73eea5268fdb856bdd64947092d3daa/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c010f5581d9c612804cc59fcf7b524b707fbcb72828551237ab545bb5c7034af", size = 242820, upload-time = "2026-08-15T08:18:46.842Z" },
+    { url = "https://files.pythonhosted.org/packages/34/17/672c251a888ed2aebcdd2fe830ad0104e25ff83c43f5c4f9c15e9fc6853c/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:52ec005752a56ae79547a05c0139ca2501a0c866390b6115008456b9f0e7cde1", size = 230504, upload-time = "2026-08-15T08:18:48.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/fc/f6a85abebd42ce4da2f1db0aa56cc6a0df1995e318b3875d14401b8381d1/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2bced4061f000f7187254a02ad3433ae17eaf991747ceea2f478422590a5bba9", size = 263087, upload-time = "2026-08-15T08:18:49.859Z" },
+    { url = "https://files.pythonhosted.org/packages/98/66/7c42677e739ba66746b297e2046918d793078094dc239e1e72768cffccc6/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9eea3ab2597a5e65fe65296e2d6a84570845a6b55532d90333d740d48bbc850a", size = 243269, upload-time = "2026-08-15T08:18:51.601Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/a50b79237f417af10f8c2a501ce8d1ca87829a22e69117891ca4ba20a69e/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:496846868fea80e479324862fa877f02411f2fd0f83b79ccee2607aa68b2a032", size = 258766, upload-time = "2026-08-15T08:18:53.23Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1d/0fc91aeaeb3c83b748f532399ce67cf84604b48297405d740000f7a9e786/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85d5855daafc240cc045c026d7a15fd198a09b0fc8ff6f5ecbb5297b509cb11e", size = 250814, upload-time = "2026-08-15T08:18:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/10/3d8c777cf9024615295aa1b808324ad5b4a77855869c00824bad74ffaf8a/charset_normalizer-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:58d3e12c88e0950bca850ae1f7c256055c097639c2edb9eb123af9807d8b15e4", size = 191074, upload-time = "2026-08-15T08:18:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/81/ae557d3c44d1a1d688696d60563413a0866a91b7ebc50f20df838be3d8c8/charset_normalizer-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:acaf604462bf330b0d07e7a07c1d6e4adac79e5fb13e9c5140590542cafacc00", size = 216476, upload-time = "2026-08-15T08:18:57.889Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e9/61c01fb8b804692569c036b3fc50495814502dcf13a60649c6055390b02c/charset_normalizer-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f", size = 194115, upload-time = "2026-08-15T08:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/8544831ef59d8f27ce92c80871380fdacc8076a8a56ed62f82e54f991333/charset_normalizer-3.5.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9085f87b0e38a2b92b8923059b4e8789fe40d9279712d15dcc670048d77079af", size = 342048, upload-time = "2026-08-15T08:19:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a6/e3b46852424246065355644f4fb6dbccc0239a42a2eee27ecfc8957f0bcd/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2679de311c7946dde5d3b6f44941844133ff5c7cb86099c0061ab1e8901c20a8", size = 242997, upload-time = "2026-08-15T08:19:02.492Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3b/0cc9a26777334ab2f2e3089b948bbf4e4fe72ea70b897715ef6415043ec8/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:baf3775a2635e5a11fbd5e4e64ee69c7e86875d224a5c72aca4c141064589a90", size = 237014, upload-time = "2026-08-15T08:19:03.943Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c2/027335f0aa337a2a2e121bac1ad88c4f02ba6053ea0926802784f3db11af/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac8c94b6539074e0f40899301273ac8402b9b3e01c7b7ba269ff30340aaaf20", size = 266174, upload-time = "2026-08-15T08:19:05.598Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d3/e367787febe4e74769dec0f406f2c3c8d1b955fce5aee1fd0f94e8367a45/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8fe532b3c966d1fb794e0698e4589d0444017ae77fc0b31edea13c0e35bcc449", size = 263361, upload-time = "2026-08-15T08:19:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3d/391b193eb9f3e84b02f9314088c386debdc0debee843535aaea2e2c6715d/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c84bec0ab5ae0c64bfe73a7d2adcb5ce73b467523fc27fd6a28ab2aa6cbe35a", size = 252143, upload-time = "2026-08-15T08:19:08.816Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/57/de221f1745a90d418199761967e2776bfe2c275a1194220985e8c1d37833/charset_normalizer-3.5.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:854066be00447fa8de2ccbbe893e2ffc4b123ef16d897af794c1e18bd4a714b0", size = 252086, upload-time = "2026-08-15T08:19:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/d119f86a01f9331e8186175f24873b1d74a7ee9e2e4b4d68f9947dae5afd/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:21b82d8082f6f5e7f456ef0bd16323d08de1266efbfeb476e64b2a91d1471a4e", size = 245231, upload-time = "2026-08-15T08:19:11.807Z" },
+    { url = "https://files.pythonhosted.org/packages/26/de/d8e48c135ae480879539cdb179c8d3b50c7879497d75dd899b5763b69cee/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:838648accb3a7fd9803fd45c87bce8509648eb0c11bc34e216141300977244f2", size = 241546, upload-time = "2026-08-15T08:19:13.416Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c4/217755fd1abc50d326c252922cd642002758095a81ff45010337b8b3ef65/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:195ce897c6153c0700078142cf8efe3e6454ca4cf4357499e4078dfd83396626", size = 267033, upload-time = "2026-08-15T08:19:14.981Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/34d8e404e358d2adcc5a228c2134643af00104c8fb0bf525f3688d756f05/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:978eab16f55b4ab2c2a745be9a0a840bf8f09a7f227d9c76eb30214d078865a5", size = 252045, upload-time = "2026-08-15T08:19:16.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fa/40414471acf0aa0692ca77305aa00e434fcd8288f0941c93c30e9a5f8f2f/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:cc0329df4caaceb950d2f580b5ac716a377f7059624a0bafaeaf8a218c6ed774", size = 264866, upload-time = "2026-08-15T08:19:18.101Z" },
+    { url = "https://files.pythonhosted.org/packages/32/90/fcc850bae791abd2e0c041847f13e270aa08692a79f3e00de6d2dce1cb50/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:687c9ca3035544b113bea2055e180af96fb63c0c476e22a9180f51925186e7b7", size = 253932, upload-time = "2026-08-15T08:19:19.734Z" },
+    { url = "https://files.pythonhosted.org/packages/af/af/53afe99068b3c10b4cbae592a52ef72a7c92c0188440e83ee3a078fd8f75/charset_normalizer-3.5.1-cp315-cp315-win32.whl", hash = "sha256:706bfd38730a5ac7a365793269a00f4e988178cec121391f4248d84ad8c972e9", size = 180320, upload-time = "2026-08-15T08:19:21.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bc/f46a132041b29e4a8779ed712d3df1bf112e94ca8de58b66d7ec2c0cf8b9/charset_normalizer-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:92caef967d287a407085d61176fce4012b1dd62daed4eb6d5ceb26d3d2538712", size = 204174, upload-time = "2026-08-15T08:19:23.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5d/9ed554480eda8e447b673648628fdc29574d23dbad01fe11837adedd1cae/charset_normalizer-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:5fc45d653ea8c9a20479167e11d4a0f8cb2fa3470737ab6f9c827532313187b7", size = 184126, upload-time = "2026-08-15T08:19:24.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/32/9b8929bf384061ee1fe5d9c27c6f9776d3d824039ad4e14c88ec00c7808e/charset_normalizer-3.5.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:59171c6e45bf07d0d5cab3b0bf81d945035530f6873398b3b531c31184d46663", size = 381441, upload-time = "2026-08-15T08:19:26.038Z" },
+    { url = "https://files.pythonhosted.org/packages/96/10/e9aa7923d3ddac652c99a1c5f7be494e737e151566a44abe018daf757f2c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dbdd9205662134957cf0c324f639bdc5031c0ca056e2369e238db75187c0f11", size = 241742, upload-time = "2026-08-15T08:19:27.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/53/a2d249ebddf47b889a100c0bdcb61a2f9dbb8bc24ef325cc062e4f476877/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4b018dc5a0eee4676e38fe84a47a427816c590b93b55d9025274ec4d6ffc2dc", size = 235298, upload-time = "2026-08-15T08:19:29.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/07/469f78af590f7d5cd48e20d8dbfa3d66deeff9ba37768c04d886b5afd45c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced3fdd71aaa83ce593746c2edb42b7a59cb4c19c8b5c407781c72e493aae55a", size = 262500, upload-time = "2026-08-15T08:19:30.955Z" },
+    { url = "https://files.pythonhosted.org/packages/55/66/3bb56a47f7dcba014055b1a1d33c6f08bbe9c1e74dba154cfa25f90ae885/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:19a3dd5aa73cef1c99687c4fc57db016a9c17104ae1185da88ba566a5d3bebe4", size = 258888, upload-time = "2026-08-15T08:19:32.458Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c1/2adc2800903fb013210349313b710a5376856578d9e33e6b9a1d8b36714a/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc5d36d96478aa9c60654bd932525bf32964c62a7281eafdf16d85003a8d6004", size = 250243, upload-time = "2026-08-15T08:19:33.94Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/a18d0dd1157ab655cc2cb14a545f4a4784bbad70ab3502412e36097502d9/charset_normalizer-3.5.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:04368edf83514385ffc3e1cfd4546e595f4f1272dd23ba437a93a9cc3741d47b", size = 249871, upload-time = "2026-08-15T08:19:35.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c3/525f508cd1e58d0450ac55ed40ac75bc3a97482c59def5278456a5fbf03c/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:9b5db6052055d34d41230fb78d7c439c23dc536a9896f6cb039e8dd92cfc1263", size = 243580, upload-time = "2026-08-15T08:19:36.886Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c1/49a91fe7e97c8140094ca5c64161ab623a70d9f636bf834eace14048acb5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:252d099029bcbea642f2a06c4ed5046bdf8b5a8150b64afa5e027e88b106e5ee", size = 239807, upload-time = "2026-08-15T08:19:38.392Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/56a48c296601274c4689b864a8e2dfb209b81dfcb39472753ce95eea662b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:6199d5606e2bbf2b096cf64d03f8b6790c91081d5ac866b8e7bb6422738cc60c", size = 264083, upload-time = "2026-08-15T08:19:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4c/dc48409274a1817ff349711d26c62aa0c597df865d4d69ef79160c859193/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:77efcff2b23071c349402ac1066667a3d011f62398d81408c9b88ad991747c9e", size = 250317, upload-time = "2026-08-15T08:19:41.53Z" },
+    { url = "https://files.pythonhosted.org/packages/81/58/d325912115caec62d6bdd77bbab5e0b7da5d234a9f20affdffcbcb530d0b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:a5cbd90ecf0fc62e64726917ad083b73001f0563657a87ec3c0b504e277dc90d", size = 258173, upload-time = "2026-08-15T08:19:43.07Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/b13b1ccae2c8ec63980d13be1890eb73f8aeabbfce02a24aabc0908788f5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:4d26f14f041e83dd8edfd61f4cd4fa7285d31798b5bf1f28e70c367ba6c41d61", size = 251960, upload-time = "2026-08-15T08:19:44.587Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/25/ed3f9919c5aef8cc818be1f972f565f7610d7b2076b8ebb98839516ffc3c/charset_normalizer-3.5.1-cp315-cp315t-win32.whl", hash = "sha256:ac13b004224fb341e1e25a1ed5e19d32f57cdb2a403e01f003b46f051a550f6f", size = 191186, upload-time = "2026-08-15T08:19:46.293Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/43c2b3e9d8267092b913eb8b0603f0f71993c395632886bd37a7223f96cf/charset_normalizer-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:35aea775dc2bd5f54cd84a1cd2696cc3207c479cb9cf0bd346f0d343e4300ddb", size = 215947, upload-time = "2026-08-15T08:19:47.853Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/9aad3e9c8865e5e0efa9a7f6f81c37a67635a985145ecd44528a81e088ee/charset_normalizer-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:fb78f6e7fcd8ad785d28cd577168bc1aaee827b25bb8755638f694794ea98f0a", size = 193909, upload-time = "2026-08-15T08:19:49.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -103,12 +237,54 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -182,6 +358,173 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/71/f85bdf13355073ae15a7375f09879375a830553552e58c1c4b7e0bbc5c8b/mkdocstrings-1.0.6.tar.gz", hash = "sha256:a0b8c2bdd29a6416c80d717aa369bbf7831946bd9f23c2a66db1b1dbe7693dbd", size = 100649, upload-time = "2026-07-11T19:38:05.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5b/4c1902e8bdd5c4db63284e9d101dece4038d4025d6d88850ffe0a1578980/mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7", size = 35787, upload-time = "2026-07-11T19:38:04.417Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/5d/1be1c7a49d8fa13dc80f66a85f53333d52cf5206911412006ffdff8fb9a0/mkdocstrings_python-2.0.7.tar.gz", hash = "sha256:8c49faf66d243072d7590a1b5dea028d9d7425fac191f54f096123a4a9c1a783", size = 201598, upload-time = "2026-08-17T16:56:18.239Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/6d/77546d8c26f038fce314a507106954f76270f6c182488bcf9ac9721175df/mkdocstrings_python-2.0.7-py3-none-any.whl", hash = "sha256:1fce5fbfe4ffa6e8136a35351cdc97c3bf55219c7efbd3f92a82260f93235d60", size = 105387, upload-time = "2026-08-17T16:56:16.813Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -242,12 +585,30 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz", hash = "sha256:f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d", size = 34079, upload-time = "2026-08-24T14:53:49.676Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl", hash = "sha256:e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586", size = 23741, upload-time = "2026-08-24T14:53:48.406Z" },
 ]
 
 [[package]]
@@ -325,6 +686,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/17/2db4b414de89659144488e0d9c6c0bf0c8395841dc12d81d0532cc6ef310/pymdown_extensions-11.0.2.tar.gz", hash = "sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d", size = 855419, upload-time = "2026-08-22T19:28:47.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/43/9f45ec4d14e596efc32c925a78104934790438b0c0628b70d741016734ad/pymdown_extensions-11.0.2-py3-none-any.whl", hash = "sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5", size = 269929, upload-time = "2026-08-22T19:28:45.389Z" },
+]
+
+[[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -347,6 +721,71 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -375,6 +814,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sovereign-agent"
 version = "1.0.0.dev1"
 source = { editable = "." }
@@ -389,6 +837,11 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2,<3" }]
@@ -399,6 +852,11 @@ dev = [
     { name = "mypy", specifier = ">=1.18" },
     { name = "pytest", specifier = ">=8" },
     { name = "ruff", specifier = ">=0.13" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6" },
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
 ]
 
 [[package]]
@@ -420,4 +878,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
# Acceptance remediation for Units 0–6

Scoped to exactly the five items ruled, from the audited SHA `9c242828`. Nothing else. 18 files.

Per the Principal's ruling this PR implements; per Sparring's own ruling it will not review it — implementer/reviewer separation, which this session spent twenty-four rounds re-establishing.

## 1. Repository-local contract

The SOW said *"the full design memo lives with the originating stream"* and **that memo is not in this tree.** Every earlier line had `docs/vX-unitN` files; 1.x had none. So the audit had nothing in-repo to grade against, and any verdict would have tested the code **against its own CHANGELOG**.

`docs/units-0-6-contract.md` retires that external dependency and records the per-unit scope plus the acceptance matrix. *An acceptance record pointing at a document not in the tree is this project's own defect class, one level up.*

## 2. Published documentation

Measured rather than read: **26 of 28** documented `from sovereign_agent import …` statements do not resolve against 1.x.

| Was | Now |
|---|---|
| nav "Build from scratch" → `chapters/index.md`, a directory that does not exist | removed |
| references `tools/verify_chapter_drift.py`, which does not exist | removed |
| `book/` — the actual product — absent from nav | published |
| quickstart: Python **3.13** vs `requires-python >=3.14` | 3.14; literal paste works |
| quickstart: `version`, `sessions`, `report` | none exist; `--version` is a flag |

Every quickstart command executed literally — which caught **one more broken line of my own** (`status` requires an `outcome_id`). The v0.7 sections are *labelled* as describing removed software, rather than silently deleted or silently left looking current. `mkdocs build --strict`: **0 warnings, 0 errors.**

`docs/book/` is a **projection** of `book/`, generated by `scripts/publish_book.py` and verified by the curriculum gate — two hand-maintained copies would be the drift this repo keeps teaching against. Drift check mutation-verified.

## 3. Curriculum

`ch03` was in `REQUIRED` but not `RUNNABLE`, so the gate reported *"3 exercises executed"* across **four** required chapters — a gate overstating its own coverage. It runs offline on the scripted provider; nothing justified the exclusion. **Now 4 of 4.**

Fixed the duplicated "7." in ch02. Taught passivity-before-Pulse in **ch00 prose**, where a learner meets it, instead of only in `book/README.md` while an Andrea task asks them to explain it — with a command that proves it (`SELECT DISTINCT kind FROM events` → no `pulse.*`).

## 4. Unit 5 interruption

`KeyboardInterrupt` and `SystemExit` are **not** `Exception`. They escaped `run_assignment`, skipped the persistence block, and left the assignment recorded `RUNNING` **with no receipt** — a ledger asserting work in progress that was not.

```text
before : KeyboardInterrupt escaped · state=RUNNING · receipts=0
after  : re-raised · state=FAILED  · receipts=1 · category=interrupted
```

Mutation-checked: removing the handler fails exactly the two interruption cases. **No cancellation state added** — hard kill stays Unit 8, because a process cannot record its own death.

Plus the eight-case Scripted matrix. **The one provider every learner runs was the one whose failure branches had no test** — the integration matrix parametrized `claude/codex/cursor` only.

## 5. Deferral records

Unit 4 fencing → Unit 8 (with `F-U4-1` named as a limit). Unit 6 credentialed smokes → Unit 12. Decisions on the record rather than absences a later reader must infer.

## Verification

**184 tests** (from 175). Gate green: pytest, ruff format, ruff check, mypy, deps (pydantic only), budget 23/40 · 3653/6000 · 7/30, curriculum 4/4, doctor, demo, `verify_store_outcome`, projections, andrea. Site builds strict.

**Not claimed:** the credentialed smokes have not run. Unit 12 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns
