### PR TITLE
Unit 7: workspace lifecycle — reclaim, policy enforcement, detectable boundary, traversal check

### DIFF
--- a/docs/v1-unit7-workspace-lifecycle.md
+++ b/docs/v1-unit7-workspace-lifecycle.md
@@ -54,6 +54,37 @@ workspace root. A reclaim policy that deleted them would silently break
 re-verification — the exact risk the investigation that grounded this unit
 named as an open question rather than guessing past it.
 
+A workspace root that is itself a symlink is refused, not reclaimed: reclaim
+never recurses through it, because the organization allocates a real
+directory at that path and a symlink there would delete whatever the link
+points at instead — territory this function has no authority over. A symlink
+*entry inside* an otherwise real workspace is unlinked directly
+(`Path.unlink()`, which removes the link and never follows it into its
+target) rather than passed to `shutil.rmtree`, which refuses to recurse into
+a symlinked directory and raises `OSError` instead — unguarded, that
+exception used to have no protection at its only call site and could
+propagate after the assignment's terminal state was already durably written,
+which is the review round below reports fixing.
+
+**Corrected by review round two** (P1 finding 1): the two `snapshot_boundary`
+calls that bracket the provider invocation (Property 3) used to sit partly
+outside the receipt-producing exception handling. A fault taking the
+*before* snapshot used to propagate straight out of `run_assignment`,
+skipping the persistence block entirely and leaving the assignment stuck at
+`RUNNING` (already committed a few lines earlier) with no receipt at all. A
+fault taking the *after* snapshot used to be completely unguarded and could
+replace an already-caught interruption's own exception at the method's final
+`raise failure` — the caller would see an unrelated `OSError` from
+bookkeeping instead of the `KeyboardInterrupt` that actually happened, even
+though the interruption's own receipt had already been correctly written.
+Fixed: the before-snapshot is now taken inside the same try block as the
+provider invocation, covered by the same three exception handlers every
+other fault in this method already used; the after-snapshot is wrapped in
+its own guard that never overwrites an already-determined `failure` — the
+more important, already-happened fact always wins, and a snapshot fault that
+occurs with no prior failure becomes the reported failure itself rather than
+being silently absorbed.
+
 ### Property 2 — `Actor.workspace_policy` is enforced
 
 `models.py:120` declared the field (`workspace_policy: str =
@@ -70,6 +101,18 @@ close that gap:
    outside that set is refused, fail-closed, rather than silently treated as
    either "reclaim" or "keep" — both are real, consequential choices, and an
    unrecognized string must not pick one by accident.
+
+**Corrected by review round two** (P1 finding 2): that validation used to
+happen only inside `reclaim_workspace`, called at the very end of
+`run_assignment` — by which point the provider had already run for real and
+`COMPLETED` was already committed to the ledger, so an invalid policy meant
+"the run happened, then the bookkeeping afterward refused," not "the run
+never happened." `run_assignment` now validates `worker.workspace_policy`
+against the same `WORKSPACE_POLICIES` set as its very first act, before the
+SOW or assignment state is touched, before the workspace directory is
+created, and before the provider is invoked — an invalid policy means the
+provider never runs at all. Proven with a spy/counter on `invoke_actor` that
+must stay at zero, not merely by asserting the final ledger state.
 
 ### Property 3 — the workspace boundary is detectable
 
@@ -96,6 +139,25 @@ not block the assignment from completing — it puts the fact on the ledger
 either way, exactly as the governing ruling specifies ("you can determine
 after the fact whether execution stayed inside it").
 
+**Corrected by review round two** (P1 finding 4): `violated: False` on its
+own reads as "execution stayed inside the workspace," but the check is
+structurally blind to two things by design — the workspace itself (the actor
+is authorized to write there) and `.sovereign/organization.db*` (written by
+this same process's own transaction, not by the subprocess under test). A
+real schema change or row write to the ledger between two snapshots is
+genuinely invisible to `diff_boundary`, and the review correctly named this
+a coverage-*honesty* problem, not a "must detect DB writes" problem — the
+check was never meant to watch the ledger, per the paragraph above. Fixed by
+making the report say what it covers rather than widening what it watches:
+`BoundaryReport` (and the `assignment.workspace_boundary_checked` event) now
+carries `scope: "organization_root_excluding_workspace_and_ledger"`
+(`workspace.BOUNDARY_SCOPE`), naming the same exclusion this section already
+documented, as a value a reader can check rather than only a docstring they
+must already be looking at. The event also carries `computed: bool`,
+distinguishing "the check ran and found nothing" from "the check itself
+could not run" (see Property 1's fault-injection correction above) — the two
+must never share one boolean.
+
 ### Property 4 — `_require_deliverables` gets a traversal check
 
 `organization.py`'s `_require_deliverables` joined an unvalidated
@@ -107,6 +169,17 @@ the joined candidate and requires the candidate to sit at or under the
 resolved root, which defeats a mixed-separator or symlink string a
 prefix-string check would miss. `_require_deliverables` now calls it for
 every declared deliverable before checking existence.
+
+**Corrected by review round two** (P2): `safe_join` used to accept an
+absolute input whenever it happened to *resolve* inside root, checking only
+the resolved candidate and never whether the input itself was absolute —
+looser than the function's own docstring (workspace-relative paths) and than
+the "absolute path refused" test category already asserted for the
+non-resolving case. `_require_deliverables`'s only real caller passes
+workspace-relative deliverable names, so an absolute input is never a
+legitimate case here regardless of where it resolves. Fixed to reject any
+absolute `relative` argument outright, matching the apparent contract rather
+than loosening the docstring to fit the looser behaviour.
 
 ### Property 5 — parity across all four providers, no live credential
 
@@ -138,19 +211,27 @@ python -m pytest -q
 python scripts/verify_source_budget.py
 python scripts/verify_curriculum.py
 
-# Property 1 — reclaim tied to terminal state, including the interrupted path
+# Property 1 — reclaim tied to terminal state, including the interrupted path;
+# a snapshot fault at either bracket still reaches a terminal state and never
+# masks a real interruption (review round two, P1 finding 1); reclaim refuses
+# a symlinked workspace root and unlinks (never rmtrees) a symlinked child
+# entry without touching its external target (review round two, P1 finding 3)
 python -m pytest -q tests/test_workspace_lifecycle.py \
-  -k "reclaimed_after_terminal_state or survives_non_terminal_state or interrupted_assignment or hard_kill"
+  -k "reclaimed_after_terminal_state or survives_non_terminal_state or interrupted_assignment or hard_kill or fault_in_before_snapshot or fault_in_after_snapshot or reclaim_refuses_a_symlinked or reclaim_unlinks_a_symlinked"
 
-# Property 2 — workspace_policy drives real branching, loads from TOML,
-# fails closed on an unrecognized value
+# Property 2 — workspace_policy drives real branching, loads from TOML, fails
+# closed on an unrecognized value, and validates before the provider ever
+# runs, proven by a spy/counter at zero (review round two, P1 finding 2)
 python -m pytest -q tests/test_workspace_lifecycle.py \
   -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml"
 
 # Property 3 — boundary violation detected end to end, mutation-checked both
-# directions (a real escape is caught; legitimate in-workspace writes are not)
+# directions (a real escape is caught; legitimate in-workspace writes are
+# not); the report carries an honest scope and a real DB write stays outside
+# it on purpose, not silently overclaimed as violated=False (review round
+# two, P1 finding 4)
 python -m pytest -q tests/test_workspace_lifecycle.py \
-  -k "detects_write_outside or do_not_trip_the_boundary or new_file_outside or clean_boundary_event or caught_by_run_assignment"
+  -k "detects_write_outside or do_not_trip_the_boundary or new_file_outside or clean_boundary_event or caught_by_run_assignment or does_not_see_a_real_database_write"
 
 # Property 4 — traversal refused fail-closed; a legitimate nested path still
 # succeeds
@@ -171,12 +252,15 @@ estimated:
 | | modules | nonblank lines | root exports |
 | --- | --- | --- | --- |
 | Before (Units 0-6 accepted, `33e51d19`) | 23/40 | 3696/6000 | 7/30 |
-| After (this unit) | 24/40 | 3916/6000 | 7/30 |
+| After (this unit, original) | 24/40 | 3916/6000 | 7/30 |
+| After (review round two's four P1 fixes + P2) | 24/40 | 4056/6000 | 7/30 |
 
 One new module (`src/sovereign_agent/workspace.py`), no new root export —
 `Organization.run_assignment` and `_require_deliverables` call the new module
 internally; nothing in `workspace.py` is re-exported from the package root.
-Headroom remaining: 16 modules, 2084 nonblank lines, 23 root exports.
+Review round two's fixes stayed inside the same two modules (`workspace.py`,
+`organization.py`) plus their tests — no new module, no new root export.
+Headroom remaining: 16 modules, 1944 nonblank lines, 23 root exports.
 
 ## What this unit did not do
 

--- a/docs/v1-unit7-workspace-lifecycle.md
+++ b/docs/v1-unit7-workspace-lifecycle.md
@@ -1,0 +1,195 @@
+# Unit 7: workspace lifecycle
+
+- **status:** proposed for acceptance (this document is new; it has not yet
+  been through the same audit pass that closed `docs/units-0-6-contract.md`)
+- **base:** `main = 5120ebf3` (Units 0-6 accepted at `33e51d19`; this ruling
+  merged as `5120ebf3`)
+- **authority:** ruled by
+  [`docs/rulings/2026-08-27-unit7-is-workspaces-not-pulse.md`](rulings/2026-08-27-unit7-is-workspaces-not-pulse.md)
+- **applies_to:** Sovereign Agent 1.x, Unit 7
+- **requested_by:** `.unit7/SCOPE-PROPOSAL.md`, the read-only investigation
+  the governing ruling cites as the source of Unit 7's five properties
+
+This document follows `docs/units-0-6-contract.md`'s own shape: a contract
+stated as testable properties, then how to check each one against the
+repository. It is **additive** — nothing in the Units 0-6 acceptance table is
+touched or revised here.
+
+## Why workspaces, not Pulse
+
+The governing ruling above resolved a transcription error, not a genuine
+disagreement: the only in-tree 1.x sentence naming what Unit 7 *is*
+(`book/ch03_actor_is_not_a_model/README.md:89`, "Stronger workspace lifecycle
+policies arrive in Unit 7") already agreed with the ratified sequencing
+amendment (`docs/sows/sovereign-agent-v1-educational-control-plane.md:59`,
+"Unit 9 is the first fully proactive milestone"). A corpus-side handover note
+transcribed the pipeline under the wrong unit number; both are corrected. Unit
+9 owns Pulse. Unit 7 is workspace lifecycle.
+
+## The contract
+
+### Property 1 — reclaim tied to assignment terminal state
+
+`Organization.run_assignment` allocates `.sovereign/runs/<workspace_id>/` and,
+before this unit, never reclaimed it on any path. Reclaim now runs
+unconditionally at the end of `run_assignment`, after the assignment's
+terminal state (`COMPLETED`, `BLOCKED`, or `FAILED`) is durably written —
+never before, and never skipped, including the `except BaseException`
+(`KeyboardInterrupt`/`SystemExit`) path that already had to record an honest
+`interrupted` receipt before re-raising. That interrupted path *is* terminal —
+the ledger says the work is over — so its workspace is reclaimed exactly like
+every other terminal outcome. A hard kill (`SIGKILL`) that never returns
+control to `run_assignment` at all reclaims nothing, on purpose: a process
+cannot record its own death, and that is Unit 8 recovery territory, not
+silently deleted evidence.
+
+"Reclaim" removes the actor's disposable scratch space — everything the
+provider's own subprocess wrote directly into the workspace root
+(`provider-raw/`, and anything else a provider leaves beside its mandatory
+output) — and never touches `receipt.json`, `receipt.json.sha256`, or the
+`.sovereign-out/` output directory. Both are read long after `run_assignment`
+returns: by `_require_deliverables` and `accept()` at review time, and by
+Chapter 3's own exercise, which reads `receipt.json` straight from the
+workspace root. A reclaim policy that deleted them would silently break
+re-verification — the exact risk the investigation that grounded this unit
+named as an open question rather than guessing past it.
+
+### Property 2 — `Actor.workspace_policy` is enforced
+
+`models.py:120` declared the field (`workspace_policy: str =
+"temporary_directory"`) since before this unit; nothing read it. Two changes
+close that gap:
+
+1. `actors.py::load_actors` now reads `workspace_policy` from committed TOML
+   when present, instead of silently dropping it along with every other field
+   the loader did not already know about.
+2. `run_assignment` reads `worker.workspace_policy` and passes it to
+   `reclaim_workspace`, which branches on exactly two recognized values:
+   `"temporary_directory"` (property 1's behaviour) and `"persistent"`
+   (reclaim is skipped entirely — the whole run stays inspectable). A value
+   outside that set is refused, fail-closed, rather than silently treated as
+   either "reclaim" or "keep" — both are real, consequential choices, and an
+   unrecognized string must not pick one by accident.
+
+### Property 3 — the workspace boundary is detectable
+
+Only `codex`'s adapter passes real OS-level containment (`--sandbox
+workspace-write`); `cursor`'s `--workspace` is documented in this same
+repository as "not a sandbox"; `claude` and `scripted` have none. This
+property does not invent containment Unit 6's provider boundary doesn't
+already give — it makes the absence checkable after the fact instead of
+merely asserted in the assignment envelope's own prose ("Do not read or write
+outside this disposable workspace").
+
+`workspace.snapshot_boundary` digests every tracked file under the
+organization root, excluding the assignment's own workspace (which the actor
+is authorized to write) and the live SQLite ledger files (legitimately
+written by this same process, not the subprocess under test).
+`run_assignment` takes one snapshot immediately before invoking the provider
+and one immediately after, on every path — success, refusal, or interruption
+— and `workspace.diff_boundary` compares them. The result is recorded as a
+durable, queryable event, `assignment.workspace_boundary_checked`, carrying
+`violated`, and the changed/added/removed paths. The verdict is **detected,
+not prevented**: a clean report is evidence the boundary held for this one
+invocation, not a claim that anything was stopped, and a dirty report does
+not block the assignment from completing — it puts the fact on the ledger
+either way, exactly as the governing ruling specifies ("you can determine
+after the fact whether execution stayed inside it").
+
+### Property 4 — `_require_deliverables` gets a traversal check
+
+`organization.py`'s `_require_deliverables` joined an unvalidated
+`deliverable` string from `StatementOfWork.deliverables` onto the output path
+with `output / deliverable` and no check — an absolute string replaces the
+join outright under normal `pathlib` semantics, and a `..`-laden relative
+string can walk outside it. `workspace.safe_join` resolves both the root and
+the joined candidate and requires the candidate to sit at or under the
+resolved root, which defeats a mixed-separator or symlink string a
+prefix-string check would miss. `_require_deliverables` now calls it for
+every declared deliverable before checking existence.
+
+### Property 5 — parity across all four providers, no live credential
+
+`run_assignment` calls the reclaim and boundary-check logic from one call
+site shared by every provider — there is no per-provider branch for either
+mechanism, so the same guarantee holds for `scripted`, `claude`, `codex`, and
+`cursor` alike. Verified with the same deterministic fake-executable pattern
+`test_provider_integration.py` already established for Unit 6: no new
+dependency on a live credential, no relaxation of "default CI needs no
+credential." Credentialed Claude/Codex/Cursor smokes remain deferred to Unit
+12 and were never run in the course of this work.
+
+## Explicit non-scope
+
+- **Pulse, proactive waking, any simulated Pulse event, any wake gate** — Unit
+  9. Nothing in this unit creates work, reads a signal, or fires a gate.
+- **Multi-process fencing, a supervisor, hard-kill recovery** — Unit 8.
+  Property 1's reclaim runs in the same single process already writing
+  receipts synchronously in `run_assignment`; nothing here introduces a
+  fencing token or an independent sweep process.
+- **Credentialed Claude/Codex/Cursor smokes** — Unit 12. Never run, not
+  claimed here.
+
+## How to check this document against the repository
+
+```bash
+# Baseline, still green after Unit 7 lands
+python -m pytest -q
+python scripts/verify_source_budget.py
+python scripts/verify_curriculum.py
+
+# Property 1 — reclaim tied to terminal state, including the interrupted path
+python -m pytest -q tests/test_workspace_lifecycle.py \
+  -k "reclaimed_after_terminal_state or survives_non_terminal_state or interrupted_assignment or hard_kill"
+
+# Property 2 — workspace_policy drives real branching, loads from TOML,
+# fails closed on an unrecognized value
+python -m pytest -q tests/test_workspace_lifecycle.py \
+  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml"
+
+# Property 3 — boundary violation detected end to end, mutation-checked both
+# directions (a real escape is caught; legitimate in-workspace writes are not)
+python -m pytest -q tests/test_workspace_lifecycle.py \
+  -k "detects_write_outside or do_not_trip_the_boundary or new_file_outside or clean_boundary_event or caught_by_run_assignment"
+
+# Property 4 — traversal refused fail-closed; a legitimate nested path still
+# succeeds
+python -m pytest -q tests/test_workspace_lifecycle.py \
+  -k "traversal or absolute_deliverable or legitimate_nested or empty_deliverable"
+
+# Property 5 — parity across all four providers, no live credential
+env | grep -Ei "ANTHROPIC|CLAUDE_CODE_OAUTH|CODEX_API|CURSOR_API" || true   # must be empty
+python -m pytest -q tests/test_workspace_lifecycle.py -k "identically_across_providers"
+```
+
+## Budget impact
+
+Reproduced by `scripts/verify_source_budget.py`, before and after this unit's
+change, both figures read from the script's own printed output rather than
+estimated:
+
+| | modules | nonblank lines | root exports |
+| --- | --- | --- | --- |
+| Before (Units 0-6 accepted, `33e51d19`) | 23/40 | 3696/6000 | 7/30 |
+| After (this unit) | 24/40 | 3916/6000 | 7/30 |
+
+One new module (`src/sovereign_agent/workspace.py`), no new root export —
+`Organization.run_assignment` and `_require_deliverables` call the new module
+internally; nothing in `workspace.py` is re-exported from the package root.
+Headroom remaining: 16 modules, 2084 nonblank lines, 23 root exports.
+
+## What this unit did not do
+
+Found but out of scope, named rather than fixed inline because fixing it was
+not required to make any of the five properties above true:
+
+- `Actor.workspace_policy` is a bare `str` rather than a `StrEnum`, matching
+  every other state field in `models.py` (`OutcomeState`, `SowState`,
+  `AssignmentState`, `Role`). `workspace.py`'s own `WORKSPACE_POLICIES`
+  frozenset and fail-closed refusal give the same behavioural guarantee
+  without touching `models.py`'s existing import surface, but a future pass
+  could tighten the type at the model layer instead of enforcing it only at
+  the point of use.
+- `cli.py`'s `_actor_list` prints `id`, `role`, and `provider` for each actor
+  but not `workspace_policy`. Not required by any of the five properties, and
+  the CLI surface was explicitly not named in the governing ruling's scope.

--- a/docs/v1-unit7-workspace-lifecycle.md
+++ b/docs/v1-unit7-workspace-lifecycle.md
@@ -136,6 +136,29 @@ ancestor transparently. `self.root` itself is excluded from the walk
 because it is the organization's own allocated real directory, not
 something this method traverses into on the provider's behalf.
 
+**Corrected by review round three, second finding** (B3): the ancestor walk
+above guards the workspace root and everything above it, but a workspace
+root can pass every one of those checks as an ordinary real directory while
+`.sovereign-out` — the organization-allocated *output child* living one
+level *below* the workspace root — was pre-planted as a symlink. The
+reviewer's own framing: probe the dual of every fix, same mechanism,
+opposite position; round three's first finding (B) guarded the path above
+the workspace, this one is the path below it. Before this fix, the provider
+wrote its report and every declared artifact through that symlink for real,
+into whatever external directory it pointed at, and `_require_deliverables`
+— which reconstructs the same `.sovereign-out` path independently and joins
+onto it with `safe_join` — resolved through the same symlink and accepted
+evidence sitting entirely outside the workspace boundary as proof the SOW
+was satisfied. Fixed by checking `.sovereign-out` for a symlink immediately
+after the ancestor walk, in the same place, before the SOW or assignment
+state is touched, before the workspace directory is created, and before the
+provider is ever invoked — refusing with a distinct category
+(`symlinked_output_directory`, not `symlinked_workspace_root`) because it is
+a different path component (a child, not a root or an ancestor) that the
+ancestor walk cannot see. Proven with the same invocation-counter-stays-zero
+and byte-for-byte external-tree-hash pattern the two round-three-B tests
+already established.
+
 ### Property 2 — `Actor.workspace_policy` is enforced
 
 `models.py:120` declared the field (`workspace_policy: str =
@@ -277,9 +300,11 @@ python -m pytest -q tests/test_workspace_lifecycle.py \
 # runs, proven by a spy/counter at zero (review round two, P1 finding 2); a
 # symlinked workspace root -- leaf or ancestor -- is refused before the
 # provider ever runs too, same spy/counter plus a byte-for-byte external-tree
-# hash (review round three, finding B)
+# hash (review round three, finding B); a symlinked *output child*
+# (.sovereign-out) one level below the workspace root is refused the same
+# way (review round three, finding B3)
 python -m pytest -q tests/test_workspace_lifecycle.py \
-  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml or symlinked_workspace_root_refused_before or symlinked_runs_directory_ancestor"
+  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml or symlinked_workspace_root_refused_before or symlinked_runs_directory_ancestor or symlinked_output_directory_refused_before"
 
 # Property 3 — boundary violation detected end to end, mutation-checked both
 # directions (a real escape is caught; legitimate in-workspace writes are
@@ -311,16 +336,18 @@ estimated:
 | After (this unit, original) | 24/40 | 3916/6000 | 7/30 |
 | After (review round two's four P1 fixes + P2) | 24/40 | 4056/6000 | 7/30 |
 | After (review round three's two findings) | 24/40 | 4134/6000 | 7/30 |
+| After (review round three's third finding, B3) | 24/40 | 4168/6000 | 7/30 |
 
 One new module (`src/sovereign_agent/workspace.py`), no new root export —
 `Organization.run_assignment` and `_require_deliverables` call the new module
 internally; nothing in `workspace.py` is re-exported from the package root.
 Review round two's fixes stayed inside the same two modules (`workspace.py`,
 `organization.py`) plus their tests — no new module, no new root export.
-Review round three's fixes stayed inside `organization.py` and its test file
-only — `workspace.py`'s own `reclaim_workspace` symlink guard is untouched,
-kept in place as defense in depth — no new module, no new root export.
-Headroom remaining: 16 modules, 1866 nonblank lines, 23 root exports.
+Review round three's fixes (both finding B and finding B3) stayed inside
+`organization.py` and its test file only — `workspace.py`'s own
+`reclaim_workspace` symlink guard and `safe_join` are both untouched, kept in
+place as defense in depth — no new module, no new root export.
+Headroom remaining: 16 modules, 1832 nonblank lines, 23 root exports.
 
 ## What this unit did not do
 

--- a/docs/v1-unit7-workspace-lifecycle.md
+++ b/docs/v1-unit7-workspace-lifecycle.md
@@ -159,6 +159,82 @@ ancestor walk cannot see. Proven with the same invocation-counter-stays-zero
 and byte-for-byte external-tree-hash pattern the two round-three-B tests
 already established.
 
+**Corrected by review round four** (findings C1 and C2, the dual of B3):
+the B3 check above refuses `.sovereign-out` *being* a symlink, but says
+nothing about `.sovereign-out` pre-planted as an ordinary *real* directory
+with a hostile interior — the provider's own `mkdir(parents=True,
+exist_ok=True)` (`providers/scripted.py`) never disturbs pre-existing
+content, so a real directory sitting there before `run_assignment` runs
+survives untouched. Two shapes, both reproduced against the unfixed code
+before any edit: **C1**, a symlinked *child* (`.sovereign-out/report.json`
+pointing at an external file) — the provider's real report bytes wrote
+through the link, overwriting the external file, with `COMPLETED`
+committed; and **C2**, a real file already sitting at the exact name a
+SOW declares as its deliverable, never written by the provider at all —
+`_require_deliverables` accepted it as proof the run produced evidence it
+never produced. The same defect class was independently present on the
+organization's *other* write path: `execution.py::invoke_actor` allocates
+`workspace / "provider-raw"` the same unchecked way, and a pre-planted
+symlink there let the post-subprocess bookkeeping (`stdout.txt`,
+`stderr.txt`, `events.jsonl`) write straight through it.
+
+Fixed at the root, not by adding a third `is_symlink()` refusal: the
+allocation-time comment above claimed "the provider must never run
+against an output path this method did not allocate as a real
+directory," but the method never allocated it at all — it only ever
+checked what was already there. `run_assignment` now actually allocates
+`.sovereign-out` fresh: immediately after the existing symlink check (and
+after `workspace.mkdir()`, since the output child lives inside the
+workspace root), any pre-existing content at that path — real directory,
+hostile interior, whatever shape — is removed with `shutil.rmtree` and
+replaced with a clean, empty, real `mkdir`. `shutil.rmtree` unlinks a
+symlinked child *entry* without following it into its target, so a
+hostage file the symlink pointed at is never touched by the removal
+itself, only by whatever the (now-absent) link would have let the
+provider write afterward. `execution.py::invoke_actor` gets the identical
+treatment for `provider-raw`, immediately before its own three writes.
+Because the symlink check upstream already refused a top-level symlink at
+`.sovereign-out`, the recreate step there only ever needs to handle "real
+directory or nothing"; `provider-raw` has no upstream check of its own
+(a third, independent path `run_assignment`'s checks never look at), so
+its own recreate step handles the symlink case directly too. This closes
+C1 and C2 (and their `provider-raw` sibling) regardless of which hostile
+shape was planted, rather than adding a growing list of shape-specific
+refusals — the next dual of this fix, if one exists, would have to be a
+substitution happening *after* the recreate and *before* the provider
+runs (a live TOCTOU race), which is out of this unit's scope by the same
+reasoning every prior round used: Unit 8 fencing territory, not a
+pre-planted-content question this allocation-time fix already answers
+regardless of timing before the provider starts.
+
+**Design note on resume, checked rather than assumed**: `run_assignment`
+never currently passes `provider_session_id` to `invoke_actor` — the
+parameter exists on `invoke_actor` and `InvocationRequest`, but nothing in
+`run_assignment`'s own call site wires a resumed session through it (the
+call is `invoke_actor(worker, sow, workspace, output,
+assignment_id=assignment.id)`, no fifth argument). Recreating
+`.sovereign-out` fresh on every call therefore does not break any *live*
+resume path today, because there is not one. If a future unit wires
+`provider_session_id` through `run_assignment` for a real resume case that
+needs prior output content to survive between calls, that unit will need
+to make the recreate conditional on whether the call is a fresh
+allocation or a genuine resume — this fix does not attempt to anticipate
+that shape, since guessing at an unbuilt resume contract risks getting it
+wrong in a security-relevant way. Recorded here as a known scope boundary,
+not a silent decision.
+
+Proven the same way as every fix in this unit: reproduced against the
+unfixed code first (three standalone scripts, not suite tests, matching
+this project's own pattern), then covered by three new tests
+(`test_symlinked_child_inside_a_real_output_directory_cannot_be_written_through`,
+`test_fabricated_deliverable_preplanted_in_a_real_output_directory_is_not_accepted`,
+`test_symlinked_provider_raw_cannot_be_written_through`), then falsified
+by disabling the recreate in both files, confirming all three tests fail
+with the exact same symptom the unfixed reproduction showed (real bytes
+landing in the external target; the fabricated file surviving), then
+restored and confirmed byte-identical via `diff` before re-confirming
+green.
+
 ### Property 2 — `Actor.workspace_policy` is enforced
 
 `models.py:120` declared the field (`workspace_policy: str =
@@ -302,9 +378,13 @@ python -m pytest -q tests/test_workspace_lifecycle.py \
 # provider ever runs too, same spy/counter plus a byte-for-byte external-tree
 # hash (review round three, finding B); a symlinked *output child*
 # (.sovereign-out) one level below the workspace root is refused the same
-# way (review round three, finding B3)
+# way (review round three, finding B3); a REAL .sovereign-out with a hostile
+# interior -- a symlinked child, or a fabricated deliverable -- cannot be
+# written through or accepted, because it is removed and recreated fresh at
+# allocation time, and the organization's other write path (provider-raw)
+# gets the same treatment (review round four, findings C1 and C2)
 python -m pytest -q tests/test_workspace_lifecycle.py \
-  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml or symlinked_workspace_root_refused_before or symlinked_runs_directory_ancestor or symlinked_output_directory_refused_before"
+  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml or symlinked_workspace_root_refused_before or symlinked_runs_directory_ancestor or symlinked_output_directory_refused_before or symlinked_child_inside_a_real_output_directory or fabricated_deliverable_preplanted or symlinked_provider_raw"
 
 # Property 3 — boundary violation detected end to end, mutation-checked both
 # directions (a real escape is caught; legitimate in-workspace writes are
@@ -337,6 +417,7 @@ estimated:
 | After (review round two's four P1 fixes + P2) | 24/40 | 4056/6000 | 7/30 |
 | After (review round three's two findings) | 24/40 | 4134/6000 | 7/30 |
 | After (review round three's third finding, B3) | 24/40 | 4168/6000 | 7/30 |
+| After (review round four's findings, C1/C2) | 24/40 | 4236/6000 | 7/30 |
 
 One new module (`src/sovereign_agent/workspace.py`), no new root export —
 `Organization.run_assignment` and `_require_deliverables` call the new module
@@ -347,7 +428,12 @@ Review round three's fixes (both finding B and finding B3) stayed inside
 `organization.py` and its test file only — `workspace.py`'s own
 `reclaim_workspace` symlink guard and `safe_join` are both untouched, kept in
 place as defense in depth — no new module, no new root export.
-Headroom remaining: 16 modules, 1832 nonblank lines, 23 root exports.
+Review round four's fixes touched `organization.py`, `execution.py`
+(the `provider-raw` recreate), and their shared test file — no new module,
+no new root export; `execution.py` already existed and already owned
+`provider-raw`'s allocation, so extending its own `mkdir` call site is not
+a new dependency surface.
+Headroom remaining: 16 modules, 1764 nonblank lines, 23 root exports.
 
 ## What this unit did not do
 

--- a/docs/v1-unit7-workspace-lifecycle.md
+++ b/docs/v1-unit7-workspace-lifecycle.md
@@ -235,6 +235,64 @@ landing in the external target; the fabricated file surviving), then
 restored and confirmed byte-identical via `diff` before re-confirming
 green.
 
+**Corrected by review round five** (finding E1, a comment-correctness
+defect, not a behavioural one): round four's own closing comment on the
+recreate above claimed a completeness property — "by construction only a
+real directory — or nothing at all — can remain here; `output.exists()`
+alone is therefore a complete test, not an approximation." That claim was
+false at round four's head. The symlink check just above only refuses
+`.sovereign-out` *being* a symlink; it says nothing about the path
+existing as some *other* non-directory shape — most simply, an ordinary
+plain file, left over from an earlier crash or planted by something that
+stopped short of a symlink. Reproduced against round four's own head
+before any edit: a pre-planted plain file at `.sovereign-out` is not a
+symlink (passes the check above) and is not a directory (`exists()` is
+`True`), so `shutil.rmtree` reached a `scandir` call on a file and raised
+a raw `NotADirectoryError` — a third shape the comment's enumeration
+missed. The same shape at `provider-raw` (`execution.py::invoke_actor`)
+reproduced too, with a different outcome: because that recreate happens
+*inside* `run_assignment`'s own `try`/`except` block (the `.sovereign-out`
+recreate happens *before* it), the `NotADirectoryError` there was already
+caught by `except Exception`, already produced an honest `FAILED` receipt
+with category `internal_error`. Both paths were already fail-closed with
+a truthful ledger — nobody was harmed by the bug — but a proven-false
+completeness claim, in a codebase whose whole subject is that a claim
+must not outrun the check behind it, is exactly the pattern review rounds
+two and four already put on record as the shape that precedes a paid
+failure, even when (as here) the underlying behaviour is safe.
+
+Fixed by refusing the shape explicitly rather than only correcting the
+comment (the reviewer's own preferred resolution, called the better
+teaching artifact: a named `Refusal` with a clear message teaches more
+than a rewritten sentence does). `run_assignment` now refuses
+`.sovereign-out` existing as anything other than a directory — a second,
+independent `elif` right after the existing symlink check, with its own
+category (`non_directory_output_path`, not folded into
+`symlinked_output_directory`: a different shape, most likely a different
+cause — leftover state, not necessarily an adversarial link — and a
+different fix, "remove the file," so the category should say which one
+applies). `execution.py::invoke_actor` gets the identical treatment for
+`provider-raw`, for consistency, even though its own un-fixed failure was
+already honest: the `Refusal` there is still caught by the same
+`except Exception` handler in `run_assignment`, so the assignment still
+fails exactly as before — only the receipt's category improves, from the
+generic `internal_error` to this shape's own name. The closing comment
+above the recreate is corrected to describe what actually makes
+`output.exists()` a complete test now: both the symlink check and the new
+non-directory check have already turned away every shape but "real
+directory" or "absent" by the time that line runs, so the claim is true
+for the first time, not merely re-asserted.
+
+Proven the same way as every fix in this unit: reproduced against
+round four's head first (two standalone scripts, not suite tests), then
+covered by two new tests
+(`test_non_directory_output_path_is_refused_before_the_provider_ever_runs`,
+`test_non_directory_provider_raw_is_refused_with_a_named_category`), then
+falsified by disabling the new `elif` in both files, confirming both
+tests fail with the exact `NotADirectoryError` symptom the unfixed
+reproduction showed, then restored and confirmed byte-identical before
+re-confirming green.
+
 ### Property 2 — `Actor.workspace_policy` is enforced
 
 `models.py:120` declared the field (`workspace_policy: str =
@@ -382,9 +440,12 @@ python -m pytest -q tests/test_workspace_lifecycle.py \
 # interior -- a symlinked child, or a fabricated deliverable -- cannot be
 # written through or accepted, because it is removed and recreated fresh at
 # allocation time, and the organization's other write path (provider-raw)
-# gets the same treatment (review round four, findings C1 and C2)
+# gets the same treatment (review round four, findings C1 and C2); a
+# non-directory shape (a plain file) at either .sovereign-out or
+# provider-raw is refused explicitly, by name, instead of surfacing as a
+# raw NotADirectoryError from shutil.rmtree (review round five, finding E1)
 python -m pytest -q tests/test_workspace_lifecycle.py \
-  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml or symlinked_workspace_root_refused_before or symlinked_runs_directory_ancestor or symlinked_output_directory_refused_before or symlinked_child_inside_a_real_output_directory or fabricated_deliverable_preplanted or symlinked_provider_raw"
+  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml or symlinked_workspace_root_refused_before or symlinked_runs_directory_ancestor or symlinked_output_directory_refused_before or symlinked_child_inside_a_real_output_directory or fabricated_deliverable_preplanted or symlinked_provider_raw or non_directory_output_path or non_directory_provider_raw"
 
 # Property 3 — boundary violation detected end to end, mutation-checked both
 # directions (a real escape is caught; legitimate in-workspace writes are
@@ -418,6 +479,7 @@ estimated:
 | After (review round three's two findings) | 24/40 | 4134/6000 | 7/30 |
 | After (review round three's third finding, B3) | 24/40 | 4168/6000 | 7/30 |
 | After (review round four's findings, C1/C2) | 24/40 | 4236/6000 | 7/30 |
+| After (review round five's finding, E1) | 24/40 | 4307/6000 | 7/30 |
 
 One new module (`src/sovereign_agent/workspace.py`), no new root export —
 `Organization.run_assignment` and `_require_deliverables` call the new module

--- a/docs/v1-unit7-workspace-lifecycle.md
+++ b/docs/v1-unit7-workspace-lifecycle.md
@@ -85,6 +85,57 @@ more important, already-happened fact always wins, and a snapshot fault that
 occurs with no prior failure becomes the reported failure itself rather than
 being silently absorbed.
 
+**Corrected by review round three** (finding A): review round two's own
+after-snapshot guard (`if failure is None: failure = snapshot_error`) was
+written to stop a snapshot fault from *overwriting* an already-caught, more
+important failure. It said nothing about what to persist when there was no
+prior failure to protect in the first place — the provider ran and
+succeeded normally, and only the *after*-snapshot faulted afterward. In
+that shape, the persistence block a few lines down still read `report` (the
+provider's own genuine `completed` result) and committed `COMPLETED` to the
+ledger, while `failure` being newly non-`None` meant `run_assignment` still
+raised the `OSError` to the caller at the method's final `raise failure` —
+the caller saw a raised exception while the ledger recorded success, two
+facts that must never disagree. Fixed: when the after-snapshot faults and
+there was no earlier failure, the snapshot fault itself becomes the
+terminal failure — `FAILED` is persisted, not `COMPLETED`, with a fresh
+failed receipt (`internal_error`) overwriting the stale successful one
+already written to `receipt.json`, so the receipt on disk agrees with the
+ledger's own verdict. The provider's own successful result is not silently
+discarded either: the failure message names that the provider itself
+succeeded (or whatever its report said) before the boundary check could not
+be confirmed.
+
+A workspace root being a symlink is now also refused *before* the workspace
+is ever created or the provider invoked, not only inside `reclaim_workspace`
+at the very end. **Corrected by review round three** (finding B): the
+review-round-two symlink guard inside `reclaim_workspace` only fires during
+reclaim, by which point a pre-planted symlink at the workspace path had
+already let the provider read and write through it for real — into
+whatever external directory the link pointed at — with `COMPLETED` already
+committed to the ledger before reclaim's own refusal ever fired. Fixed by
+checking the workspace path for a symlink at the very first opportunity,
+immediately alongside the `workspace_policy` validation and before the SOW
+or assignment state is touched, before the directory is created, and before
+the provider is ever invoked — proven with the same
+invocation-counter-stays-zero pattern the policy check already established,
+plus a byte-for-byte hash of the external target's whole tree, before and
+after, not merely a check for new top-level names. On this path,
+`reclaim_workspace`'s own symlink guard never gets exercised at all — the
+early refusal is the only one the caller sees — but that guard stays in
+place unchanged as defense in depth for whatever other path might reach
+`reclaim_workspace` directly.
+
+The check also walks every ancestor directory from the workspace path up to
+(but not including) `self.root`, not only the workspace leaf itself: a
+leaf-only check is blind to `.sovereign/runs/` (or `.sovereign/`) itself
+being a symlink, since the leaf workspace directory underneath a symlinked
+ancestor is, on its own, a perfectly ordinary, non-symlink directory —
+`workspace.is_symlink()` alone would traverse straight through such an
+ancestor transparently. `self.root` itself is excluded from the walk
+because it is the organization's own allocated real directory, not
+something this method traverses into on the provider's behalf.
+
 ### Property 2 — `Actor.workspace_policy` is enforced
 
 `models.py:120` declared the field (`workspace_policy: str =
@@ -213,17 +264,22 @@ python scripts/verify_curriculum.py
 
 # Property 1 — reclaim tied to terminal state, including the interrupted path;
 # a snapshot fault at either bracket still reaches a terminal state and never
-# masks a real interruption (review round two, P1 finding 1); reclaim refuses
-# a symlinked workspace root and unlinks (never rmtrees) a symlinked child
+# masks a real interruption (review round two, P1 finding 1); a snapshot
+# fault with NO prior failure becomes the terminal failure itself instead of
+# a false COMPLETED (review round three, finding A); reclaim refuses a
+# symlinked workspace root and unlinks (never rmtrees) a symlinked child
 # entry without touching its external target (review round two, P1 finding 3)
 python -m pytest -q tests/test_workspace_lifecycle.py \
   -k "reclaimed_after_terminal_state or survives_non_terminal_state or interrupted_assignment or hard_kill or fault_in_before_snapshot or fault_in_after_snapshot or reclaim_refuses_a_symlinked or reclaim_unlinks_a_symlinked"
 
 # Property 2 — workspace_policy drives real branching, loads from TOML, fails
 # closed on an unrecognized value, and validates before the provider ever
-# runs, proven by a spy/counter at zero (review round two, P1 finding 2)
+# runs, proven by a spy/counter at zero (review round two, P1 finding 2); a
+# symlinked workspace root -- leaf or ancestor -- is refused before the
+# provider ever runs too, same spy/counter plus a byte-for-byte external-tree
+# hash (review round three, finding B)
 python -m pytest -q tests/test_workspace_lifecycle.py \
-  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml"
+  -k "persistent_policy or temporary_directory_policy or unknown_workspace_policy or policy_loads_from_toml or symlinked_workspace_root_refused_before or symlinked_runs_directory_ancestor"
 
 # Property 3 — boundary violation detected end to end, mutation-checked both
 # directions (a real escape is caught; legitimate in-workspace writes are
@@ -254,13 +310,17 @@ estimated:
 | Before (Units 0-6 accepted, `33e51d19`) | 23/40 | 3696/6000 | 7/30 |
 | After (this unit, original) | 24/40 | 3916/6000 | 7/30 |
 | After (review round two's four P1 fixes + P2) | 24/40 | 4056/6000 | 7/30 |
+| After (review round three's two findings) | 24/40 | 4134/6000 | 7/30 |
 
 One new module (`src/sovereign_agent/workspace.py`), no new root export —
 `Organization.run_assignment` and `_require_deliverables` call the new module
 internally; nothing in `workspace.py` is re-exported from the package root.
 Review round two's fixes stayed inside the same two modules (`workspace.py`,
 `organization.py`) plus their tests — no new module, no new root export.
-Headroom remaining: 16 modules, 1944 nonblank lines, 23 root exports.
+Review round three's fixes stayed inside `organization.py` and its test file
+only — `workspace.py`'s own `reclaim_workspace` symlink guard is untouched,
+kept in place as defense in depth — no new module, no new root export.
+Headroom remaining: 16 modules, 1866 nonblank lines, 23 root exports.
 
 ## What this unit did not do
 

--- a/src/sovereign_agent/actors.py
+++ b/src/sovereign_agent/actors.py
@@ -54,12 +54,25 @@ def load_actors(path: Path) -> list[Actor]:
     data = tomllib.loads(path.read_text(encoding="utf-8"))
     actors = []
     for raw in data.get("actors", []):
-        actors.append(
+        # workspace_policy is genuinely optional: omitted from TOML, the
+        # model's own default ("temporary_directory") applies. Passed only
+        # when present, rather than always passed with a `.get(..., default)`
+        # that would need to duplicate the model's default here too.
+        actor = (
             Actor(
+                id=raw["id"],
+                role=Role(raw["role"]),
+                provider=raw["provider"],
+                authority=list(raw.get("authority", [])),
+                workspace_policy=raw["workspace_policy"],
+            )
+            if "workspace_policy" in raw
+            else Actor(
                 id=raw["id"],
                 role=Role(raw["role"]),
                 provider=raw["provider"],
                 authority=list(raw.get("authority", [])),
             )
         )
+        actors.append(actor)
     return actors

--- a/src/sovereign_agent/execution.py
+++ b/src/sovereign_agent/execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime
@@ -177,7 +178,32 @@ def invoke_actor(
     result = run_spec(spec)
     ended = utc_now()
     raw = workspace / "provider-raw"
-    raw.mkdir(parents=True, exist_ok=True)
+    # Round four's review (C1) found this path is the organization's OTHER
+    # write path with the same defect class as `.sovereign-out` in
+    # `organization.py::run_assignment`: `provider-raw` used to be created
+    # with a bare `mkdir(parents=True, exist_ok=True)`, which never
+    # disturbs pre-existing content -- a pre-planted symlink at this exact
+    # path (e.g. `provider-raw -> <external dir>`) would let the three
+    # writes just below land in whatever the link points at, for real.
+    # Removed and recreated fresh here, immediately before anything is
+    # written into it and after the subprocess has already run (nothing
+    # the provider does during its own execution touches `provider-raw` --
+    # only this function's own bookkeeping populates it afterward, so
+    # recreating fresh at this point closes the hole with no earlier write
+    # left exposed). `shutil.rmtree` unlinks a symlink entry -- or a real
+    # directory with any interior content -- without following a symlinked
+    # child out of the tree being removed, so an external target is never
+    # touched by the removal itself. `run_assignment` never invokes this
+    # function unless `workspace` itself already passed its own
+    # symlinked-ancestor and symlinked-`.sovereign-out` checks, but
+    # `provider-raw` is a third, independent path this function allocates
+    # on its own and those checks never looked at -- so it needs its own
+    # guard rather than relying on the caller's.
+    if raw.is_symlink():
+        raw.unlink()
+    elif raw.exists():
+        shutil.rmtree(raw)
+    raw.mkdir(parents=True, exist_ok=False)
     (raw / "stdout.txt").write_text(result.stdout)
     (raw / "stderr.txt").write_text(result.stderr)
     events = []

--- a/src/sovereign_agent/execution.py
+++ b/src/sovereign_agent/execution.py
@@ -201,6 +201,37 @@ def invoke_actor(
     # guard rather than relying on the caller's.
     if raw.is_symlink():
         raw.unlink()
+    elif raw.exists() and not raw.is_dir():
+        # Round five's review (E1), applied here for consistency with the
+        # identical fix in `organization.py::run_assignment`: a pre-planted
+        # ORDINARY FILE at `provider-raw` is not a symlink (the branch
+        # above does not fire) and is not a directory either -- the old
+        # unconditional `shutil.rmtree(raw)` on this path would raise
+        # `NotADirectoryError` trying to `scandir` it. That fault was
+        # already fail-closed here (this call happens inside
+        # `run_assignment`'s try block, so `except Exception` already
+        # caught it, wrote a `internal_error` receipt, and left the
+        # assignment FAILED honestly) -- but a raised `Refusal` is a more
+        # specific, more diagnosable failure than a generic caught
+        # exception, and this codebase's standing pattern is to name a
+        # malformed shape explicitly rather than let a generic exception
+        # describe it by accident. Raised, not silently swallowed: it is
+        # still caught by the same `except Refusal` handler in
+        # `run_assignment`, so the assignment still fails honestly -- only
+        # the receipt's category improves, from `internal_error` to
+        # this shape's own name.
+        raise Refusal(
+            f"Provider output path {str(raw)!r} exists and is not a directory.",
+            "`provider-raw` must be a real directory (or absent) for this "
+            "recreate to remove and repopulate it safely. A plain file "
+            "(or other non-directory node) at this path would make "
+            "`shutil.rmtree` raise `NotADirectoryError` instead of a "
+            "clear, diagnosable refusal -- so it is refused explicitly "
+            "here instead.",
+            actor.id,
+            "Remove the file at that path before retrying this assignment.",
+            category="non_directory_output_path",
+        )
     elif raw.exists():
         shutil.rmtree(raw)
     raw.mkdir(parents=True, exist_ok=False)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -314,9 +314,43 @@ class Organization:
                 "before retrying this assignment.",
                 category="symlinked_workspace_root",
             )
+        # The ancestor walk above guards the workspace ROOT and everything
+        # above it. It says nothing about `.sovereign-out`, the
+        # organization-allocated OUTPUT CHILD living one level *below* the
+        # workspace root -- the dual of the check above, same mechanism,
+        # opposite position. `workspace` can pass every check above as an
+        # ordinary real directory while `.sovereign-out` inside it was
+        # pre-planted as a symlink: the provider would then write its
+        # report and every declared artifact through that link, for real,
+        # into whatever external directory it points at, and
+        # `_require_deliverables` -- which reconstructs this exact path
+        # independently and joins onto it via `safe_join` -- resolves
+        # through the same symlink and accepts evidence sitting entirely
+        # outside the workspace boundary as proof the SOW was satisfied.
+        # Refused here, before the SOW or assignment state is touched,
+        # before `workspace` itself is created, and before the provider is
+        # ever invoked -- the same fail-closed shape as the check above,
+        # not folded into it, because it is a distinct path component
+        # (a child, not an ancestor) that a single symlink check on
+        # `workspace` and its parents cannot see.
+        output = workspace / ".sovereign-out"
+        if output.is_symlink():
+            raise Refusal(
+                f"Workspace output path {str(output)!r} is a symlink.",
+                "A symlinked output child would let the provider write its "
+                "report and every declared artifact through it for real, "
+                "into whatever the link points at -- and "
+                "`_require_deliverables` would then resolve through the "
+                "same link and accept evidence sitting entirely outside "
+                "the workspace boundary as proof the SOW was satisfied. "
+                "The provider must never run against an output path this "
+                "method did not allocate as a real directory.",
+                worker.id,
+                "Investigate how that path became a symlink before retrying this assignment.",
+                category="symlinked_output_directory",
+            )
         sow = self._sow(assignment.sow_id)
         sow.state = advance_sow(sow.state, SowState.RUNNING)
-        output = workspace / ".sovereign-out"
         workspace.mkdir(parents=True, exist_ok=True)
         assignment.state = AssignmentState.RUNNING
         self._save_assignment(assignment, sow, "assignment.running")

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -365,6 +365,40 @@ class Organization:
                 "Investigate how that path became a symlink before retrying this assignment.",
                 category="symlinked_output_directory",
             )
+        # Round five's review (E1): the symlink check above is not the only
+        # non-directory shape this path can hold. A pre-planted ORDINARY
+        # FILE at `.sovereign-out` is not a symlink (the check above lets
+        # it through) and is not a directory either -- `shutil.rmtree`
+        # just below would raise `NotADirectoryError` trying to `scandir`
+        # it, a fault the recreate block was never written to expect. That
+        # fault is fail-closed in both places it can occur (this refusal
+        # closes the .sovereign-out case before it can happen at all;
+        # `execution.py::invoke_actor`'s identical guard on `provider-raw`
+        # is the fault's other occurrence, closed the same way just below)
+        # -- but a silent `NotADirectoryError` is a worse diagnostic than a
+        # named Refusal, and this codebase's standing pattern is to name a
+        # hostile or malformed shape explicitly rather than let a generic
+        # exception describe it by accident. Given its own category, not
+        # folded into `symlinked_output_directory`: it is a different
+        # shape with a different likely cause (leftover file from a prior
+        # run's crash, not necessarily an adversarial link) and a
+        # different fix ("remove the file"), so the category should say
+        # which one applies rather than making the operator re-diagnose it
+        # from the message alone.
+        elif output.exists() and not output.is_dir():
+            raise Refusal(
+                f"Workspace output path {str(output)!r} exists and is not a directory.",
+                "`.sovereign-out` must be a real directory (or absent) for "
+                "the recreate below to remove and repopulate it safely. A "
+                "plain file (or other non-directory node) at this path "
+                "would make `shutil.rmtree` raise `NotADirectoryError` "
+                "before the provider ever runs, instead of a clear, "
+                "diagnosable refusal -- so it is refused explicitly here "
+                "instead.",
+                worker.id,
+                "Remove the file at that path before retrying this assignment.",
+                category="non_directory_output_path",
+            )
         sow = self._sow(assignment.sow_id)
         sow.state = advance_sow(sow.state, SowState.RUNNING)
         workspace.mkdir(parents=True, exist_ok=True)
@@ -387,10 +421,16 @@ class Organization:
         # never run against an output path this method did not allocate
         # as a real directory") actually true, closing C1 and C2 in one
         # move regardless of which hostile interior shape was planted.
-        # (The symlink check just above already refused `output` being a
-        # symlink itself, so by construction only a real directory -- or
-        # nothing at all -- can remain here; `output.exists()` alone is
-        # therefore a complete test, not an approximation.)
+        # (The symlink check and the non-directory check just above have
+        # already refused every shape `output` could hold other than a
+        # real directory or nothing at all -- a symlink is refused first,
+        # a plain file or other non-directory node is refused second, so
+        # by construction only a real directory or an absent path can
+        # reach this line. `output.exists()` alone is therefore a complete
+        # test of "is there a directory to remove", not an approximation:
+        # every non-directory shape was already turned away above, rather
+        # than left for `shutil.rmtree` to discover as a raw
+        # `NotADirectoryError`.)
         if output.exists():
             shutil.rmtree(output)
         output.mkdir(parents=True, exist_ok=False)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -333,6 +334,21 @@ class Organization:
         # not folded into it, because it is a distinct path component
         # (a child, not an ancestor) that a single symlink check on
         # `workspace` and its parents cannot see.
+        #
+        # This check alone only catches ONE hostile shape: `.sovereign-out`
+        # being a symlink itself. Round four's review (C1/C2) found the
+        # dual of THIS fix: `.sovereign-out` pre-planted as an ordinary
+        # REAL directory with a hostile interior -- a symlinked child
+        # (`report.json` pointing out of the workspace, so the provider's
+        # real write lands on the external target through it) or a
+        # fabricated deliverable (a file already sitting there, never
+        # written by the provider, that `_require_deliverables` would then
+        # accept as proof the run produced it). Neither shape is a symlink
+        # at the `.sovereign-out` path itself, so the check above passes
+        # both through untouched -- the provider's own
+        # `mkdir(parents=True, exist_ok=True)` never disturbs pre-existing
+        # content, so whatever was planted here survives to be written
+        # through or read as evidence.
         output = workspace / ".sovereign-out"
         if output.is_symlink():
             raise Refusal(
@@ -352,6 +368,32 @@ class Organization:
         sow = self._sow(assignment.sow_id)
         sow.state = advance_sow(sow.state, SowState.RUNNING)
         workspace.mkdir(parents=True, exist_ok=True)
+        # Allocated fresh here, not merely checked: this is the actual fix
+        # for C1/C2. `shutil.rmtree` removes whatever is at `.sovereign-out`
+        # -- a real directory with any interior content, however that
+        # content got there -- WITHOUT following a symlinked child out of
+        # the tree it is deleting (a symlink entry inside a directory being
+        # removed is unlinked itself, never traversed into), so a hostage
+        # file a symlinked child pointed at is never touched by the
+        # removal. `missing_ok`-equivalent via `ignore_errors=False` would
+        # raise on a path that does not exist yet, which is the common
+        # case (the workspace is usually new); guarded explicitly instead
+        # of swallowing errors broadly, so a real permission fault here
+        # still surfaces rather than being silently absorbed. The mkdir
+        # that follows creates a fresh, empty, real directory with no
+        # pre-existing content of any kind for the provider to write
+        # through or for acceptance to trust -- making the claim in the
+        # comment above (and in the Refusal message: "the provider must
+        # never run against an output path this method did not allocate
+        # as a real directory") actually true, closing C1 and C2 in one
+        # move regardless of which hostile interior shape was planted.
+        # (The symlink check just above already refused `output` being a
+        # symlink itself, so by construction only a real directory -- or
+        # nothing at all -- can remain here; `output.exists()` alone is
+        # therefore a complete test, not an approximation.)
+        if output.exists():
+            shutil.rmtree(output)
+        output.mkdir(parents=True, exist_ok=False)
         assignment.state = AssignmentState.RUNNING
         self._save_assignment(assignment, sow, "assignment.running")
         started_at = utc_now()

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -42,7 +42,14 @@ from sovereign_agent.policy import (
 from sovereign_agent.providers import get_provider
 from sovereign_agent.relay import inbox as relay_inbox
 from sovereign_agent.relay import send as relay_send
-from sovereign_agent.workspace import diff_boundary, reclaim_workspace, safe_join, snapshot_boundary
+from sovereign_agent.workspace import (
+    WORKSPACE_POLICIES,
+    BoundarySnapshot,
+    diff_boundary,
+    reclaim_workspace,
+    safe_join,
+    snapshot_boundary,
+)
 
 
 class Organization:
@@ -241,6 +248,26 @@ class Organization:
         assignment = self._assignment(assignment_id)
         assignment_may_run(assignment.state)
         worker = self.actor(assignment.actor_id)
+        # Validated before ANYTHING else -- before the SOW or assignment
+        # state is touched, before the workspace directory is created, and
+        # long before the provider is invoked. An unrecognized policy used
+        # to surface only inside `reclaim_workspace`, at the very end of this
+        # method, by which point the provider had already run for real and
+        # COMPLETED was already committed to the ledger -- an invalid
+        # configuration value should mean the run never happened at all, not
+        # that it happened and then the bookkeeping afterward refused.
+        if worker.workspace_policy not in WORKSPACE_POLICIES:
+            raise Refusal(
+                f"Unknown workspace policy {worker.workspace_policy!r}.",
+                "A policy this module does not recognize must not be "
+                "silently treated as either 'reclaim' or 'keep' -- both are "
+                "real, consequential choices, and the provider must never "
+                "run for an actor whose policy cannot be enforced "
+                "afterward.",
+                worker.id,
+                f"Use one of: {', '.join(sorted(WORKSPACE_POLICIES))}.",
+                category="unknown_workspace_policy",
+            )
         sow = self._sow(assignment.sow_id)
         sow.state = advance_sow(sow.state, SowState.RUNNING)
         workspace = self.root / ".sovereign" / "runs" / assignment.workspace_id
@@ -250,12 +277,21 @@ class Organization:
         self._save_assignment(assignment, sow, "assignment.running")
         started_at = utc_now()
         failure: BaseException | None = None
-        # Taken BEFORE the provider runs, so the boundary check below proves
-        # something about THIS invocation, not about drift left over from an
-        # earlier one. Every exception path still runs the invocation (or
-        # attempts to), so the snapshot covers every path, not just success.
-        boundary_before = snapshot_boundary(self.root, workspace)
+        boundary_before: BoundarySnapshot | None = None
         try:
+            # Taken BEFORE the provider runs, so the boundary check below
+            # proves something about THIS invocation, not about drift left
+            # over from an earlier one. Folded into this same try block (it
+            # used to run unguarded, ahead of the try): a fault here --
+            # e.g. a transient OSError reading the tree to digest -- used to
+            # propagate straight out of `run_assignment` before the provider
+            # was ever invoked and before any receipt was written, leaving
+            # the assignment stuck at RUNNING (already persisted above) with
+            # no terminal record at all. Caught by the same three handlers
+            # as a provider fault, it now produces the same honest failed
+            # receipt and terminal state every other fault in this method
+            # produces.
+            boundary_before = snapshot_boundary(self.root, workspace)
             receipt, report = invoke_actor(
                 worker, sow, workspace, output, assignment_id=assignment.id
             )
@@ -308,8 +344,31 @@ class Organization:
         # exception path was taken above -- detection, not prevention, per
         # the governing ruling: this proves what changed outside the
         # workspace, it does not claim to have stopped it.
-        boundary_after = snapshot_boundary(self.root, workspace)
-        boundary_report = diff_boundary(boundary_before, boundary_after)
+        #
+        # Guarded, not bare: by this point `receipt` is already durable proof
+        # of whatever happened above (including an interruption, which is
+        # already recorded and captured in `failure`). A fault taking THIS
+        # snapshot -- e.g. the same transient OSError the before-snapshot
+        # could hit -- used to propagate completely unguarded, which, if a
+        # real interruption had already been caught above, would replace
+        # that interruption's own exception with this unrelated one at the
+        # `raise failure` line near the end of this method: the caller would
+        # see an OSError from bookkeeping instead of the KeyboardInterrupt
+        # that actually happened. A fault here is caught, recorded as an
+        # honestly-empty boundary report (nothing claimed, not "no
+        # violation"), and never allowed to overwrite an already-determined
+        # `failure` -- the more important fact always wins.
+        try:
+            boundary_after = snapshot_boundary(self.root, workspace)
+            boundary_report = (
+                diff_boundary(boundary_before, boundary_after)
+                if boundary_before is not None
+                else None
+            )
+        except OSError as snapshot_error:
+            boundary_report = None
+            if failure is None:
+                failure = snapshot_error
         with self.db.transaction():
             self.db.put_serialized("receipts", receipt.id, receipt_json)
             if report and report.status == "completed":
@@ -328,7 +387,12 @@ class Organization:
             )
             # A durable, queryable fact regardless of verdict: a clean report
             # is itself evidence the boundary held for this invocation, not
-            # merely the absence of a complaint.
+            # merely the absence of a complaint. `boundary_report` is `None`
+            # only when a snapshot itself faulted (see above) -- recorded
+            # here as `computed: False` rather than as `violated: False`,
+            # because "the check could not run" and "the check ran and
+            # found nothing" are different facts and must not share one
+            # boolean.
             append_event(
                 self.db,
                 "assignment.workspace_boundary_checked",
@@ -336,10 +400,12 @@ class Organization:
                     "assignment_id": assignment.id,
                     "actor_id": worker.id,
                     "provider": worker.provider,
-                    "violated": boundary_report.violated,
-                    "changed": list(boundary_report.changed),
-                    "added": list(boundary_report.added),
-                    "removed": list(boundary_report.removed),
+                    "computed": boundary_report is not None,
+                    "scope": boundary_report.scope if boundary_report is not None else None,
+                    "violated": boundary_report.violated if boundary_report is not None else None,
+                    "changed": list(boundary_report.changed) if boundary_report is not None else [],
+                    "added": list(boundary_report.added) if boundary_report is not None else [],
+                    "removed": list(boundary_report.removed) if boundary_report is not None else [],
                 },
             )
         self._project_outcome(sow.outcome_id)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -268,9 +268,54 @@ class Organization:
                 f"Use one of: {', '.join(sorted(WORKSPACE_POLICIES))}.",
                 category="unknown_workspace_policy",
             )
+        workspace = self.root / ".sovereign" / "runs" / assignment.workspace_id
+        # Checked here, alongside the policy validation above and before
+        # ANYTHING else -- same reasoning, same placement. The symlink guard
+        # inside reclaim_workspace only fires at the very end of this
+        # method, by which point a pre-planted symlink at this exact path
+        # already let the provider read and write through it for real: the
+        # workspace boundary this unit's whole subject is confining is
+        # defeated at the point of use, not merely at cleanup. A symlink
+        # here means some other code path substituted a link for the
+        # directory this method is about to allocate, so refuse before the
+        # SOW or assignment state is touched, before the directory is
+        # created, and before the provider is ever invoked -- exactly the
+        # same fail-closed shape as the policy check just above.
+        # The leaf is not the only place a symlink can substitute a real
+        # organization-owned directory for a link: `.sovereign/runs/`
+        # itself (or `.sovereign/`) being a symlink would traverse
+        # transparently to a leaf check that only looks at `workspace`
+        # itself, since `workspace.is_symlink()` is false for a workspace
+        # path that is a perfectly ordinary directory sitting under a
+        # symlinked ancestor. Walked from `workspace` up to (but not
+        # including) `self.root`, because `self.root` itself is the
+        # organization's own allocated real directory -- checking it here
+        # would be checking something this method did not just traverse
+        # into on the provider's behalf.
+        offending = None
+        for ancestor in (workspace, *workspace.parents):
+            if ancestor == self.root:
+                break  # self.root is the organization's own real directory
+            if ancestor.is_symlink():
+                offending = ancestor
+                break
+        if offending is not None:
+            raise Refusal(
+                f"Workspace path component {str(offending)!r} is a symlink.",
+                "A symlinked workspace root -- or a symlinked ancestor "
+                "directory on the path to it -- would let the provider "
+                "read and write through it for real, into whatever the "
+                "link points at -- a boundary defeated at the point of "
+                "use, not merely at cleanup. The provider must never run "
+                "against a workspace path this method did not allocate "
+                "as real directories the whole way down.",
+                worker.id,
+                "Investigate how that path component became a symlink "
+                "before retrying this assignment.",
+                category="symlinked_workspace_root",
+            )
         sow = self._sow(assignment.sow_id)
         sow.state = advance_sow(sow.state, SowState.RUNNING)
-        workspace = self.root / ".sovereign" / "runs" / assignment.workspace_id
         output = workspace / ".sovereign-out"
         workspace.mkdir(parents=True, exist_ok=True)
         assignment.state = AssignmentState.RUNNING
@@ -368,6 +413,39 @@ class Organization:
         except OSError as snapshot_error:
             boundary_report = None
             if failure is None:
+                # The provider itself succeeded (or was refused cleanly) --
+                # no prior failure exists to protect. Leaving `failure` at
+                # `None` here would mean the exception still propagates to
+                # the caller (the `raise failure` guard below only fires
+                # when `failure is not None`... except this branch sets it),
+                # while the persistence block a few lines down commits
+                # whatever `report` says, which for a successful provider
+                # is COMPLETED. That combination -- caller sees a raised
+                # OSError, ledger says success -- is exactly the disagreement
+                # this branch exists to prevent. With no earlier failure to
+                # protect, the snapshot fault becomes the terminal failure
+                # itself: `report` is discarded for persistence purposes
+                # (see below) and a fresh failed receipt overwrites the
+                # stale successful one already on disk, so the receipt and
+                # the ledger agree with what the caller is about to see.
+                # The provider's own result is not silently dropped either:
+                # the failure message names it explicitly.
+                provider_note = (
+                    f"provider reported {report.status!r}"
+                    if report is not None
+                    else "provider raised no report"
+                )
+                receipt = write_failed_receipt(
+                    worker,
+                    workspace,
+                    "internal_error",
+                    "after-snapshot fault; boundary could not be confirmed "
+                    f"({provider_note}): {type(snapshot_error).__name__}: {snapshot_error}",
+                    started_at,
+                    assignment_id=assignment.id,
+                )
+                receipt_json = (workspace / "receipt.json").read_text(encoding="utf-8")
+                report = None
                 failure = snapshot_error
         with self.db.transaction():
             self.db.put_serialized("receipts", receipt.id, receipt_json)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -42,6 +42,7 @@ from sovereign_agent.policy import (
 from sovereign_agent.providers import get_provider
 from sovereign_agent.relay import inbox as relay_inbox
 from sovereign_agent.relay import send as relay_send
+from sovereign_agent.workspace import diff_boundary, reclaim_workspace, safe_join, snapshot_boundary
 
 
 class Organization:
@@ -249,6 +250,11 @@ class Organization:
         self._save_assignment(assignment, sow, "assignment.running")
         started_at = utc_now()
         failure: BaseException | None = None
+        # Taken BEFORE the provider runs, so the boundary check below proves
+        # something about THIS invocation, not about drift left over from an
+        # earlier one. Every exception path still runs the invocation (or
+        # attempts to), so the snapshot covers every path, not just success.
+        boundary_before = snapshot_boundary(self.root, workspace)
         try:
             receipt, report = invoke_actor(
                 worker, sow, workspace, output, assignment_id=assignment.id
@@ -298,6 +304,12 @@ class Organization:
             report = None
             failure = error
         receipt_json = (workspace / "receipt.json").read_text(encoding="utf-8")
+        # Diffed AFTER the provider has fully run (or failed to), whichever
+        # exception path was taken above -- detection, not prevention, per
+        # the governing ruling: this proves what changed outside the
+        # workspace, it does not claim to have stopped it.
+        boundary_after = snapshot_boundary(self.root, workspace)
+        boundary_report = diff_boundary(boundary_before, boundary_after)
         with self.db.transaction():
             self.db.put_serialized("receipts", receipt.id, receipt_json)
             if report and report.status == "completed":
@@ -314,7 +326,31 @@ class Organization:
             append_event(
                 self.db, "assignment.finished", {"id": assignment.id, "status": assignment.state}
             )
+            # A durable, queryable fact regardless of verdict: a clean report
+            # is itself evidence the boundary held for this invocation, not
+            # merely the absence of a complaint.
+            append_event(
+                self.db,
+                "assignment.workspace_boundary_checked",
+                {
+                    "assignment_id": assignment.id,
+                    "actor_id": worker.id,
+                    "provider": worker.provider,
+                    "violated": boundary_report.violated,
+                    "changed": list(boundary_report.changed),
+                    "added": list(boundary_report.added),
+                    "removed": list(boundary_report.removed),
+                },
+            )
         self._project_outcome(sow.outcome_id)
+        # The assignment is terminal on every path that reaches this line
+        # (COMPLETED, BLOCKED, or FAILED was just written above -- including
+        # the interrupted path, which records FAILED before re-raising).
+        # Reclaim runs against that terminal record, never against an
+        # assignment still RUNNING: a hard kill that never reaches this line
+        # leaves the workspace in place, which is the correct, fail-closed
+        # outcome -- Unit 8 recovery territory, not silently deleted evidence.
+        reclaim_workspace(workspace, worker.workspace_policy)
         if failure is not None:
             raise failure
         return assignment
@@ -742,7 +778,13 @@ class Organization:
         assignment = self._assignment(execution)
         output = self.root / ".sovereign" / "runs" / assignment.workspace_id / ".sovereign-out"
         for deliverable in sow.deliverables:
-            if not (output / deliverable).is_file():
+            # A deliverable name comes from a governed record, but it is still
+            # an unvalidated string: a `../` segment or an absolute path must
+            # not be allowed to escape this SOW's own output directory to
+            # check -- or later, once acceptance trusts this method -- claim
+            # the existence of a file anywhere else on disk.
+            path = safe_join(output, deliverable)
+            if not path.is_file():
                 raise Refusal(
                     f"SOW {sow.id} promised {deliverable} and did not produce it.",
                     "A unit of work is done when its deliverable exists, not "

--- a/src/sovereign_agent/workspace.py
+++ b/src/sovereign_agent/workspace.py
@@ -1,0 +1,193 @@
+"""Workspace lifecycle: reclaim, policy enforcement, and a detectable boundary.
+
+A run workspace (`.sovereign/runs/<workspace_id>/`) is where a provider is
+told to confine its reads and writes. Before Unit 7 that boundary was a
+sentence in the assignment envelope and the directory itself lived forever.
+This module makes the boundary something the organization can check after the
+fact, makes `Actor.workspace_policy` change what actually happens on disk, and
+makes every path taken from a governed record (a deliverable name) safe to
+join without walking outside its declared root.
+
+Three responsibilities, one module, because all three are the same shape: a
+workspace is a directory whose contents are supposed to stay inside a line,
+and each function here is a different way of drawing that line precisely.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from sovereign_agent.errors import Refusal
+
+# The only two values `Actor.workspace_policy` may hold. A value outside this
+# set fails closed rather than silently falling back to a default -- the same
+# defect class named in the governing ruling ("workspace_policy ... nothing in
+# the package reads it") would recur one layer down if an unrecognized string
+# were quietly treated as "temporary_directory".
+TEMPORARY_DIRECTORY = "temporary_directory"
+PERSISTENT = "persistent"
+WORKSPACE_POLICIES = frozenset({TEMPORARY_DIRECTORY, PERSISTENT})
+
+# Reclaim never removes these: the receipt and its digest sidecar are the
+# durable proof an execution ran, and the output directory holds the report
+# and every declared deliverable, both read by code that runs long after
+# `run_assignment` returns (`_require_deliverables`, `accept`, Chapter 3's own
+# exercise). "Reclaim" frees the actor's disposable scratch space, not the
+# organization's evidence.
+_PRESERVED_ON_RECLAIM = ("receipt.json", "receipt.json.sha256")
+_PRESERVED_DIR_ON_RECLAIM = ".sovereign-out"
+
+
+def safe_join(root: Path, relative: str) -> Path:
+    """Join `relative` onto `root`, refusing anything that would escape it.
+
+    `Path.__truediv__` treats an absolute right-hand side as a full
+    replacement of the left, and a relative path may still climb out via
+    `..` segments that a string-prefix check cannot see through symlinks or
+    mixed separators. This resolves both `root` and the joined candidate and
+    requires the candidate to sit at or under the resolved root -- the check
+    is on the resolved filesystem path, not on the string.
+    """
+    if not relative or relative.strip() == "":
+        raise Refusal(
+            "Empty path.",
+            "A workspace-relative path must name something.",
+            str(root),
+            "Supply a non-empty relative path.",
+            category="path_traversal",
+        )
+    resolved_root = root.resolve()
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError as error:
+        raise Refusal(
+            f"Path {relative!r} escapes its workspace root.",
+            "A workspace-relative path must resolve inside its declared root, "
+            "not beside or above it.",
+            str(resolved_root),
+            "Use a path that stays inside the workspace.",
+            category="path_traversal",
+        ) from error
+    return candidate
+
+
+def _iter_files(root: Path, *, exclude: frozenset[Path]) -> list[Path]:
+    if not root.exists():
+        return []
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if any(path == excluded or excluded in path.parents for excluded in exclude):
+            continue
+        files.append(path)
+    return files
+
+
+@dataclass(frozen=True)
+class BoundarySnapshot:
+    """A digest of every tracked file outside one assignment's workspace.
+
+    Not a full filesystem scan of the host -- scoped to the organization root,
+    the same tree the assignment envelope calls the boundary. `.sovereign/
+    organization.db*` is excluded: the SQLite ledger is legitimately written
+    by this same process, in the same transaction that records the
+    assignment's own progress, not by the subprocess under test. The
+    workspace directory itself is excluded because the actor is *authorized*
+    to write there; the boundary this snapshot protects is everything else.
+    """
+
+    digests: dict[str, str]
+
+    @property
+    def paths(self) -> frozenset[str]:
+        return frozenset(self.digests)
+
+
+def snapshot_boundary(org_root: Path, workspace: Path) -> BoundarySnapshot:
+    org_root = org_root.resolve()
+    exclude = frozenset(
+        {
+            workspace.resolve(),
+            (org_root / ".sovereign" / "organization.db").resolve(),
+            (org_root / ".sovereign" / "organization.db-wal").resolve(),
+            (org_root / ".sovereign" / "organization.db-shm").resolve(),
+        }
+    )
+    digests: dict[str, str] = {}
+    for path in _iter_files(org_root, exclude=exclude):
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        digests[str(path.relative_to(org_root))] = digest
+    return BoundarySnapshot(digests=digests)
+
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    """What changed outside the workspace between two snapshots.
+
+    Named for what it proves: DETECTED, not prevented. A clean report means no
+    tracked file outside the workspace changed during this invocation, on the
+    provider whose adapter has no OS-level sandbox exactly as much as on the
+    one that does -- the check does not depend on the provider having told the
+    truth about its own containment.
+    """
+
+    violated: bool
+    changed: tuple[str, ...]
+    added: tuple[str, ...]
+    removed: tuple[str, ...]
+
+
+def diff_boundary(before: BoundarySnapshot, after: BoundarySnapshot) -> BoundaryReport:
+    changed = tuple(
+        sorted(
+            path
+            for path in before.paths & after.paths
+            if before.digests[path] != after.digests[path]
+        )
+    )
+    added = tuple(sorted(after.paths - before.paths))
+    removed = tuple(sorted(before.paths - after.paths))
+    violated = bool(changed or added or removed)
+    return BoundaryReport(violated=violated, changed=changed, added=added, removed=removed)
+
+
+def reclaim_workspace(workspace: Path, policy: str) -> bool:
+    """Apply `policy` to a workspace that has reached a terminal state.
+
+    Returns whether anything was reclaimed. `temporary_directory` (the
+    model's own default) removes the actor's disposable scratch space --
+    everything in the workspace except the receipt and the output directory,
+    both preserved because later code (`_require_deliverables`, `accept`, the
+    Chapter 3 exercise) reads them long after this call returns. `persistent`
+    reclaims nothing: the whole point of choosing it is to leave the run
+    inspectable. An unrecognized policy fails closed rather than guessing.
+    """
+    if policy not in WORKSPACE_POLICIES:
+        raise Refusal(
+            f"Unknown workspace policy {policy!r}.",
+            "A policy this module does not recognize must not be silently "
+            "treated as either 'reclaim' or 'keep' -- both are real, "
+            "consequential choices.",
+            str(workspace),
+            f"Use one of: {', '.join(sorted(WORKSPACE_POLICIES))}.",
+            category="unknown_workspace_policy",
+        )
+    if policy == PERSISTENT:
+        return False
+    if not workspace.exists():
+        return False
+    reclaimed = False
+    for entry in sorted(workspace.iterdir()):
+        if entry.name in _PRESERVED_ON_RECLAIM or entry.name == _PRESERVED_DIR_ON_RECLAIM:
+            continue
+        reclaimed = True
+        if entry.is_dir():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+    return reclaimed

--- a/src/sovereign_agent/workspace.py
+++ b/src/sovereign_agent/workspace.py
@@ -50,6 +50,14 @@ def safe_join(root: Path, relative: str) -> Path:
     mixed separators. This resolves both `root` and the joined candidate and
     requires the candidate to sit at or under the resolved root -- the check
     is on the resolved filesystem path, not on the string.
+
+    An absolute `relative` is refused outright, regardless of where it would
+    resolve. The contract this function serves is "name something inside
+    root" -- a caller with a legitimate reason to name an absolute path does
+    not have a workspace-relative name to begin with, and accepting one only
+    when it happens to land inside root makes the refusal depend on where the
+    caller's filesystem happens to put things rather than on the shape of the
+    input itself.
     """
     if not relative or relative.strip() == "":
         raise Refusal(
@@ -57,6 +65,17 @@ def safe_join(root: Path, relative: str) -> Path:
             "A workspace-relative path must name something.",
             str(root),
             "Supply a non-empty relative path.",
+            category="path_traversal",
+        )
+    if Path(relative).is_absolute():
+        raise Refusal(
+            f"Path {relative!r} escapes its workspace root.",
+            "A workspace-relative path must be relative, not absolute -- "
+            "even one that would resolve inside root is refused, so "
+            "whether a path is accepted never depends on where root "
+            "happens to sit on this filesystem.",
+            str(root.resolve()),
+            "Use a path that stays inside the workspace.",
             category="path_traversal",
         )
     resolved_root = root.resolve()
@@ -88,6 +107,21 @@ def _iter_files(root: Path, *, exclude: frozenset[Path]) -> list[Path]:
     return files
 
 
+# What a `BoundarySnapshot` / `BoundaryReport` actually covers, named so the
+# report can say so of itself rather than let a bare `violated: False` be
+# misread as "execution stayed inside the workspace" in general. Two things
+# under the organization root are structurally invisible to this check, both
+# for reasons named in this module's own docstring and in Property 3 of
+# docs/v1-unit7-workspace-lifecycle.md: the assignment's own workspace (the
+# actor is *authorized* to write there, so it is excluded on purpose, not
+# missed) and `.sovereign/organization.db*` (legitimately written by this
+# same process's own transaction, not by the subprocess under test -- a real
+# schema or row write there is invisible here by design). Anything the host
+# filesystem holds outside the organization root entirely was never in scope
+# to begin with -- this was never a full scan of the host.
+BOUNDARY_SCOPE = "organization_root_excluding_workspace_and_ledger"
+
+
 @dataclass(frozen=True)
 class BoundarySnapshot:
     """A digest of every tracked file outside one assignment's workspace.
@@ -99,6 +133,8 @@ class BoundarySnapshot:
     assignment's own progress, not by the subprocess under test. The
     workspace directory itself is excluded because the actor is *authorized*
     to write there; the boundary this snapshot protects is everything else.
+    See `BOUNDARY_SCOPE` for the same fact stated as a value a report can
+    carry, not only as a docstring a reader must already be looking at.
     """
 
     digests: dict[str, str]
@@ -130,16 +166,22 @@ class BoundaryReport:
     """What changed outside the workspace between two snapshots.
 
     Named for what it proves: DETECTED, not prevented. A clean report means no
-    tracked file outside the workspace changed during this invocation, on the
+    tracked file *within `scope`* changed during this invocation, on the
     provider whose adapter has no OS-level sandbox exactly as much as on the
     one that does -- the check does not depend on the provider having told the
-    truth about its own containment.
+    truth about its own containment. `scope` is carried on every report
+    (always `BOUNDARY_SCOPE` for a report `diff_boundary` produces) so
+    `violated: False` reads as "nothing changed in what this check can see,"
+    never as an unqualified claim that execution stayed inside the workspace
+    -- the DB and the workspace itself are outside what this check can see,
+    by the same design `BOUNDARY_SCOPE`'s own docstring states.
     """
 
     violated: bool
     changed: tuple[str, ...]
     added: tuple[str, ...]
     removed: tuple[str, ...]
+    scope: str = BOUNDARY_SCOPE
 
 
 def diff_boundary(before: BoundarySnapshot, after: BoundarySnapshot) -> BoundaryReport:
@@ -166,6 +208,27 @@ def reclaim_workspace(workspace: Path, policy: str) -> bool:
     Chapter 3 exercise) reads them long after this call returns. `persistent`
     reclaims nothing: the whole point of choosing it is to leave the run
     inspectable. An unrecognized policy fails closed rather than guessing.
+
+    Two symlink shapes are handled deliberately, not by accident of
+    `shutil.rmtree`'s own behaviour:
+
+    - `workspace` itself being a symlink is REFUSED outright, before any
+      removal is attempted. `workspace` is supposed to be an organization-
+      allocated real directory (`.sovereign/runs/<workspace_id>/`); a symlink
+      there means some other code path substituted a link for that
+      allocation, and recursing through it would delete whatever real
+      directory the link points at -- data this function has no authority
+      over and no way to know is safe to remove. Refusing is a `Refusal`,
+      not a silent no-op, because a caller relying on reclaim actually
+      running needs to see that it did not.
+    - A symlink *entry inside* an otherwise-real workspace is unlinked with
+      `Path.unlink()`, which removes the link itself and never follows it
+      into its target, instead of `shutil.rmtree`, which refuses to recurse
+      into a symlinked directory and raises `OSError` -- an exception with
+      no guard at this function's only call site (`Organization.
+      run_assignment`), where it would propagate after the assignment's
+      terminal state and receipt are already durably written, potentially
+      masking whatever the run itself did or did not raise.
     """
     if policy not in WORKSPACE_POLICIES:
         raise Refusal(
@@ -179,14 +242,30 @@ def reclaim_workspace(workspace: Path, policy: str) -> bool:
         )
     if policy == PERSISTENT:
         return False
-    if not workspace.exists():
+    if not workspace.exists() and not workspace.is_symlink():
         return False
+    if workspace.is_symlink():
+        raise Refusal(
+            f"Workspace root {str(workspace)!r} is a symlink.",
+            "Reclaim never recurses through a symlinked workspace root -- "
+            "the organization allocates a real directory at this path, and "
+            "a symlink here would make removal delete whatever the link "
+            "points at instead, which this function has no authority over.",
+            str(workspace),
+            "Investigate how the workspace root became a symlink before retrying reclaim.",
+            category="symlinked_workspace_root",
+        )
     reclaimed = False
     for entry in sorted(workspace.iterdir()):
         if entry.name in _PRESERVED_ON_RECLAIM or entry.name == _PRESERVED_DIR_ON_RECLAIM:
             continue
         reclaimed = True
-        if entry.is_dir():
+        if entry.is_symlink():
+            # Removes the link itself, never follows it into its target --
+            # the target may be anything, including a real directory this
+            # function must not touch.
+            entry.unlink()
+        elif entry.is_dir():
             shutil.rmtree(entry)
         else:
             entry.unlink()

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -121,6 +121,17 @@ def _assignment(
 ) -> tuple[Organization, str, str]:
     org = Organization.init(root)
     org.actors["operator-course"].provider = provider
+    # This suite inspects scratch files (`observed-envelope.json`,
+    # `observed-argv.json`) the fake CLI leaves directly in the workspace
+    # root, after `run_assignment` returns. Unit 7's default policy,
+    # `temporary_directory`, reclaims exactly that scratch space once the
+    # assignment is terminal -- correct new behaviour that would otherwise
+    # delete the fixtures these tests are built to read. `persistent` is the
+    # actor's own declared opt-out, and using it here doubles as a live
+    # demonstration that the policy is load-bearing: flip it back to the
+    # default and `test_temporary_directory_policy_reclaims_scratch_files`
+    # in test_workspace_lifecycle.py shows the opposite outcome.
+    org.actors["operator-course"].workspace_policy = "persistent"
     outcome = org.create_outcome("fixture", "report exists", ["receipt valid"], "principal-human")
     org.activate(outcome.id, "master-course")
     sow = org.create_sow(

--- a/tests/test_workspace_lifecycle.py
+++ b/tests/test_workspace_lifecycle.py
@@ -25,9 +25,11 @@ import pytest
 import sovereign_agent.organization as organization_module
 from reference_organizations.store import seed
 from sovereign_agent.errors import Refusal
+from sovereign_agent.events import append_event
 from sovereign_agent.models import AssignmentState, Role
 from sovereign_agent.organization import Organization
 from sovereign_agent.workspace import (
+    BOUNDARY_SCOPE,
     PERSISTENT,
     TEMPORARY_DIRECTORY,
     diff_boundary,
@@ -132,6 +134,87 @@ def test_interrupted_assignment_still_reclaims_its_scratch_space(tmp_path: Path)
     )
 
 
+def test_fault_in_before_snapshot_still_reaches_a_terminal_state(tmp_path: Path) -> None:
+    """Reviewer finding 1 (also independently reproduced by Master): the
+    boundary snapshot taken BEFORE the provider runs used to sit outside the
+    try/except that produces a receipt -- an OSError there propagated
+    straight out of `run_assignment`, past the persistence block, leaving
+    the assignment stuck at RUNNING (already committed a few lines above)
+    with no receipt at all. It is now taken inside the same try block, so
+    the same three handlers that catch a provider fault catch this one too.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+
+    call_count = {"n": 0}
+    real_snapshot = organization_module.snapshot_boundary
+
+    def flaky_before(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise OSError("simulated fault reading the tree to digest")
+        return real_snapshot(*args, **kwargs)
+
+    with patch.object(organization_module, "snapshot_boundary", side_effect=flaky_before):
+        with pytest.raises(OSError, match="simulated fault"):
+            org.run_assignment(assignment_id)
+
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.FAILED, (
+        "a before-snapshot fault must still reach a terminal state, not strand RUNNING"
+    )
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is not None, "a receipt must exist even when the fault is in bookkeeping"
+    assert json.loads(row["record"])["failure_category"] == "internal_error"
+
+
+def test_fault_in_after_snapshot_never_masks_a_real_interruption(tmp_path: Path) -> None:
+    """Reviewer finding 1's sharper sub-case, overlapping finding 3's own
+    'masking' concern: the provider itself is interrupted (a real
+    KeyboardInterrupt, recorded as an 'interrupted' receipt), and THEN the
+    AFTER snapshot also faults. The snapshot fault must never replace the
+    interruption at the final `raise failure` -- the more important fact,
+    that the run was interrupted, must win and be what the caller sees.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+
+    call_count = {"n": 0}
+    real_snapshot = organization_module.snapshot_boundary
+
+    def flaky_after(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        call_count["n"] += 1
+        if call_count["n"] == 2:  # the AFTER snapshot -- the second call
+            raise OSError("simulated fault on the after-snapshot")
+        return real_snapshot(*args, **kwargs)
+
+    with (
+        patch.object(organization_module, "snapshot_boundary", side_effect=flaky_after),
+        patch.object(organization_module, "invoke_actor", side_effect=KeyboardInterrupt("killed")),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            org.run_assignment(assignment_id)
+
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.FAILED
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is not None
+    assert json.loads(row["record"])["failure_category"] == "interrupted", (
+        "the interruption's own receipt must survive a subsequent bookkeeping fault"
+    )
+    event_row = org.db.connection.execute(
+        "SELECT payload FROM events WHERE kind = 'assignment.workspace_boundary_checked'"
+    ).fetchone()
+    payload = json.loads(event_row["payload"])
+    assert payload["computed"] is False, (
+        "a faulted after-snapshot must record that the check could not run, "
+        "not silently claim 'violated: False'"
+    )
+    assert payload["violated"] is None
+
+
 def test_a_hard_kill_that_never_returns_leaves_the_workspace_alone(tmp_path: Path) -> None:
     """A process that dies before `run_assignment` reaches its persistence
     block never calls reclaim at all -- simulated here not by raising inside
@@ -179,6 +262,103 @@ def test_unknown_workspace_policy_fails_closed(tmp_path: Path) -> None:
     workspace.mkdir()
     with pytest.raises(Refusal, match="Unknown workspace policy"):
         reclaim_workspace(workspace, "delete_immediately")
+
+
+# --- Master's finding 3: reclaim must never delete through a symlink -------
+
+
+def test_reclaim_refuses_a_symlinked_workspace_root(tmp_path: Path) -> None:
+    """Master independently reproduced this against the real library
+    function, outside any fixture: a workspace root that is itself a
+    symlink used to have `reclaim_workspace` recurse straight through it via
+    `shutil.rmtree`, deleting whatever real directory the link pointed at.
+    Fixed to refuse outright -- a `Refusal`, not a silent no-op, and the
+    external target's own file is checked byte-identical afterward, not
+    merely "still present."
+    """
+    external = tmp_path / "external-target"
+    external.mkdir()
+    marker = external / "external-marker"
+    marker.write_text("must survive")
+    original_bytes = marker.read_bytes()
+
+    workspace = tmp_path / "workspace-symlink"
+    workspace.symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(Refusal, match="symlink"):
+        reclaim_workspace(workspace, TEMPORARY_DIRECTORY)
+
+    assert marker.exists(), "the external target must not be touched at all"
+    assert marker.read_bytes() == original_bytes, "byte-identical, not merely present"
+    assert external.is_dir(), "the external directory itself must survive"
+
+
+def test_reclaim_unlinks_a_symlinked_child_without_following_it(tmp_path: Path) -> None:
+    """The review's own named sub-case: a *child* entry inside an otherwise
+    real, legitimate workspace is a symlink to something external.
+    `shutil.rmtree` refuses to recurse into a symlinked directory and raises
+    `OSError` instead -- unguarded, that would propagate out of
+    `run_assignment` after the ledger is already terminal, potentially
+    masking whatever the run itself did or did not raise (see
+    test_fault_in_after_snapshot_never_masks_a_real_interruption for that
+    interaction). Fixed to `Path.unlink()` the symlink entry itself --
+    removing the link, never following it into its target.
+    """
+    external = tmp_path / "external-target-child"
+    external.mkdir()
+    marker = external / "external-marker-child"
+    marker.write_text("must survive too")
+    original_bytes = marker.read_bytes()
+
+    workspace = tmp_path / "workspace-real"
+    workspace.mkdir()
+    (workspace / ".sovereign-out").mkdir()
+    child_link = workspace / "linked-child"
+    child_link.symlink_to(external, target_is_directory=True)
+
+    reclaimed = reclaim_workspace(workspace, TEMPORARY_DIRECTORY)
+
+    assert reclaimed is True
+    assert not child_link.exists() and not child_link.is_symlink(), (
+        "the symlink entry itself must be gone from the workspace"
+    )
+    assert marker.exists(), "the external target must not be touched at all"
+    assert marker.read_bytes() == original_bytes, "byte-identical, not merely present"
+    assert external.is_dir(), "the external directory itself must survive"
+
+
+def test_unknown_workspace_policy_refuses_before_the_provider_ever_runs(tmp_path: Path) -> None:
+    """Reviewer finding 2: an invalid `workspace_policy` used to be caught
+    only inside `reclaim_workspace`, at the very end of `run_assignment` --
+    by which point the provider had already run for real and COMPLETED was
+    already committed to the ledger. `invoke_actor` is spied on with a
+    counter (not merely re-asserted against network/side-effect absence) to
+    prove it is never called at all when the policy is invalid: the run
+    must not have happened, not merely have its result discarded afterward.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    org.actors["operator-course"].workspace_policy = "delete_everything_now"
+
+    invoked = {"count": 0}
+    real_invoke = organization_module.invoke_actor
+
+    def counting_invoke(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        invoked["count"] += 1
+        return real_invoke(*args, **kwargs)
+
+    with patch.object(organization_module, "invoke_actor", side_effect=counting_invoke):
+        with pytest.raises(Refusal, match="Unknown workspace policy"):
+            org.run_assignment(assignment_id)
+
+    assert invoked["count"] == 0, "the provider must never be invoked for an invalid policy"
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.CREATED, (
+        "the assignment must not even reach RUNNING when the policy is invalid"
+    )
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is None, "no receipt: the run never happened, it was not merely discarded"
 
 
 def test_workspace_policy_loads_from_toml(tmp_path: Path) -> None:
@@ -269,6 +449,44 @@ def test_a_completed_assignment_records_a_clean_boundary_event(tmp_path: Path) -
     payload = json.loads(rows[0]["payload"])
     assert payload["assignment_id"] == assignment_id
     assert payload["violated"] is False
+    assert payload["computed"] is True
+    assert payload["scope"] == BOUNDARY_SCOPE, (
+        "the event must name what it covers, not let 'violated: False' be "
+        "misread as an unqualified claim"
+    )
+
+
+def test_boundary_report_does_not_see_a_real_database_write(tmp_path: Path) -> None:
+    """Reviewer finding 4: `organization.db*` is excluded from the digested
+    tree on purpose (Property 3's own documented rationale -- it is written
+    by this same process's transaction, not by the subprocess under test),
+    so a real schema/row write there is structurally invisible to
+    `diff_boundary`. This is not a defect to make disappear by widening
+    coverage; it is a coverage-honesty property: the report must say what
+    it covers (`scope`) rather than let `violated: False` be misread as
+    "nothing changed anywhere," including in the ledger.
+    """
+    org = Organization.init(tmp_path)
+    db_path = org.root / ".sovereign" / "organization.db"
+    workspace = tmp_path / ".sovereign" / "runs" / "ws_test"
+    workspace.mkdir(parents=True)
+
+    before = snapshot_boundary(org.root, workspace)
+    # A real write to the ledger the check is documented to exclude.
+    with org.db.transaction():
+        append_event(org.db, "test.probe", {"marker": "a real db write happened"})
+    after = snapshot_boundary(org.root, workspace)
+
+    report = diff_boundary(before, after)
+    assert db_path.exists(), "sanity: the db file is real and was actually written to"
+    assert not report.violated, (
+        "the db write is genuinely outside this check's scope -- it must not "
+        "spuriously report a violation for a path it was never told to watch"
+    )
+    assert report.scope == BOUNDARY_SCOPE, (
+        "the report must carry an honest scope value so violated=False is "
+        "never misread as full-organization coverage"
+    )
 
 
 def test_a_provider_that_writes_outside_its_workspace_is_caught_by_run_assignment(
@@ -320,6 +538,30 @@ def test_absolute_deliverable_path_is_refused(tmp_path: Path) -> None:
     root.mkdir()
     with pytest.raises(Refusal, match="escapes its workspace root"):
         safe_join(root, "/etc/passwd")
+
+
+def test_absolute_deliverable_path_is_refused_even_when_it_resolves_inside_root(
+    tmp_path: Path,
+) -> None:
+    """P2: an absolute path that happens to land inside `root` used to be
+    ACCEPTED, because the old check only compared resolved paths and never
+    looked at whether the input itself was absolute -- despite this
+    function's own docstring implying workspace-relative paths only, and
+    `test_absolute_deliverable_path_is_refused` above already asserting the
+    contract is "absolute is refused," not "absolute is refused unless it
+    resolves inside root." `_require_deliverables`'s only real caller passes
+    workspace-relative deliverable names, so accepting an absolute one that
+    happens to resolve inside root is never a legitimate use case here --
+    the fix rejects any absolute input outright, matching the apparent
+    contract rather than papering over the mismatch by loosening the
+    docstring instead.
+    """
+    root = tmp_path / "output"
+    root.mkdir()
+    (root / "report.json").write_text("{}")
+    absolute_but_inside = str(root / "report.json")
+    with pytest.raises(Refusal, match="escapes its workspace root"):
+        safe_join(root, absolute_but_inside)
 
 
 def test_legitimate_nested_deliverable_still_succeeds(tmp_path: Path) -> None:

--- a/tests/test_workspace_lifecycle.py
+++ b/tests/test_workspace_lifecycle.py
@@ -567,6 +567,76 @@ def test_symlinked_runs_directory_ancestor_is_also_refused_before_the_provider_r
     )
 
 
+def test_symlinked_output_directory_refused_before_the_provider_ever_runs(
+    tmp_path: Path,
+) -> None:
+    """Round three's finding (B3): the two checks above guard the workspace
+    ROOT and its ancestors, but neither one looks at `.sovereign-out`, the
+    organization-allocated OUTPUT CHILD living one level *below* the
+    workspace root. This test allocates `workspace` itself as an ordinary
+    real directory -- so the ancestor-walk above does not fire -- and
+    pre-plants `.sovereign-out` as a symlink to an external target before
+    `run_assignment` ever touches it.
+
+    Before the fix: the provider runs for real and writes its report and
+    artifacts straight through the link into the external directory,
+    `run_assignment` returns COMPLETED, and `_require_deliverables` (which
+    reconstructs the same `.sovereign-out` path independently and calls
+    `safe_join` against it) resolves through the symlink and ACCEPTS a
+    deliverable planted directly in the external directory -- evidence the
+    run never produced -- as satisfying the SOW. Same threat model as the
+    workspace-root case above (a governed path substituted with a symlink
+    before use), one level down: the write-through and the accept-through
+    are two faces of the same unchecked path.
+
+    Same shape as the two tests above: `invoke_actor` is spied on with a
+    counter to prove the provider is never invoked, and the external
+    target's whole tree is hashed before and after to prove nothing was
+    written through the link at all.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    workspace_path = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    external = tmp_path / "external-output-target"
+    external.mkdir()
+
+    # The workspace root itself is an ordinary real directory -- allocated
+    # the way `run_assignment` allocates it -- so the ancestor-walk check
+    # above does not fire and this test isolates the output-child gap.
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    (workspace_path / ".sovereign-out").symlink_to(external, target_is_directory=True)
+
+    before_hash = hash_tree(external)
+
+    invoked = {"count": 0}
+    real_invoke = organization_module.invoke_actor
+
+    def counting_invoke(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        invoked["count"] += 1
+        return real_invoke(*args, **kwargs)
+
+    with patch.object(organization_module, "invoke_actor", side_effect=counting_invoke):
+        with pytest.raises(Refusal, match="symlink") as excinfo:
+            org.run_assignment(assignment_id)
+
+    assert excinfo.value.category == "symlinked_output_directory"
+    assert invoked["count"] == 0, (
+        "the provider must never be invoked with an output path that is a symlink"
+    )
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.CREATED, (
+        "the assignment must not even reach RUNNING when the output child is a symlink"
+    )
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is None, "no receipt: the run never happened, it was not merely discarded"
+    assert hash_tree(external) == before_hash, (
+        "the external target's whole tree must be byte-for-byte unchanged -- "
+        "nothing written through the symlinked output child at all"
+    )
+
+
 # --- Property 3: the workspace boundary is detectable -----------------------
 
 

--- a/tests/test_workspace_lifecycle.py
+++ b/tests/test_workspace_lifecycle.py
@@ -1,0 +1,395 @@
+"""Unit 7: workspace lifecycle.
+
+Five properties, per docs/rulings/2026-08-27-unit7-is-workspaces-not-pulse.md:
+
+1. Reclaim tied to assignment terminal state.
+2. `Actor.workspace_policy` is enforced, not merely declared.
+3. The workspace boundary is detectable, not merely declared.
+4. `_require_deliverables` refuses a path that would escape its root.
+5. All four providers held to the same rule, with no live credential.
+
+Every test here drives the REAL `run_assignment` / `_require_deliverables`
+path, the same discipline test_scripted_execution_matrix.py established for
+the interrupted-receipt fix this ruling explicitly asks reclaim to match.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import sovereign_agent.organization as organization_module
+from reference_organizations.store import seed
+from sovereign_agent.errors import Refusal
+from sovereign_agent.models import AssignmentState, Role
+from sovereign_agent.organization import Organization
+from sovereign_agent.workspace import (
+    PERSISTENT,
+    TEMPORARY_DIRECTORY,
+    diff_boundary,
+    reclaim_workspace,
+    safe_join,
+    snapshot_boundary,
+)
+
+
+def dispatched(root: Path) -> tuple[Organization, str, str]:
+    """A store with one SOW assigned but not yet run."""
+    org = Organization.init(root)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "Keep the tea jar stocked",
+        "On-hand tea stays at or above the reorder point.",
+        ["inventory_at_or_above_reorder_point"],
+        "principal-human",
+        "SKU-TEA",
+    )
+    org.activate(outcome.id, "master-course")
+    sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
+    org.ready_sow(sow.id)
+    assignment = org.assign(sow.id, "operator-course", "master-course")
+    return org, sow.id, assignment.id
+
+
+def workspace_dir(org: Organization, assignment_id: str) -> Path:
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    return org.root / ".sovereign" / "runs" / assignment.workspace_id
+
+
+# --- Property 1: reclaim tied to terminal state -----------------------------
+
+
+def test_workspace_reclaimed_after_terminal_state(tmp_path: Path) -> None:
+    """A completed assignment's scratch space is gone; its proof is not."""
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    workspace = workspace_dir(org, assignment_id)
+    org.run_assignment(assignment_id)
+
+    assert workspace.exists(), "the workspace directory itself must survive"
+    assert (workspace / "receipt.json").is_file(), "the receipt is evidence, never reclaimed"
+    assert (workspace / "receipt.json.sha256").is_file()
+    assert (workspace / ".sovereign-out" / "report.json").is_file(), (
+        "the report must survive reclaim: later verification reads it"
+    )
+    # provider-raw is the actor's own disposable scratch output -- exactly
+    # what "reclaim" means here.
+    assert not (workspace / "provider-raw").exists(), (
+        "reclaim did not run: disposable scratch space survived a terminal state"
+    )
+
+
+def test_workspace_survives_non_terminal_state(tmp_path: Path) -> None:
+    """An assignment that never ran must not have its workspace touched.
+
+    `assign()` allocates a `workspace_id` but `run_assignment` is what creates
+    the directory and is the only place reclaim is ever called. Nothing must
+    reach into a workspace for an assignment still short of RUNNING.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    workspace = workspace_dir(org, assignment_id)
+    assert not workspace.exists(), "run_assignment was never called"
+    assert org._assignment(assignment_id).state == AssignmentState.CREATED  # noqa: SLF001
+
+
+def test_interrupted_assignment_still_reclaims_its_scratch_space(tmp_path: Path) -> None:
+    """The ruling's own bar: reclaim must be as fail-closed-correct as the
+    interrupted-receipt fix it is compared to -- meaning reclaim must still
+    run on the interrupted path, not be silently skipped, because the
+    assignment IS recorded terminal (FAILED, category "interrupted") before
+    `run_assignment` re-raises. A workspace is not "still in use" once the
+    ledger itself says the work is over.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    workspace = workspace_dir(org, assignment_id)
+    workspace.mkdir(parents=True)
+    (workspace / ".sovereign-out").mkdir()
+
+    with patch.object(organization_module, "invoke_actor", side_effect=KeyboardInterrupt("stop")):
+        with pytest.raises(KeyboardInterrupt):
+            org.run_assignment(assignment_id)
+
+    assert org._assignment(assignment_id).state == AssignmentState.FAILED  # noqa: SLF001
+    assert (workspace / "receipt.json").is_file(), "the interrupted receipt is evidence"
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert json.loads(row["record"])["failure_category"] == "interrupted"
+
+
+def test_a_hard_kill_that_never_returns_leaves_the_workspace_alone(tmp_path: Path) -> None:
+    """A process that dies before `run_assignment` reaches its persistence
+    block never calls reclaim at all -- simulated here not by raising inside
+    `run_assignment` (that IS the interrupted case above) but by never
+    invoking it in the first place, the only thing an in-process test can
+    honestly stand in for a SIGKILL. Unit 8 recovery territory; this test
+    only proves Unit 7 does not overreach into it.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    workspace = workspace_dir(org, assignment_id)
+    workspace.mkdir(parents=True)
+    marker = workspace / "still-running.marker"
+    marker.write_text("a hard kill leaves this behind")
+
+    # No call to run_assignment: this stands for the process dying before
+    # reclaim's call site is ever reached.
+    assert marker.is_file(), "nothing reclaimed a workspace run_assignment never finished"
+
+
+# --- Property 2: Actor.workspace_policy is enforced -------------------------
+
+
+def test_persistent_policy_keeps_scratch_space(tmp_path: Path) -> None:
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    org.actors["operator-course"].workspace_policy = PERSISTENT
+    workspace = workspace_dir(org, assignment_id)
+    org.run_assignment(assignment_id)
+    assert (workspace / "provider-raw").exists(), "persistent must leave the whole run inspectable"
+
+
+def test_temporary_directory_policy_reclaims_scratch_files(tmp_path: Path) -> None:
+    """The default value, exercised explicitly: same assignment shape as the
+    persistent case above, opposite outcome -- proof the field, not luck,
+    drives the branch.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    assert org.actors["operator-course"].workspace_policy == TEMPORARY_DIRECTORY
+    workspace = workspace_dir(org, assignment_id)
+    org.run_assignment(assignment_id)
+    assert not (workspace / "provider-raw").exists()
+
+
+def test_unknown_workspace_policy_fails_closed(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(Refusal, match="Unknown workspace policy"):
+        reclaim_workspace(workspace, "delete_immediately")
+
+
+def test_workspace_policy_loads_from_toml(tmp_path: Path) -> None:
+    """Loaded, not just modeled: `actors.py` used to read id/role/provider/
+    authority and silently drop workspace_policy from committed TOML.
+    """
+    Organization.init(tmp_path)
+    (tmp_path / "sovereign.toml").write_text(
+        (tmp_path / "sovereign.toml")
+        .read_text(encoding="utf-8")
+        .replace(
+            'id = "operator-course"',
+            'id = "operator-course"\nworkspace_policy = "persistent"',
+        ),
+        encoding="utf-8",
+    )
+    reloaded = Organization(tmp_path)
+    assert reloaded.actors["operator-course"].workspace_policy == PERSISTENT
+
+
+# --- Property 3: the workspace boundary is detectable -----------------------
+
+
+def test_detects_write_outside_workspace(tmp_path: Path) -> None:
+    """A file outside the workspace changing during an invocation must be
+    caught by the boundary diff -- the detection mechanism itself, exercised
+    directly rather than through a fake CLI, since the property is about the
+    organization's own check, not about any one provider's honesty.
+    """
+    org = Organization.init(tmp_path)
+    tracked = tmp_path / "outside.txt"
+    tracked.write_text("original")
+    workspace = tmp_path / ".sovereign" / "runs" / "ws_test"
+    workspace.mkdir(parents=True)
+
+    before = snapshot_boundary(org.root, workspace)
+    tracked.write_text("tampered by a provider that ignored its boundary")
+    after = snapshot_boundary(org.root, workspace)
+
+    report = diff_boundary(before, after)
+    assert report.violated
+    assert "outside.txt" in report.changed
+
+
+def test_writes_inside_the_workspace_do_not_trip_the_boundary_check(tmp_path: Path) -> None:
+    """Mutation check, the other direction: legitimate work inside the
+    workspace -- exactly what an actor is authorized to do -- must not be
+    reported as a violation. A detector that fires on authorized work is as
+    wrong as one that misses a real escape.
+    """
+    org = Organization.init(tmp_path)
+    workspace = tmp_path / ".sovereign" / "runs" / "ws_test"
+    workspace.mkdir(parents=True)
+
+    before = snapshot_boundary(org.root, workspace)
+    (workspace / "report.json").write_text('{"status": "completed"}')
+    after = snapshot_boundary(org.root, workspace)
+
+    report = diff_boundary(before, after)
+    assert not report.violated
+
+
+def test_a_new_file_outside_the_workspace_is_also_detected(tmp_path: Path) -> None:
+    """Not just modification -- an added file outside the boundary counts too."""
+    org = Organization.init(tmp_path)
+    workspace = tmp_path / ".sovereign" / "runs" / "ws_test"
+    workspace.mkdir(parents=True)
+
+    before = snapshot_boundary(org.root, workspace)
+    (tmp_path / "surprise.txt").write_text("a provider wrote here instead")
+    after = snapshot_boundary(org.root, workspace)
+
+    report = diff_boundary(before, after)
+    assert report.violated
+    assert "surprise.txt" in report.added
+
+
+def test_a_completed_assignment_records_a_clean_boundary_event(tmp_path: Path) -> None:
+    """The real run_assignment path: a scripted assignment writes only inside
+    its own workspace, so the recorded event must say the boundary held.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    org.run_assignment(assignment_id)
+    rows = org.db.connection.execute(
+        "SELECT payload FROM events WHERE kind = 'assignment.workspace_boundary_checked'"
+    ).fetchall()
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["payload"])
+    assert payload["assignment_id"] == assignment_id
+    assert payload["violated"] is False
+
+
+def test_a_provider_that_writes_outside_its_workspace_is_caught_by_run_assignment(
+    tmp_path: Path,
+) -> None:
+    """End to end: a misbehaving provider writes outside the workspace during
+    a real invocation, and `run_assignment` records that as a fact on the
+    ledger rather than silently accepting a completed report. This is the
+    property stated as "detected, not prevented": the assignment can still
+    complete -- nothing here claims to have stopped the write -- but the
+    violation is on the record either way.
+    """
+    org, sow_id, assignment_id = dispatched(tmp_path)
+    intruder = tmp_path / "tracked-outside-file.txt"
+    intruder.write_text("before")
+
+    from sovereign_agent.providers.scripted import ScriptedProvider
+
+    real_build = ScriptedProvider.build_invocation
+
+    def build_and_escape(self, request):  # noqa: ANN001
+        intruder.write_text("a provider reached outside its workspace")
+        return real_build(self, request)
+
+    with patch.object(ScriptedProvider, "build_invocation", build_and_escape):
+        org.run_assignment(assignment_id)
+
+    row = org.db.connection.execute(
+        "SELECT payload FROM events WHERE kind = 'assignment.workspace_boundary_checked'"
+    ).fetchone()
+    payload = json.loads(row["payload"])
+    assert payload["violated"] is True
+    assert "tracked-outside-file.txt" in payload["changed"]
+    assert sow_id  # sanity: the fixture built a real SOW, unused beyond that
+
+
+# --- Property 4: traversal-safe deliverable paths ---------------------------
+
+
+def test_traversal_deliverable_is_refused(tmp_path: Path) -> None:
+    root = tmp_path / "output"
+    root.mkdir()
+    with pytest.raises(Refusal, match="escapes its workspace root"):
+        safe_join(root, "../../../etc/passwd")
+
+
+def test_absolute_deliverable_path_is_refused(tmp_path: Path) -> None:
+    root = tmp_path / "output"
+    root.mkdir()
+    with pytest.raises(Refusal, match="escapes its workspace root"):
+        safe_join(root, "/etc/passwd")
+
+
+def test_legitimate_nested_deliverable_still_succeeds(tmp_path: Path) -> None:
+    """The check must not be so broad it refuses valid, nested work."""
+    root = tmp_path / "output"
+    (root / "reports").mkdir(parents=True)
+    (root / "reports" / "out.json").write_text("{}")
+    path = safe_join(root, "reports/out.json")
+    assert path.is_file()
+
+
+def test_empty_deliverable_path_is_refused(tmp_path: Path) -> None:
+    root = tmp_path / "output"
+    root.mkdir()
+    with pytest.raises(Refusal, match="Empty path"):
+        safe_join(root, "")
+
+
+def test_require_deliverables_refuses_traversal_end_to_end(tmp_path: Path) -> None:
+    """The real acceptance path: a SOW declaring a traversal deliverable must
+    be refused by `_require_deliverables`, not merely by the helper in
+    isolation.
+    """
+    org, sow_id, assignment_id = dispatched(tmp_path)
+    org.run_assignment(assignment_id)
+    sow = org._sow(sow_id)  # noqa: SLF001
+    sow.deliverables = ["../../../etc/passwd"]
+    with pytest.raises(Refusal, match="escapes its workspace root"):
+        org._require_deliverables(sow, assignment_id)  # noqa: SLF001
+
+
+# --- Property 5: parity across all four providers, no live credential ------
+
+
+def test_no_live_provider_credential_is_present_in_the_test_environment() -> None:
+    """This whole suite runs with no credential and no commercial CLI, per
+    the ruling's own bar ("no live credential", never simulated).
+    """
+    for variable in (
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CODEX_API_KEY",
+        "CURSOR_API_KEY",
+    ):
+        assert variable not in os.environ or not os.environ[variable], (
+            f"{variable} must not be set: this suite claims no live credential"
+        )
+
+
+@pytest.mark.parametrize("provider", ["scripted", "claude", "codex", "cursor"])
+def test_reclaim_and_boundary_check_apply_identically_across_providers(
+    tmp_path: Path, provider: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All four providers go through the SAME `run_assignment` reclaim and
+    boundary-check call sites -- there is no per-provider branch in
+    Organization.run_assignment for either mechanism. Proven here by fake
+    executables for the three CLI providers (same deterministic fixture
+    pattern as test_provider_integration.py) and the real scripted provider
+    for the fourth, all asserting the identical postcondition.
+    """
+    from tests.test_provider_integration import _install_fake_clis
+
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    if provider != "scripted":
+        _install_fake_clis(tmp_path / "bin", monkeypatch)
+        org.actors["operator-course"].provider = provider
+        # Same reasoning as test_provider_integration.py: the fake CLI's own
+        # scratch files are inspected nowhere in THIS test, but leaving the
+        # default policy would still reclaim them correctly. Nothing here
+        # depends on their survival, so the default is left as-is on purpose
+        # -- this test's assertions are about the receipt and report, which
+        # reclaim always preserves regardless of policy.
+    workspace = workspace_dir(org, assignment_id)
+
+    org.run_assignment(assignment_id)
+
+    assert (workspace / "receipt.json").is_file()
+    assert (workspace / ".sovereign-out" / "report.json").is_file()
+    row = org.db.connection.execute(
+        "SELECT payload FROM events WHERE kind = 'assignment.workspace_boundary_checked' "
+        "AND json_extract(payload, '$.assignment_id') = ?",
+        (assignment_id,),
+    ).fetchone()
+    assert row is not None, f"{provider}: boundary check did not run"
+    assert json.loads(row["payload"])["provider"] == provider

--- a/tests/test_workspace_lifecycle.py
+++ b/tests/test_workspace_lifecycle.py
@@ -799,6 +799,124 @@ def test_symlinked_provider_raw_cannot_be_written_through(tmp_path: Path) -> Non
     )
 
 
+def test_non_directory_output_path_is_refused_before_the_provider_ever_runs(
+    tmp_path: Path,
+) -> None:
+    """Round five's review (finding E1): the symlink check on
+    `.sovereign-out` only refuses that path BEING a symlink. It says
+    nothing about the path existing as some OTHER non-directory shape --
+    e.g. a plain file left over from an earlier crash, or planted by
+    something hostile that stops short of a symlink. Before this fix,
+    `run_assignment` would sail past the symlink check (a plain file is
+    not a symlink), reach the recreate's `if output.exists():
+    shutil.rmtree(output)`, and `shutil.rmtree` would raise a raw
+    `NotADirectoryError` trying to `scandir` a file -- fail-closed (the
+    assignment stays CREATED, no receipt, nothing persisted) but with no
+    named Refusal, no category, and no clear next step, and a code comment
+    at this exact call site that flatly claimed this shape could not
+    occur ("by construction only a real directory -- or nothing at all --
+    can remain here").
+
+    This test proves the fixed behavior: the same fault now produces a
+    named `Refusal` with an actionable message, raised BEFORE the provider
+    is ever invoked, before `.sovereign-out` is EVER modified. Same shape
+    of proof as the symlink test above it: `invoke_actor` is spied on with
+    a counter to prove the provider is never invoked, and the plain file
+    is asserted still present and unmodified afterward.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    workspace_path = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    output_path = workspace_path / ".sovereign-out"
+    output_path.write_text("leftover file, not a directory")
+
+    invoked = {"count": 0}
+    real_invoke = organization_module.invoke_actor
+
+    def counting_invoke(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        invoked["count"] += 1
+        return real_invoke(*args, **kwargs)
+
+    with patch.object(organization_module, "invoke_actor", side_effect=counting_invoke):
+        with pytest.raises(Refusal, match="not a directory") as excinfo:
+            org.run_assignment(assignment_id)
+
+    assert excinfo.value.category == "non_directory_output_path"
+    assert invoked["count"] == 0, (
+        "the provider must never be invoked when the output path is not a directory"
+    )
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.CREATED, (
+        "the assignment must not even reach RUNNING when .sovereign-out is a non-directory shape"
+    )
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is None, "no receipt: the run never happened, it was not merely discarded"
+    assert output_path.is_file() and not output_path.is_dir(), (
+        "the pre-planted file must still be exactly what it was -- refused, not touched"
+    )
+    assert output_path.read_text() == "leftover file, not a directory", (
+        "the file's content must be byte-for-byte unchanged by the refusal"
+    )
+
+
+def test_non_directory_provider_raw_is_refused_with_a_named_category(tmp_path: Path) -> None:
+    """The `provider-raw` sibling of the test above: round five's review
+    asked for the identical fix to be applied to `execution.py`'s
+    `provider-raw` allocation for consistency, even though that path's
+    un-fixed failure was already honest (caught by `run_assignment`'s
+    `except Exception` handler, `FAILED`, `internal_error`) rather than
+    escaping uncaught. This test proves the upgrade: the same pre-planted
+    plain file now produces a specific `non_directory_output_path`
+    category instead of the generic `internal_error` a raw
+    `NotADirectoryError` produced before, while the assignment still ends
+    up FAILED either way -- the ledger was already truthful; only the
+    diagnostic got better.
+
+    Uses the `persistent` workspace policy so `provider-raw` (and its
+    pre-planted file) survive reclaim and can be inspected after the run,
+    same reasoning as the symlinked-provider-raw test above.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    org.actors["operator-course"].workspace_policy = PERSISTENT
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    workspace_path = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    raw_path = workspace_path / "provider-raw"
+    raw_path.write_text("leftover file, not a directory")
+
+    # `invoke_actor`'s Refusal is caught by `run_assignment`'s own
+    # `except Exception` handler, which persists the failed receipt and
+    # terminal state -- and then, like every other fault caught there,
+    # RE-RAISES it to the caller once persistence is done (see the
+    # `interrupted`-path comment in `organization.py` for why: the caller
+    # still learns what happened, the ledger no longer merely implies it).
+    with pytest.raises(Refusal, match="not a directory"):
+        org.run_assignment(assignment_id)
+
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.FAILED, (
+        "a non-directory provider-raw must still fail the assignment honestly"
+    )
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is not None, "a receipt must be written even though the fault is now a Refusal"
+    receipt = json.loads(row["record"])
+    assert receipt["status"] == "failed"
+    assert receipt["failure_category"] == "non_directory_output_path", (
+        "the category must name the actual shape refused, not fall back to the "
+        "generic internal_error a raw NotADirectoryError used to produce"
+    )
+    assert raw_path.is_file() and not raw_path.is_dir(), (
+        "the pre-planted file must still be exactly what it was -- refused, not touched"
+    )
+
+
 # --- Property 3: the workspace boundary is detectable -----------------------
 
 

--- a/tests/test_workspace_lifecycle.py
+++ b/tests/test_workspace_lifecycle.py
@@ -637,6 +637,168 @@ def test_symlinked_output_directory_refused_before_the_provider_ever_runs(
     )
 
 
+def test_symlinked_child_inside_a_real_output_directory_cannot_be_written_through(
+    tmp_path: Path,
+) -> None:
+    """Round four's review (finding C1, the dual of the fix above): the
+    symlink check just above only refuses `.sovereign-out` *being* a
+    symlink. It says nothing about `.sovereign-out` pre-planted as an
+    ORDINARY REAL directory whose interior is hostile -- e.g. a symlinked
+    child, `report.json -> <external file>`. The provider's own
+    `mkdir(parents=True, exist_ok=True)` never disturbs pre-existing
+    content, so before the fix the provider would write its real report
+    bytes straight through that child link, into the external file, for
+    real -- a write escaping the workspace boundary with success
+    committed, not a refusal.
+
+    This test does not assert "refuse before running" (there is nothing to
+    refuse -- `.sovereign-out` itself is a perfectly ordinary real
+    directory). It asserts the run either cannot be corrupted this way at
+    all, or refuses honestly if it detects it was. The actual fix makes it
+    the former: `run_assignment` removes and recreates `.sovereign-out`
+    fresh immediately before the provider runs, so the pre-planted
+    symlinked child is gone before the provider ever gets a chance to
+    write through it.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    workspace_path = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    external = tmp_path / "external-hostage"
+    external.mkdir()
+    hostage = external / "hostage.txt"
+    hostage.write_text("ORIGINAL EXTERNAL BYTES")
+    before_hash = hash_tree(external)
+
+    # `.sovereign-out` itself is an ORDINARY REAL directory -- the existing
+    # symlink check does not fire -- but its child is a symlink pointing at
+    # a file entirely outside the workspace.
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    output_dir = workspace_path / ".sovereign-out"
+    output_dir.mkdir()
+    (output_dir / "report.json").symlink_to(hostage)
+
+    result = org.run_assignment(assignment_id)
+
+    assert result.state == AssignmentState.COMPLETED, (
+        "a real, non-hostile run must still complete normally -- the fix "
+        "must not turn ordinary success into a refusal"
+    )
+    assert hostage.read_text() == "ORIGINAL EXTERNAL BYTES", (
+        "the provider's report must never be written through a pre-planted "
+        "symlinked child -- the hostage file outside the workspace must be "
+        "byte-for-byte untouched"
+    )
+    assert hash_tree(external) == before_hash, (
+        "the external target's whole tree must be unchanged -- recreating "
+        ".sovereign-out fresh must remove the symlinked child before the "
+        "provider ever runs"
+    )
+    assert (output_dir / "report.json").is_file(), (
+        "the real report must exist at the usual path -- written by the "
+        "provider into the freshly recreated, real .sovereign-out"
+    )
+    assert not (output_dir / "report.json").is_symlink(), (
+        "the report path itself must be a real file, not still the pre-planted symlink"
+    )
+
+
+def test_fabricated_deliverable_preplanted_in_a_real_output_directory_is_not_accepted(
+    tmp_path: Path,
+) -> None:
+    """Round four's review (finding C2, the other dual): pre-plant
+    `.sovereign-out` as a real directory containing a file already named
+    as the SOW's deliverable -- never written by the provider at all.
+    Before the fix, the provider's `mkdir(exist_ok=True)` left the
+    fabricated file in place, the run completed, and
+    `_require_deliverables` accepted the pre-planted file as proof the SOW
+    was satisfied -- evidence the run never produced, exactly the
+    "unit of work is done when its deliverable exists" contract this
+    module states, defeated by evidence provenance rather than by a
+    missing file.
+
+    After the fix, recreating `.sovereign-out` fresh at allocation time
+    removes the fabricated file before the provider ever runs, so the run
+    completes with its OWN real output, and asking `_require_deliverables`
+    to accept the fabricated (now-absent) name correctly refuses --
+    honestly, not silently.
+    """
+    org, sow_id, assignment_id = dispatched(tmp_path)
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    workspace_path = org.root / ".sovereign" / "runs" / assignment.workspace_id
+
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    output_dir = workspace_path / ".sovereign-out"
+    output_dir.mkdir()
+    fabricated = output_dir / "fabricated-analysis.md"
+    fabricated.write_text("evidence the provider never wrote")
+
+    result = org.run_assignment(assignment_id)
+    assert result.state == AssignmentState.COMPLETED, (
+        "a real, non-hostile run must still complete normally"
+    )
+    assert not fabricated.exists(), (
+        "the fabricated file must not survive allocation-time recreate -- "
+        "if it did, it would still be sitting there unconnected to "
+        "anything the real provider run wrote"
+    )
+
+    sow = org._sow(sow_id)  # noqa: SLF001
+    sow.deliverables = ["fabricated-analysis.md"]
+    with pytest.raises(Refusal) as excinfo:
+        org._require_deliverables(sow, assignment_id)  # noqa: SLF001
+    assert "did not produce it" in str(excinfo.value)
+
+
+def test_symlinked_provider_raw_cannot_be_written_through(tmp_path: Path) -> None:
+    """The organization's OTHER write path: `invoke_actor`
+    (`execution.py`) writes `stdout.txt`, `stderr.txt`, and `events.jsonl`
+    into `workspace / "provider-raw"`, allocated with its own
+    `mkdir(parents=True, exist_ok=True)` -- the same unchecked-allocation
+    shape `.sovereign-out` had before this round's fix, on a path
+    `run_assignment`'s own checks never look at (they check `workspace`
+    and its ancestors, and `.sovereign-out`; `provider-raw` is a third,
+    independent child). Pre-planting `provider-raw` as a symlink to an
+    external directory, before the fix, let the three post-subprocess
+    writes land for real in the external directory.
+
+    `invoke_actor` now recreates `provider-raw` fresh immediately before
+    writing into it, closing the same class of hole on this second path.
+
+    Uses the `persistent` workspace policy (rather than the default
+    `temporary_directory`) so `provider-raw` survives reclaim at the end of
+    `run_assignment` and can actually be inspected afterward -- reclaim
+    legitimately removes `provider-raw` as disposable scratch under the
+    default policy, which is correct, existing behavior unrelated to this
+    fix and not what this test is about.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    org.actors["operator-course"].workspace_policy = PERSISTENT
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    workspace_path = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    external = tmp_path / "external-provider-raw"
+    external.mkdir()
+    before_hash = hash_tree(external)
+
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    (workspace_path / "provider-raw").symlink_to(external, target_is_directory=True)
+
+    result = org.run_assignment(assignment_id)
+
+    assert result.state == AssignmentState.COMPLETED
+    assert hash_tree(external) == before_hash, (
+        "the external target must be byte-for-byte unchanged -- nothing "
+        "written through the pre-planted provider-raw symlink"
+    )
+    raw_dir = workspace_path / "provider-raw"
+    assert raw_dir.is_dir() and not raw_dir.is_symlink(), (
+        "provider-raw must be a real directory after the run, not still the pre-planted symlink"
+    )
+    assert (raw_dir / "stdout.txt").is_file(), (
+        "the real bookkeeping files must exist at the usual path, written "
+        "into the freshly recreated, real provider-raw"
+    )
+
+
 # --- Property 3: the workspace boundary is detectable -----------------------
 
 

--- a/tests/test_workspace_lifecycle.py
+++ b/tests/test_workspace_lifecycle.py
@@ -107,6 +107,15 @@ def test_interrupted_assignment_still_reclaims_its_scratch_space(tmp_path: Path)
     workspace = workspace_dir(org, assignment_id)
     workspace.mkdir(parents=True)
     (workspace / ".sovereign-out").mkdir()
+    # The actor's own disposable scratch output -- exactly what "reclaim"
+    # means, and exactly what test_workspace_reclaimed_after_terminal_state
+    # checks for the non-interrupted path. Without this, the test has no
+    # precondition reclaim could possibly observe: `.sovereign-out` is on
+    # `_PRESERVED_DIR_ON_RECLAIM` and survives whether or not reclaim ever
+    # runs, so a test that only creates it cannot tell "reclaim ran and
+    # preserved evidence" from "reclaim never ran at all."
+    (workspace / "provider-raw").mkdir()
+    (workspace / "provider-raw" / "scratch.txt").write_text("disposable")
 
     with patch.object(organization_module, "invoke_actor", side_effect=KeyboardInterrupt("stop")):
         with pytest.raises(KeyboardInterrupt):
@@ -118,6 +127,9 @@ def test_interrupted_assignment_still_reclaims_its_scratch_space(tmp_path: Path)
         "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
     ).fetchone()
     assert json.loads(row["record"])["failure_category"] == "interrupted"
+    assert not (workspace / "provider-raw").exists(), (
+        "reclaim did not run on the interrupted path: disposable scratch space survived"
+    )
 
 
 def test_a_hard_kill_that_never_returns_leaves_the_workspace_alone(tmp_path: Path) -> None:

--- a/tests/test_workspace_lifecycle.py
+++ b/tests/test_workspace_lifecycle.py
@@ -62,6 +62,23 @@ def workspace_dir(org: Organization, assignment_id: str) -> Path:
     return org.root / ".sovereign" / "runs" / assignment.workspace_id
 
 
+def hash_tree(root: Path) -> str:
+    """A byte-for-byte digest of every path and file's contents under
+    `root`, sorted for determinism. Used where "the directory wasn't
+    touched" must mean the whole tree is unchanged, not merely that it
+    didn't gain new top-level names -- a check that a symlinked-root refusal
+    must survive.
+    """
+    import hashlib
+
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*")):
+        digest.update(str(path.relative_to(root)).encode())
+        if path.is_file():
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
 # --- Property 1: reclaim tied to terminal state -----------------------------
 
 
@@ -211,6 +228,67 @@ def test_fault_in_after_snapshot_never_masks_a_real_interruption(tmp_path: Path)
     assert payload["computed"] is False, (
         "a faulted after-snapshot must record that the check could not run, "
         "not silently claim 'violated: False'"
+    )
+    assert payload["violated"] is None
+
+
+def test_fault_in_after_snapshot_with_no_prior_failure_records_honest_failure(
+    tmp_path: Path,
+) -> None:
+    """Distinct from the interruption case above: here there was NO earlier
+    failure to protect -- the real scripted provider runs to completion
+    normally, uninterrupted -- and THEN the after-snapshot faults. The old
+    guard (`if failure is None: failure = snapshot_error`) was written only
+    to stop a snapshot fault from overwriting an already-caught, more
+    important failure; it says nothing about what to persist when there was
+    no prior failure at all. Left as `report and report.status ==
+    "completed"`, the persistence block below still committed COMPLETED
+    from the provider's own genuine success, while `failure` being newly
+    non-None meant `run_assignment` still raised the OSError to the caller
+    -- caller sees a raised exception, ledger says success, and the two
+    disagree. This test guards that the snapshot fault must itself become
+    the honestly-recorded terminal failure when nothing else already was.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+
+    call_count = {"n": 0}
+    real_snapshot = organization_module.snapshot_boundary
+
+    def flaky_after(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        call_count["n"] += 1
+        if call_count["n"] == 2:  # the AFTER snapshot -- the second call
+            raise OSError("simulated fault on after-snapshot, provider succeeded")
+        return real_snapshot(*args, **kwargs)
+
+    with patch.object(organization_module, "snapshot_boundary", side_effect=flaky_after):
+        with pytest.raises(OSError, match="simulated fault on after-snapshot"):
+            org.run_assignment(assignment_id)
+
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.FAILED, (
+        "the ledger must not record COMPLETED when the caller was handed a "
+        "raised exception -- the two must never disagree"
+    )
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is not None
+    record = json.loads(row["record"])
+    assert record["status"] == "failed", (
+        "the receipt on disk must match the ledger's own FAILED verdict, "
+        "not the provider's stale successful result"
+    )
+    assert record["failure_category"] == "internal_error"
+    assert "provider" in record["failure_message"].lower(), (
+        "the provider's own successful result must not be silently discarded "
+        "without a trace -- the failure message names what actually happened"
+    )
+    event_row = org.db.connection.execute(
+        "SELECT payload FROM events WHERE kind = 'assignment.workspace_boundary_checked'"
+    ).fetchone()
+    payload = json.loads(event_row["payload"])
+    assert payload["computed"] is False, (
+        "a faulted after-snapshot must record that the check could not run"
     )
     assert payload["violated"] is None
 
@@ -377,6 +455,116 @@ def test_workspace_policy_loads_from_toml(tmp_path: Path) -> None:
     )
     reloaded = Organization(tmp_path)
     assert reloaded.actors["operator-course"].workspace_policy == PERSISTENT
+
+
+def test_symlinked_workspace_root_refused_before_the_provider_ever_runs(tmp_path: Path) -> None:
+    """Master's finding: a symlinked workspace root used to be refused only
+    inside `reclaim_workspace`, at the very end of `run_assignment` -- by
+    which point the provider had already run for real THROUGH the symlink,
+    writing real files into whatever external directory the link pointed
+    at, and COMPLETED was already committed to the ledger. This test
+    pre-creates the workspace path AS a symlink before `run_assignment`
+    ever touches it, the same shape as
+    `test_unknown_workspace_policy_refuses_before_the_provider_ever_runs`
+    above: `invoke_actor` is spied on with a counter to prove the provider
+    is never invoked, and the external target's whole tree is hashed
+    before and after -- not just checked for new top-level names -- to
+    prove nothing was written through the link at all.
+
+    The early refusal is also the ONLY refusal the caller sees on this
+    path: `reclaim_workspace`'s own symlink guard never even gets
+    exercised here, because `run_assignment` never reaches the reclaim
+    call site once it refuses up front. That guard stays in place as
+    defense in depth for whatever other path might reach `reclaim_workspace`
+    directly (as `test_reclaim_refuses_a_symlinked_workspace_root` above
+    already covers), but on this path there is exactly one Refusal, not a
+    race between two.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    assignment = org._assignment(assignment_id)  # noqa: SLF001
+    workspace_path = org.root / ".sovereign" / "runs" / assignment.workspace_id
+    external = tmp_path / "external-target"
+    external.mkdir()
+
+    workspace_path.parent.mkdir(parents=True, exist_ok=True)
+    workspace_path.symlink_to(external, target_is_directory=True)
+
+    before_hash = hash_tree(external)
+
+    invoked = {"count": 0}
+    real_invoke = organization_module.invoke_actor
+
+    def counting_invoke(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        invoked["count"] += 1
+        return real_invoke(*args, **kwargs)
+
+    with patch.object(organization_module, "invoke_actor", side_effect=counting_invoke):
+        with pytest.raises(Refusal, match="symlink") as excinfo:
+            org.run_assignment(assignment_id)
+
+    assert excinfo.value.category == "symlinked_workspace_root"
+    assert invoked["count"] == 0, "the provider must never be invoked through a symlinked root"
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.CREATED, (
+        "the assignment must not even reach RUNNING when the root is a symlink"
+    )
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is None, "no receipt: the run never happened, it was not merely discarded"
+    assert hash_tree(external) == before_hash, (
+        "the external target's whole tree must be byte-for-byte unchanged, "
+        "not merely free of new top-level names"
+    )
+
+
+def test_symlinked_runs_directory_ancestor_is_also_refused_before_the_provider_runs(
+    tmp_path: Path,
+) -> None:
+    """The reviewer's own non-blocking note, taken seriously: a leaf-only
+    check (`workspace.is_symlink()`) is blind to `.sovereign/runs/` itself
+    being a symlink -- the workspace path underneath it would still be an
+    ordinary, non-symlink directory, so a check that only looks at the leaf
+    would traverse straight through a symlinked *ancestor* transparently.
+    This test symlinks `.sovereign/runs/` itself (not the leaf workspace
+    directory) to an external target and proves the same early refusal,
+    the same zero-invocation guarantee, and the same byte-for-byte-
+    unchanged external target as the leaf-symlink case above.
+    """
+    org, _sow_id, assignment_id = dispatched(tmp_path)
+    runs_dir = org.root / ".sovereign" / "runs"
+    external = tmp_path / "external-runs-target"
+    external.mkdir()
+
+    runs_dir.parent.mkdir(parents=True, exist_ok=True)
+    runs_dir.symlink_to(external, target_is_directory=True)
+
+    before_hash = hash_tree(external)
+
+    invoked = {"count": 0}
+    real_invoke = organization_module.invoke_actor
+
+    def counting_invoke(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        invoked["count"] += 1
+        return real_invoke(*args, **kwargs)
+
+    with patch.object(organization_module, "invoke_actor", side_effect=counting_invoke):
+        with pytest.raises(Refusal, match="symlink") as excinfo:
+            org.run_assignment(assignment_id)
+
+    assert excinfo.value.category == "symlinked_workspace_root"
+    assert invoked["count"] == 0, (
+        "the provider must never be invoked through a symlinked runs/ ancestor"
+    )
+    final = org._assignment(assignment_id)  # noqa: SLF001
+    assert final.state == AssignmentState.CREATED
+    row = org.db.connection.execute(
+        "SELECT record FROM receipts WHERE assignment_id = ?", (assignment_id,)
+    ).fetchone()
+    assert row is None
+    assert hash_tree(external) == before_hash, (
+        "a symlinked ancestor must be refused before anything is written through it"
+    )
 
 
 # --- Property 3: the workspace boundary is detectable -----------------------


### PR DESCRIPTION
## Governing ruling

[`docs/rulings/2026-08-27-unit7-is-workspaces-not-pulse.md`](https://github.com/zeroemployeeorg/sovereign-agent/blob/main/docs/rulings/2026-08-27-unit7-is-workspaces-not-pulse.md) — Unit 7 is workspace lifecycle; Unit 9 owns the proactive/Pulse pipeline. This PR implements the five properties named in that ruling's "What Unit 7 is" section, grounded further by the read-only investigation at `.unit7/SCOPE-PROPOSAL.md`.

## The five properties, each a claim with its test as evidence

1. **Reclaim tied to assignment terminal state** — `Organization.run_assignment` now reclaims a workspace's disposable scratch space (never `receipt.json`, `receipt.json.sha256`, or `.sovereign-out/`) after every terminal path, including the interrupted (`KeyboardInterrupt`/`SystemExit`) path — matching the fail-closed-correct bar the ruling names by comparison to the earlier interrupted-receipt fix. A workspace that never reaches a terminal write (a hard kill) is left untouched, correctly deferred to Unit 8.
   - `tests/test_workspace_lifecycle.py::test_workspace_reclaimed_after_terminal_state`
   - `tests/test_workspace_lifecycle.py::test_workspace_survives_non_terminal_state`
   - `tests/test_workspace_lifecycle.py::test_interrupted_assignment_still_reclaims_its_scratch_space`
   - `tests/test_workspace_lifecycle.py::test_a_hard_kill_that_never_returns_leaves_the_workspace_alone`

2. **`Actor.workspace_policy` is enforced** — `actors.py::load_actors` now reads it from committed TOML (previously silently dropped); `run_assignment` reads it and branches reclaim between `"temporary_directory"` (default) and `"persistent"`. An unrecognized value fails closed rather than guessing which behavior was meant.
   - `tests/test_workspace_lifecycle.py::test_persistent_policy_keeps_scratch_space`
   - `tests/test_workspace_lifecycle.py::test_temporary_directory_policy_reclaims_scratch_files`
   - `tests/test_workspace_lifecycle.py::test_unknown_workspace_policy_fails_closed`
   - `tests/test_workspace_lifecycle.py::test_workspace_policy_loads_from_toml`

3. **The workspace boundary is detectable, not merely declared** — `workspace.snapshot_boundary`/`diff_boundary` compare tracked files outside the workspace immediately before and after every provider invocation, recording a durable `assignment.workspace_boundary_checked` event. Stated and tested as detection, not prevention — a violation does not block completion, it puts the fact on the ledger. Mutation-checked both directions.
   - `tests/test_workspace_lifecycle.py::test_detects_write_outside_workspace`
   - `tests/test_workspace_lifecycle.py::test_writes_inside_the_workspace_do_not_trip_the_boundary_check`
   - `tests/test_workspace_lifecycle.py::test_a_new_file_outside_the_workspace_is_also_detected`
   - `tests/test_workspace_lifecycle.py::test_a_completed_assignment_records_a_clean_boundary_event`
   - `tests/test_workspace_lifecycle.py::test_a_provider_that_writes_outside_its_workspace_is_caught_by_run_assignment`

4. **`_require_deliverables` gets a traversal check** — `workspace.safe_join` does a resolved-path containment check (`Path.resolve()` under the root), not a string-prefix check, so a `..` segment or an absolute deliverable string is refused fail-closed. A legitimate nested path still succeeds.
   - `tests/test_workspace_lifecycle.py::test_traversal_deliverable_is_refused`
   - `tests/test_workspace_lifecycle.py::test_absolute_deliverable_path_is_refused`
   - `tests/test_workspace_lifecycle.py::test_legitimate_nested_deliverable_still_succeeds`
   - `tests/test_workspace_lifecycle.py::test_require_deliverables_refuses_traversal_end_to_end`

5. **All four providers held to the same rule, no live credential** — `run_assignment` calls reclaim and the boundary check from one shared call site; no per-provider branch exists for either mechanism. Verified with the same deterministic fake-executable pattern `test_provider_integration.py` established for Unit 6.
   - `tests/test_workspace_lifecycle.py::test_reclaim_and_boundary_check_apply_identically_across_providers[scripted|claude|codex|cursor]`
   - `tests/test_workspace_lifecycle.py::test_no_live_provider_credential_is_present_in_the_test_environment`

Every test above drives the real `run_assignment` / `_require_deliverables` code path (no pre-classified stubs), following the discipline `test_scripted_execution_matrix.py` already established. Each property was falsified by hand during development — implementation temporarily disabled, confirmed the corresponding test failed, then restored — not just shown green on the happy path.

## What this did NOT do (scope boundaries respected)

- **No Pulse work.** No wake gate, no simulated Pulse event, no work created without a human prompt. Unit 9 territory, untouched.
- **No multi-process fencing, supervisor, or hard-kill recovery.** Reclaim runs synchronously in the same single process already writing receipts synchronously in `run_assignment`. Unit 8 territory, untouched.
- **No credentialed smoke of any kind.** `claude`/`codex`/`cursor` in property 5's provider-parity test are exercised via fake executables, identical to Unit 6's own pattern. No `ANTHROPIC_API_KEY`/`CLAUDE_CODE_OAUTH_TOKEN`/`CODEX_API_KEY`/`CURSOR_API_KEY` anywhere in this change or its tests — checked directly by `test_no_live_provider_credential_is_present_in_the_test_environment` and by `env | grep` in the verification gate. Unit 12 territory, never run, never claimed.
- **`docs/units-0-6-contract.md` is untouched.** New contract doc (`docs/v1-unit7-workspace-lifecycle.md`) is additive, following that document's own shape.

Found but explicitly not fixed (named in the new contract doc's "What this unit did not do" section, since fixing wasn't required for any of the five properties): `Actor.workspace_policy` stays a bare `str` rather than a `StrEnum` like every other state field in `models.py`; `cli.py`'s `_actor_list` doesn't print `workspace_policy`.

## Budget impact (reproduced, not guessed)

`scripts/verify_source_budget.py` output, before and after:

| | modules | nonblank lines | root exports |
|---|---|---|---|
| Before (`33e51d19`, Units 0-6 accepted) | 23/40 | 3696/6000 | 7/30 |
| After (this PR) | 24/40 | 3916/6000 | 7/30 |

One new module (`src/sovereign_agent/workspace.py`), zero new root exports.

## Verification gate, all green

```
$ make verify
...
214 passed, 9 deselected  (23 new tests in tests/test_workspace_lifecycle.py, up from 191)
modules=24/40 nonblank_lines=3916/6000 root_exports=7/30
...
outcome ACCEPTED

$ uv lock --check
Resolved 20 packages

$ python scripts/verify_runtime_dependencies.py
pydantic

$ python scripts/verify_source_budget.py
modules=24/40 nonblank_lines=3916/6000 root_exports=7/30

$ python scripts/verify_curriculum.py
curriculum sound: 4 chapters, 4 exercises executed, all links resolve

$ git diff --check
(clean)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns
