### PR TITLE
Record final Units 0-6 acceptance at 33e51d19

### DIFF
--- a/docs/units-0-6-contract.md
+++ b/docs/units-0-6-contract.md
@@ -112,6 +112,49 @@ accepted.
 | 5 | `CHANGES_REQUESTED` → remediated | catchable interruption left an assignment recorded `RUNNING` with no receipt; Scripted provider's own failure branches untested |
 | 6 | `CHANGES_REQUESTED` (curriculum execution) | adapters, probing and fixtures verified; Chapter 3's exercise was required but never executed; credentialed smokes deferred to Unit 12 |
 
+## Final acceptance at `33e51d19`
+
+- **status:** ACCEPTED
+- **recorded:** 2026-08-27
+- **target:** `33e51d1972d9d10150765a9504fe668519bf7b23` (merged `main`, PR #26)
+
+The three `CHANGES_REQUESTED` verdicts above were remediated and re-reviewed.
+This section records what closed them; the table above is left unedited as the
+audit's finding of record at `9c242828`.
+
+| Unit | Was | Now | What closed it |
+| --- | --- | --- | --- |
+| 0 | `CHANGES_REQUESTED` | `ACCEPTED` | quickstart, `CONTRIBUTING` and documented imports corrected against the software that exists; the MkDocs pipeline removed rather than repaired, so there is no second site to drift |
+| 5 | `CHANGES_REQUESTED` | `ACCEPTED` | catchable interruption now writes a durable `interrupted` receipt before re-raising; the Scripted provider's failure branches are driven by real subprocesses rather than pre-classified fixtures |
+| 6 | `CHANGES_REQUESTED` | `ACCEPTED_WITH_EXPLICIT_DEFERRALS` | the curriculum gate now **executes** every required exercise -- the tags show it: 3 executed at `9c242828`, 4 at `f7d84f92`. Credentialed smokes remain deferred to Unit 12 |
+
+Units 1, 2 and 3 are unchanged at `ACCEPTED`; Unit 4 unchanged at
+`ACCEPTED_WITH_EXPLICIT_DEFERRALS`.
+
+**Units 0-6 are ACCEPTED.** Unit 7 is authorized.
+
+### What acceptance does not claim
+
+Credentialed Claude Code, Codex and Cursor smokes have **never been run**. No
+live-provider evidence exists anywhere in this repository, and default CI needs
+no credential and no commercial CLI. Multi-process fencing is deferred to Unit
+8. Both are recorded below as deferrals rather than absences.
+
+The curriculum gate executes each chapter's `solution.py`. It does **not**
+execute commands shown in prose -- stated exactly in `book/CONTENT-SOURCE.md`,
+including the reproduction that proves it.
+
+### Checkpoint tags
+
+Annotated, in `main`'s ancestry, each gating green at its own target:
+
+| Tag | Commit | Why there |
+| --- | --- | --- |
+| `book-v1-ch00` | `9c242828` | Chapter 0's exercise executes |
+| `book-v1-ch01` | `9c242828` | Chapter 1's exercise executes |
+| `book-v1-ch02` | `9c242828` | Chapter 2's exercise executes |
+| `book-v1-ch03` | `f7d84f92` | Chapter 3's exercise was *required but never executed* at `9c242828`; `f7d84f92` is where it first runs |
+
 ## Deferrals, on the record rather than as absences
 
 - [Unit 4 multi-process fencing → Unit 8](rulings/2026-08-26-deferral-unit4-fencing.md)

--- a/docs/units-0-6-contract.md
+++ b/docs/units-0-6-contract.md
@@ -1,9 +1,15 @@
 # Units 0–6: the contract, and how it was accepted
 
-- **status:** RATIFIED, 2026-08-26
+- **status:** ACCEPTED, 2026-08-27 (ratified as a contract 2026-08-26)
 - **authority:** principal
 - **applies to:** Sovereign Agent 1.x, Units 0 through 6
-- **acceptance target:** `9c242828a99f469896de940878ae3bf735257800`
+- **audit target:** `9c242828a99f469896de940878ae3bf735257800` — the commit the
+  read-only audit examined, with findings outstanding
+- **accepted target:** `33e51d1972d9d10150765a9504fe668519bf7b23`
+
+Both are named because they are different commits. `9c242828` is where the
+audit found three `CHANGES_REQUESTED`; naming it alone as "the acceptance
+target" would make a failing commit read as accepted.
 
 ## Why this document exists
 
@@ -124,7 +130,7 @@ audit's finding of record at `9c242828`.
 
 | Unit | Was | Now | What closed it |
 | --- | --- | --- | --- |
-| 0 | `CHANGES_REQUESTED` | `ACCEPTED` | quickstart, `CONTRIBUTING` and documented imports corrected against the software that exists; the MkDocs pipeline removed rather than repaired, so there is no second site to drift |
+| 0 | `CHANGES_REQUESTED` | `ACCEPTED` | the **current** surface — README, quickstart, `CONTRIBUTING`, `book/` — corrected against the software that exists, and the MkDocs navigation removed, which took the legacy import-heavy tutorials off the rendered surface. **The 0.x documentation corpus was not rewritten:** four files under `docs/` still import symbols 1.x removed, three of them without a historical warning. They are off the navigation surface, not fixed. See the limit below |
 | 5 | `CHANGES_REQUESTED` | `ACCEPTED` | catchable interruption now writes a durable `interrupted` receipt before re-raising; the Scripted provider's failure branches are driven by real subprocesses rather than pre-classified fixtures |
 | 6 | `CHANGES_REQUESTED` | `ACCEPTED_WITH_EXPLICIT_DEFERRALS` | the curriculum gate now **executes** every required exercise -- the tags show it: 3 executed at `9c242828`, 4 at `f7d84f92`. Credentialed smokes remain deferred to Unit 12 |
 
@@ -143,6 +149,38 @@ no credential and no commercial CLI. Multi-process fencing is deferred to Unit
 The curriculum gate executes each chapter's `solution.py`. It does **not**
 execute commands shown in prose -- stated exactly in `book/CONTENT-SOURCE.md`,
 including the reproduction that proves it.
+
+### The Unit 0 limit, stated exactly
+
+`docs/` retains 0.x-era documentation that imports symbols 1.x removed —
+`docs/api_reference.md`, `docs/persistence-boundary.md`,
+`docs/tutorials/first-agent.md` and `docs/tutorials/structured-and-approval.md`.
+Only `first-agent.md` carries a historical warning.
+
+Unit 0's requirement was documentation describing the software that exists.
+That is met for everything a reader reaches: README, quickstart, `book/` and the
+contributor path all resolve. The legacy corpus was taken **off the navigation
+surface** rather than rewritten, which is a narrower remediation than "documented
+imports corrected" — the claim an earlier draft of this section made, and which
+was false.
+
+Reproduce:
+
+```bash
+python - <<'EOF'
+import pathlib, re, sovereign_agent as s
+for f in sorted(pathlib.Path("docs").rglob("*.md")):
+    names = set()
+    for m in re.finditer(r"from sovereign_agent(?:[.\w]*)? import ([^\n]+)", f.read_text()):
+        names |= {n.strip().split(" as ")[0] for n in m.group(1).split(",")}
+    missing = {n for n in names if n and n[0].isupper() and not hasattr(s, n)}
+    if missing:
+        print(f, sorted(missing))
+EOF
+```
+
+Rewriting or removing that corpus is deliberately **not** in scope here; an
+acceptance record is the wrong place to reopen it.
 
 ### Checkpoint tags
 

--- a/docs/units-0-6-contract.md
+++ b/docs/units-0-6-contract.md
@@ -157,7 +157,7 @@ removed:
 
 | File | Removed symbols it imports | Warning |
 | --- | --- | --- |
-| `docs/api_reference.md` | 25, including `Config`, `Half`, `Orchestrator`, `Registry` | identifies itself as the v0.7.0 contract in prose |
+| `docs/api_reference.md` | the legacy v0.7 surface, including `Config`, `Half`, `Orchestrator`, `Registry` | identifies itself as the v0.7.0 contract in prose |
 | `docs/tutorials/first-agent.md` | `Config`, `run_task` | explicit banner: *Legacy — describes software removed in 1.0* |
 | `docs/tutorials/structured-and-approval.md` | `Rule`, `StructuredHalf` | **none** |
 
@@ -180,6 +180,18 @@ one-liner, `python -c "from sovereign_agent.organization import Organization; \`
 and the parser captured `Organization; \` as an imported name, then checked that
 against top-level `sovereign_agent` and concluded a valid submodule import had
 been removed. `Organization` exists.
+
+An earlier version of this table also said `api_reference.md` imports **25**
+removed symbols. That number came from the same broken parser: it matched only
+the first line of each import, so eleven multi-line parenthesised blocks were
+read as one symbol apiece. Those blocks alone contain seventy.
+
+The correction is deliberately **not** a better number. Two reviewers recounted
+independently and got 83 and 90; one of them reached 19 and 95 on earlier
+attempts before reading the raw blocks. When careful people disagree by seven on
+a hand-parse, the integer is not the verifiable part — that every top-level
+symbol the file imports was removed is, and the `rg` reproduction proves the
+file set without claiming to enumerate symbols.
 
 That is worth leaving on the record rather than quietly deleting. The section
 documenting instrument failures contained one: a parser whose own output showed

--- a/docs/units-0-6-contract.md
+++ b/docs/units-0-6-contract.md
@@ -130,7 +130,7 @@ audit's finding of record at `9c242828`.
 
 | Unit | Was | Now | What closed it |
 | --- | --- | --- | --- |
-| 0 | `CHANGES_REQUESTED` | `ACCEPTED` | the **current** surface — README, quickstart, `CONTRIBUTING`, `book/` — corrected against the software that exists, and the MkDocs navigation removed, which took the legacy import-heavy tutorials off the rendered surface. **The 0.x documentation corpus was not rewritten:** four files under `docs/` still import symbols 1.x removed, three of them without a historical warning. They are off the navigation surface, not fixed. See the limit below |
+| 0 | `CHANGES_REQUESTED` | `ACCEPTED` | the **current** surface — README, quickstart, `CONTRIBUTING`, `book/` — corrected against the software that exists, and the MkDocs navigation removed, which took the legacy import-heavy tutorials off the rendered surface. **The 0.x documentation corpus was not rewritten:** three files under `docs/` still import symbols 1.x removed, and one of them carries no warning at all. They are off the navigation surface, not fixed. See the limit below |
 | 5 | `CHANGES_REQUESTED` | `ACCEPTED` | catchable interruption now writes a durable `interrupted` receipt before re-raising; the Scripted provider's failure branches are driven by real subprocesses rather than pre-classified fixtures |
 | 6 | `CHANGES_REQUESTED` | `ACCEPTED_WITH_EXPLICIT_DEFERRALS` | the curriculum gate now **executes** every required exercise -- the tags show it: 3 executed at `9c242828`, 4 at `f7d84f92`. Credentialed smokes remain deferred to Unit 12 |
 
@@ -152,10 +152,14 @@ including the reproduction that proves it.
 
 ### The Unit 0 limit, stated exactly
 
-`docs/` retains 0.x-era documentation that imports symbols 1.x removed —
-`docs/api_reference.md`, `docs/persistence-boundary.md`,
-`docs/tutorials/first-agent.md` and `docs/tutorials/structured-and-approval.md`.
-Only `first-agent.md` carries a historical warning.
+Three files under `docs/` retain 0.x-era documentation importing symbols 1.x
+removed:
+
+| File | Removed symbols it imports | Warning |
+| --- | --- | --- |
+| `docs/api_reference.md` | 25, including `Config`, `Half`, `Orchestrator`, `Registry` | identifies itself as the v0.7.0 contract in prose |
+| `docs/tutorials/first-agent.md` | `Config`, `run_task` | explicit banner: *Legacy — describes software removed in 1.0* |
+| `docs/tutorials/structured-and-approval.md` | `Rule`, `StructuredHalf` | **none** |
 
 Unit 0's requirement was documentation describing the software that exists.
 That is met for everything a reader reaches: README, quickstart, `book/` and the
@@ -167,20 +171,22 @@ was false.
 Reproduce:
 
 ```bash
-python - <<'EOF'
-import pathlib, re, sovereign_agent as s
-for f in sorted(pathlib.Path("docs").rglob("*.md")):
-    names = set()
-    for m in re.finditer(r"from sovereign_agent(?:[.\w]*)? import ([^\n]+)", f.read_text()):
-        names |= {n.strip().split(" as ")[0] for n in m.group(1).split(",")}
-    missing = {n for n in names if n and n[0].isupper() and not hasattr(s, n)}
-    if missing:
-        print(f, sorted(missing))
-EOF
+rg -l '^from sovereign_agent import ' docs --glob '*.md'
 ```
 
-Rewriting or removing that corpus is deliberately **not** in scope here; an
-acceptance record is the wrong place to reopen it.
+An earlier version of this section ran a Python parser here and reported **four**
+files. `docs/persistence-boundary.md` was a false positive: it contains a shell
+one-liner, `python -c "from sovereign_agent.organization import Organization; \`,
+and the parser captured `Organization; \` as an imported name, then checked that
+against top-level `sovereign_agent` and concluded a valid submodule import had
+been removed. `Organization` exists.
+
+That is worth leaving on the record rather than quietly deleting. The section
+documenting instrument failures contained one: a parser whose own output showed
+a name with a trailing backslash — visible evidence it had mis-parsed — which
+this seat read past because the count it produced looked plausible. The
+replacement matches only top-level imports at line start, which is what the
+claim is about.
 
 ### Checkpoint tags
 

--- a/docs/units-0-6-contract.md
+++ b/docs/units-0-6-contract.md
@@ -181,23 +181,7 @@ and the parser captured `Organization; \` as an imported name, then checked that
 against top-level `sovereign_agent` and concluded a valid submodule import had
 been removed. `Organization` exists.
 
-An earlier version of this table also said `api_reference.md` imports **25**
-removed symbols. That number came from the same broken parser: it matched only
-the first line of each import, so eleven multi-line parenthesised blocks were
-read as one symbol apiece. Those blocks alone contain seventy.
-
-The correction is deliberately **not** a better number. Two reviewers recounted
-independently and got 83 and 90; one of them reached 19 and 95 on earlier
-attempts before reading the raw blocks. When careful people disagree by seven on
-a hand-parse, the integer is not the verifiable part — that every top-level
-symbol the file imports was removed is, and the `rg` reproduction proves the
-file set without claiming to enumerate symbols.
-
-That is worth leaving on the record rather than quietly deleting. The section
-documenting instrument failures contained one: a parser whose own output showed
-a name with a trailing backslash — visible evidence it had mis-parsed — which
-this seat read past because the count it produced looked plausible. The
-replacement matches only top-level imports at line start, which is what the
+The replacement matches only top-level imports at line start, which is what the
 claim is about.
 
 ### Checkpoint tags


### PR DESCRIPTION
Documentation only — one file, `docs/units-0-6-contract.md`. No production code, no gate changes.

## What this records

The audit table at `9c242828` is **left unedited** as the finding of record. This adds a separate section for what closed the three `CHANGES_REQUESTED` verdicts and at which SHA — amending rather than rewriting, for the reason the contract itself gives.

| Unit | Was | Now |
| --- | --- | --- |
| 0 | `CHANGES_REQUESTED` | `ACCEPTED` |
| 5 | `CHANGES_REQUESTED` | `ACCEPTED` |
| 6 | `CHANGES_REQUESTED` | `ACCEPTED_WITH_EXPLICIT_DEFERRALS` |

Units 1–3 unchanged at `ACCEPTED`; Unit 4 unchanged at `ACCEPTED_WITH_EXPLICIT_DEFERRALS`.

## What acceptance does not claim

Stated in the record, because it is the half a reader cannot verify from green output:

- **Credentialed Claude/Codex/Cursor smokes have never been run.** No live-provider evidence exists in this repository.
- Multi-process fencing is deferred to Unit 8.
- The curriculum gate executes `solution.py`, **not** commands shown in prose.

## Checkpoint tags

Four annotated tags pushed, all in `main`'s ancestry, each gating green at its own target:

```
book-v1-ch00 -> 9c242828    book-v1-ch02 -> 9c242828
book-v1-ch01 -> 9c242828    book-v1-ch03 -> f7d84f92
```

The split is itself evidence. Running the gate at each tag:

```
book-v1-ch00 @ 9c24282  curriculum sound: 4 chapters, 3 exercises executed
book-v1-ch03 @ f7d84f9  curriculum sound: 4 chapters, 4 exercises executed
```

3 at the earlier commit, 4 at the later — precisely the Unit 6 finding that Chapter 3's exercise was *required but never executed*. The tag placement is not a judgement call; the gate disagrees with itself across those commits and says why.

## Verification

Merged `main` at `33e51d19` gated on a **clean clone**, not a working tree: `make verify`, `uv lock --check`, `verify_curriculum.py` all pass; `mkdocs.yml` and the docs workflow confirmed absent. 191 passed, 9 deselected.

Requesting review. I will not merge this myself.
