### PR TITLE
Unit 8: flip status to ACCEPTED; close A-U8-1

### DIFF
--- a/docs/rulings/2026-08-26-one-process-per-actor.md
+++ b/docs/rulings/2026-08-26-one-process-per-actor.md
@@ -94,3 +94,21 @@ lease` as the first thing it does, before anything else is touched, and
 connecting the two mechanisms rather than leaving the lease unused. See
 `docs/v1-unit8-supervisor-fencing-recovery.md`'s Property 1 for the full,
 current account.
+
+### Second addendum (A-U8-1, Unit 8 audit finding, closed same day)
+
+`test_the_same_actor_from_two_processes_is_idempotent_not_exclusive`, cited
+above as verification, was the exact test the Unit 8 SOW ordered replaced
+with tests proving the new process-level guarantee — "not merely renamed."
+That replacement landed (`tests/test_fencing.py::
+test_actor_lease_blocks_a_second_assignment_for_the_same_actor_before_invocation`),
+but this original test itself survived byte-identical through all three PR
+#31 rounds, still asserting a docstring claim — "1.x does not provide
+fencing" — that became false the moment Unit 8 merged. A second, independent
+Sparring audit of the merged `main` (distinct from the PR review rounds
+above) found it. Renamed to
+`test_the_same_actor_from_two_processes_is_idempotent_within_an_unexpired_lease`
+and its docstring narrowed to state only what remains true — same-owner,
+same-lease-window idempotency — with an explicit historical note. The
+citation above is left unedited as the historical record of this ruling's
+own verification at the time it was written.

--- a/docs/v1-unit8-supervisor-fencing-recovery.md
+++ b/docs/v1-unit8-supervisor-fencing-recovery.md
@@ -1,10 +1,14 @@
 # Unit 8: supervisor, fencing, and hard-kill recovery
 
-- **status:** PROPOSED, 2026-08-28 (this status is set by the authoring
-  stream; the flip to ACCEPTED happens later, by Master/Sparring/Principal
-  process, not by this document)
-- **authority:** principal (ratifying prior rulings this unit closes);
-  status flip to ACCEPTED is a separate later act
+- **status:** ACCEPTED, 2026-08-28 (Principal acceptance granted at exact
+  head `2b9e99ffe2da7c7b54cd53fabdd8c0d1d1066ff7`; merged into `main` at
+  `1d3bb55585f9fcfb04c63e11126665c8ad5635ea`; acceptance record filed as
+  [PR #31 comment 5456428388](https://github.com/zeroemployeeorg/sovereign-agent/pull/31#issuecomment-5456428388);
+  this status flip itself lands as a separate, Sparring-reviewed change —
+  review before merge, not authored-and-co-signed by the same act, not
+  backdated)
+- **authority:** principal (ratified acceptance; the prior rulings this
+  unit closes are ratified by the same authority)
 - **base:** `main = 5dbcabca640426a4510a9a82c78beff0889696f6` (Units 0-7
   ACCEPTED, clean tree; the exact commit this branch forked from)
 - **review history:** PR #31, first head `344b77b`. Sparring's independent

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -147,18 +147,38 @@ def test_only_one_contender_wins_a_contested_lease(tmp_path: Path) -> None:
     assert claimed_events == 1
 
 
-def test_the_same_actor_from_two_processes_is_idempotent_not_exclusive(tmp_path: Path) -> None:
-    """State the property honestly rather than overclaiming exclusivity.
+def test_the_same_actor_from_two_processes_is_idempotent_within_an_unexpired_lease(
+    tmp_path: Path,
+) -> None:
+    """A-U8-1 (Unit 8 audit finding): this test predates Unit 8 and used to be
+    named `..._is_idempotent_not_exclusive`, with a docstring stating three
+    things that were true when it was written (pre-Unit-8 `main`) and are
+    FALSE now, on merged `main`, present tense: "1.x does not provide
+    fencing", "two processes hosting one actor can therefore both proceed",
+    and "lease fencing is deferred to Unit 8's supervisor." Unit 8 landed
+    exactly that fencing -- `sovereign_agent.fencing`, proven end to end by
+    `tests/test_fencing.py::
+    test_actor_lease_blocks_a_second_assignment_for_the_same_actor_before_invocation`,
+    which shows a second process CANNOT proceed while a first process's actor
+    lease is live: its `invoke_actor` is spied on and shown to fire zero
+    times. The Unit 8 SOW ordered this exact test replaced with tests proving
+    the new process-level guarantee, "not merely renamed" -- that replacement
+    (the test named above) landed in `test_fencing.py`, but this test itself
+    was left byte-identical, unselected by any of Unit 8's own audit
+    commands, and its docstring was never corrected. Caught by a second,
+    independent Sparring audit reading the SOW's own requirement rather than
+    only the accepting document's self-attestation.
 
-    A second connection using the SAME actor id is granted the claim, because a
-    claim already held by that actor short circuits. Two processes hosting one
-    actor can therefore both proceed. That is actor-level idempotency; it is NOT
-    process-level fencing, and 1.x does not provide fencing.
-
-    The governing rule is recorded in
-    docs/rulings/2026-08-26-one-process-per-actor.md: one process may host an
-    actor, and lease fencing is deferred to Unit 8's supervisor. This test
-    exists so nobody reads the mailbox as offering a guarantee it does not.
+    What survives, narrowed and renamed to say only what remains true: a
+    SECOND CONNECTION reclaiming a lease it ALREADY HOLDS, before that lease
+    EXPIRES, is granted the same claim back rather than refused -- the
+    same-owner-unexpired short-circuit in `relay.claim()`, a deliberate
+    idempotency feature (a retried worker inside its own lease window is
+    harmless), not a gap. It says nothing about two DIFFERENT processes, or
+    about a lease that has EXPIRED -- see F-U4-1's closure
+    (`docs/rulings/2026-08-26-deferral-unit4-fencing.md`) for the expired
+    case, and `test_fencing.py` for actual process-level exclusivity, which
+    this test never tested and does not test now.
     """
     org = Organization.init(tmp_path)
     message = send(org.db, "master-course", "sparring-course", "s", "b")


### PR DESCRIPTION
## Summary

Two changes, per the Principal's explicit scope for this step:

1. **Status flip.** `docs/v1-unit8-supervisor-fencing-recovery.md` moves from `PROPOSED` to `ACCEPTED`, binding to:
   - accepted head: `2b9e99ffe2da7c7b54cd53fabdd8c0d1d1066ff7`
   - merge commit: `1d3bb55585f9fcfb04c63e11126665c8ad5635ea`
   - acceptance record: [PR #31 comment 5456428388](https://github.com/zeroemployeeorg/sovereign-agent/pull/31#issuecomment-5456428388)
   - authority: principal
   - The document's existing Unit 9, Unit 12, and no-live-provider-evidence non-claims are unchanged.

2. **A-U8-1 closed** — a second, independent Sparring audit finding against merged `main`, distinct from the three PR #31 review rounds. The Unit 8 SOW ordered `test_the_same_actor_from_two_processes_is_idempotent_not_exclusive` replaced with tests proving the new process-level guarantee ("not merely renamed"). That replacement landed (`tests/test_fencing.py::test_actor_lease_blocks_a_second_assignment_for_the_same_actor_before_invocation`), but the original test itself survived byte-identical through all three rounds — none of which selected it by name in their own targeted check commands, even though the doc's Property-3 `-k` filter happens to substring-match it — still carrying a docstring asserting three things that were true when it was written and are false on merged `main`: "1.x does not provide fencing", "two processes hosting one actor can therefore both proceed", "lease fencing is deferred to Unit 8's supervisor".

   Its assertion remained correct throughout — a same-owner, same-lease-window reclaim is genuinely still idempotent by design (the short-circuit only fires when unexpired, per F-U4-1's closure) — so nothing was lost by fixing only the claim: renamed to `test_the_same_actor_from_two_processes_is_idempotent_within_an_unexpired_lease`, docstring narrowed to state only what remains true, with an explicit historical note pointing at the real process-level guarantee now proven elsewhere. `docs/rulings/2026-08-26-one-process-per-actor.md` gets a small additive addendum recording the rename; the ruling's original verification citation is left unedited as the historical record of what was true when it was written. `docs/rulings/2026-08-26-deferral-unit4-fencing.md`'s own reference to the old test name is in a purely historical "Verification" section making no present-tense claim, so it was left untouched.

## Verification

- Confirmed the defect myself before fixing it: read the test on merged `main`, confirmed its docstring's three present-tense claims are false against the actual merged `fencing.py`/`organization.py`/`test_fencing.py`.
- Confirmed the test's assertion remains true post-rename (still passes, for the correct, narrower reason).
- Full gate green: 281 passed / 9 deselected, `mypy --strict` clean, budget unchanged at `26/40 modules, 5473/6000 lines, 7/30 exports` (prose-only change, no new implementation lines), `verify_curriculum.py` sound, `verify_runtime_dependencies.py` → exactly `pydantic`, `git diff --check` clean.
- Scope confirmed minimal: exactly the three files the Principal authorized (the doc, the ruling addendum, the one test file), nothing else touched.

Requesting Sparring review at this exact head before merge — review before merge, not authored-and-co-signed by the same act that made the finding, not backdated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns