### PR TITLE
Unit 9: Pulse and proactive governed work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,24 @@ a wake gate.
   per-occurrence component) -- a source row Pulse origin could not safely
   reference durably. Now a plain, append-only `INSERT`, with a genuinely
   unique key per occurrence.
-- **The canonical creation transaction.** `Organization.create_pulse_work`
-  claims one wake decision per source signal at the SQLite boundary
-  (`UNIQUE(source_signal_id)`, not a preflight scan) and reuses `create_sow`,
-  `ready_sow`, and `assign` -- the same production methods manual dispatch
-  uses -- never a copied or Pulse-only fork. A concurrent loser returns the
-  same SOW and assignment identifiers, never a second, competing pair,
-  proven with a REAL two-connection `threading.Barrier` race.
+- **The canonical creation transaction, genuinely atomic.**
+  `Organization.create_pulse_work` composes the wake-decision claim
+  (`UNIQUE(source_signal_id)` at the SQLite boundary, not a preflight scan),
+  the SOW's creation and transitions, the assignment, the genuine
+  `pulse.work_created` event, and the origin row inside ONE `db.immediate()`
+  transaction -- corrected from an original five-separate-commit shape
+  (Sparring's finding F-U9-1 on PR #35, confirmed by independent Principal
+  reproduction) that could durably strand a wake decision with no recovery
+  path if an ordinary exception landed between any two commits. `create_sow`,
+  `ready_sow`, and `assign` reuse connection-taking `_on` helpers shared with
+  their own unchanged public, single-call form -- manual dispatch calls the
+  exact same production methods it always did, never a copied or Pulse-only
+  fork. In-transaction revalidation (re-asking the wake gate under the
+  write lock, not merely before it) prevents stale work from a condition
+  that resolved between the caller's read and the lock being acquired. A
+  concurrent loser still returns the same SOW and assignment identifiers,
+  never a second, competing pair, re-proven under the atomic design with a
+  REAL two-connection `threading.Barrier` race.
 - **The Pulse component and the Store's own wake gate.**
   `sovereign-agent pulse --once --root PATH` reads durable signals, asks a
   caller-supplied wake gate, and invokes the existing production
@@ -45,13 +56,25 @@ a wake gate.
   pre-existing SOW.
 - Migration 15: `pulse_wake_decisions`, `pulse_origins`, both append-only.
 
-Tests grow from 281 to 322 (33 new in `tests/test_pulse.py`, 8 new migration
-tests in `tests/test_persistence.py`), including a mutation-checked proof
-for the four properties this unit exists to protect (the fix reverted, the
-specific test confirmed red, restored byte-identical, re-confirmed green) --
-see
+Tests grow from 281 to 332 (33 new in `tests/test_pulse.py` from the
+initial implementation, 8 new migration tests in `tests/test_persistence.py`,
+10 more in `tests/test_pulse.py` from the F-U9-1 correction below),
+including a mutation-checked proof for every decisive property this unit
+exists to protect (the fix reverted, the specific test confirmed red,
+restored byte-identical, re-confirmed green) -- see
 [docs/v1-unit9-pulse-proactive-work.md](docs/v1-unit9-pulse-proactive-work.md)
 for the full contract and proof matrix.
+
+**Review correction (PR #35, F-U9-1).** Sparring found, and the Principal
+independently reproduced, that the canonical creation transaction was not
+actually atomic: a fault between any two of its five original separate
+commits durably stranded the wake decision, and `source_signal_id`'s own
+`UNIQUE` constraint then made every retry impossible -- the signal was
+orphaned permanently. Closed by composing all five writes into one
+`db.immediate()` transaction (see above); the source-line budget was raised
+from 6000 to 6250 to accommodate the honest cost of that composition
+(`scripts/verify_source_budget.py`'s own comment records the ruling; module
+and export ceilings are unchanged).
 
 **Not claimed:** credentialed Claude/Codex/Cursor provider tests remain
 deselected and unrun. No OS service, scheduling, cron, or webhooks. No

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ Repository: [`zeroemployeeorg/sovereign-agent`](https://github.com/zeroemployeeo
 
 ## Unreleased
 
+### Pulse and proactive governed work (Unit 9)
+
+Closes the gap between the manually dispatched Unit 5 Store pipeline and
+sequencing amendment 5's proactive milestone: "sale → inventory signal →
+deterministic wake gate → pulse → replenishment work created without a
+human prompt." Pulse is a **distinct mechanism from the supervisor**, per
+[the governing ruling](docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md):
+`supervisor.tick()` is unchanged, still never reads a Pulse signal or fires
+a wake gate.
+
+- **Signal stability.** A committed sale signal was previously replaced,
+  not appended, when a later sale happened to leave inventory at the same
+  level (`INSERT OR REPLACE`, keyed implicitly on a `dedupe_key` with no
+  per-occurrence component) -- a source row Pulse origin could not safely
+  reference durably. Now a plain, append-only `INSERT`, with a genuinely
+  unique key per occurrence.
+- **The canonical creation transaction.** `Organization.create_pulse_work`
+  claims one wake decision per source signal at the SQLite boundary
+  (`UNIQUE(source_signal_id)`, not a preflight scan) and reuses `create_sow`,
+  `ready_sow`, and `assign` -- the same production methods manual dispatch
+  uses -- never a copied or Pulse-only fork. A concurrent loser returns the
+  same SOW and assignment identifiers, never a second, competing pair,
+  proven with a REAL two-connection `threading.Barrier` race.
+- **The Pulse component and the Store's own wake gate.**
+  `sovereign-agent pulse --once --root PATH` reads durable signals, asks a
+  caller-supplied wake gate, and invokes the existing production
+  `run_assignment()` path for qualifying work -- never bypassing Unit 8's
+  actor-lease or execution-attempt fencing. The Store's own gate (a genuine
+  sale-origin signal, still below reorder when re-checked live, mapped to
+  exactly one active outcome) lives outside `sovereign_agent`'s own module
+  budget, in `reference_organizations/store`.
+- **Structured, durable origin.** Every SOW -- manual or Pulse-created, new
+  or migrated -- carries an explicit `pulse_origins` row (`origin_kind`,
+  `wake_decision_id`, `pulse_event_id`, `sow_id`, `assignment_id`). Absence
+  of a row is never the definition of manual: `create_sow` inserts one for
+  every SOW at creation time, and migration 15 backfills one for every
+  pre-existing SOW.
+- Migration 15: `pulse_wake_decisions`, `pulse_origins`, both append-only.
+
+Tests grow from 281 to 322 (33 new in `tests/test_pulse.py`, 8 new migration
+tests in `tests/test_persistence.py`), including a mutation-checked proof
+for the four properties this unit exists to protect (the fix reverted, the
+specific test confirmed red, restored byte-identical, re-confirmed green) --
+see
+[docs/v1-unit9-pulse-proactive-work.md](docs/v1-unit9-pulse-proactive-work.md)
+for the full contract and proof matrix.
+
+**Not claimed:** credentialed Claude/Codex/Cursor provider tests remain
+deselected and unrun. No OS service, scheduling, cron, or webhooks. No
+automatic retry policy for failed governed work.
+
 ### Supervisor, fencing, and hard-kill recovery (Unit 8)
 
 A worker that no longer holds the current lease could still commit

--- a/book/README.md
+++ b/book/README.md
@@ -17,10 +17,17 @@ you to take on faith.
 
 ## What is not here yet
 
-Pulse — the organization waking itself up — is Unit 9. Nothing in these chapters
-simulates a Pulse event, and the store demo is explicitly manually dispatched. A
-chapter that promised proactive behaviour before the code could do it would be
-the same kind of lie this book spends Chapter 2 teaching you to catch.
+Pulse — the organization waking itself up — was Unit 9's own future territory
+when this section was written. Nothing in Chapters 0-3 simulates a Pulse
+event, and their store demo is explicitly manually dispatched. A chapter that
+promised proactive behaviour before the code could do it would be the same
+kind of lie this book spends Chapter 2 teaching you to catch.
+
+**Added, Unit 9:** Pulse is now real production code (`sovereign-agent pulse
+--once`; see `docs/v1-unit9-pulse-proactive-work.md`), but no chapter below
+exercises it yet — that editorial work is Unit 10's, not silently folded in
+here. Chapters 0-3 remain exactly as they were: manually dispatched, and
+truthful about it.
 
 ## Every chapter contains
 

--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -114,10 +114,10 @@ decide on its own that the tea needs reordering. Every step you just watched was
 dispatched because the demo dispatched it.
 
 That capacity — the organization waking itself and creating work with nobody
-prompting it — is called **Pulse**, and it does not exist yet. It arrives in
-Unit 9. Nothing in this book simulates it, and no event in the ledger you just
-inspected pretends otherwise. You can check that claim the same way you checked
-the others:
+prompting it — is called **Pulse**. This exercise does not run it: the demo
+above dispatches every step by hand, and no event in the ledger you just
+inspected pretends otherwise. You can check that claim the same way you
+checked the others:
 
 ```bash
 sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
@@ -125,7 +125,13 @@ sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
 ```
 
 Every `kind` describes something a human or a governed actor did. There is no
-`pulse.*` anywhere, because there is no Pulse.
+`pulse.*` anywhere in THIS run, because this exercise never calls Pulse.
+
+**Added, Unit 9:** Pulse is now real, as a separate mechanism you invoke
+yourself with `sovereign-agent pulse --once --root PATH` — it is not this
+chapter's exercise, and it never runs itself. See
+`docs/v1-unit9-pulse-proactive-work.md` for the sale-to-proactive-work slice
+this chapter's own dispatched-by-hand version is contrasted against.
 
 Knowing what a system cannot yet do is part of knowing what it does.
 

--- a/docs/v1-unit9-pulse-proactive-work.md
+++ b/docs/v1-unit9-pulse-proactive-work.md
@@ -1,0 +1,384 @@
+# Unit 9: Pulse and proactive governed work
+
+- **status:** PROPOSED (this status flips to `ACCEPTED` only in a separate,
+  Sparring-reviewed change — not by this stream, and not by this commit)
+- **authority:** principal (SOW authorization); acceptance is granted
+  separately, after independent review
+- **base:** `main = 95ceb8d66b0734a3942d71d3510660c0f4109eb5` (the exact
+  commit the Unit 9 SOW was reviewed and merged at; Units 0-8 ACCEPTED)
+- **governing SOW:**
+  [`docs/sows/sovereign-agent-v1-unit9-pulse-proactive-work.md`](sows/sovereign-agent-v1-unit9-pulse-proactive-work.md)
+- **governing ruling:**
+  [`docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md`](rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md)
+- **applies_to:** Sovereign Agent 1.x, Unit 9
+
+This document follows `docs/v1-unit8-supervisor-fencing-recovery.md` and
+`docs/v1-unit7-workspace-lifecycle.md`'s own shape: a contract stated as
+testable properties, then how to check each one against the repository. It
+is **additive** — nothing in the Units 0-8 acceptance record is touched or
+revised here.
+
+## The separate-Pulse ruling, and why this document exists to prove it held
+
+`docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md` decided
+two open questions ahead of this unit's implementation:
+
+1. **Pulse is a separate mechanism.** `Supervisor.tick()` is not extended
+   with a fourth step. Pulse lives under the reserved `pulse` CLI surface,
+   as its own component, calling `Organization.run_assignment()` the same
+   way every other caller does — never disguised as supervisor
+   reconciliation.
+2. **Pulse origin is structured and durable.** "Created without a human
+   prompt" must be provable in the ledger after the fact — a column read,
+   never an inference from the absence of a CLI invocation or the absence
+   of a manual-origin row.
+
+This unit's whole job is proving both holdings true in code, not merely in
+prose. The mutation-checking section below is where that proof is made
+falsifiable rather than asserted.
+
+## The pipeline this unit closes
+
+```text
+sale
+→ durable inventory signal (append-only, per occurrence — fixed this unit)
+→ deterministic wake gate (Store-specific, outside sovereign_agent's budget)
+→ genuine durable pulse.work_created event
+→ governed replenishment work created without a human prompt
+→ Scripted Operator, through the existing production run_assignment path
+→ deterministic effect boundary (apply_restock, unchanged)
+→ evidence, independent review, acceptance (unchanged)
+```
+
+Every stage after "deterministic wake gate" reuses production code that
+existed before this unit. Unit 9 built exactly four new things: signal
+stability, the canonical creation transaction, the Pulse component itself,
+and the Store's own wake gate.
+
+## The contract
+
+### Property 1 — Pulse is a distinct mechanism; `supervisor.tick()` is unchanged
+
+`src/sovereign_agent/pulse.py` never imports `sovereign_agent.supervisor`,
+proven both statically (an AST walk over its own imports) and behaviourally:
+running `supervisor.tick()` against an organization carrying a genuinely
+qualifying, uncommitted sale creates no SOW, no assignment, and no
+`pulse.*` event. `Supervisor.tick()`'s own four steps (Unit 8, unchanged)
+still run in the same order, and its accepted claim — "never reads a Pulse
+signal, never fires a wake gate" — remains literally true, unedited, in both
+`supervisor.py`'s own docstring and
+`docs/v1-unit8-supervisor-fencing-recovery.md`.
+
+### Property 2 — Signal stability: a committed sale signal is never replaced
+
+Before this unit, `record_sale`'s own signal insert was `INSERT OR REPLACE`,
+keyed implicitly on `dedupe_key`'s `UNIQUE` constraint (migration 1).
+`dedupe_key` was exactly `f"inventory:{sku}:{on_hand}"` — no per-occurrence
+component — so a second, later sale that happened to leave inventory at the
+same `on_hand` level silently deleted the first sale's own signal row and
+replaced it with a new one carrying a different id. A Pulse origin
+referencing a source signal by durable id cannot safely point at a row that
+can later disappear under an unrelated, later sale.
+
+Fixed in `src/reference_organizations/store/__init__.py`: `dedupe_key` is
+now suffixed with the signal's own id, and the write is a plain `INSERT`,
+not `INSERT OR REPLACE` — signals are now append-only, exactly like every
+other proof-bearing table in this database. `record_sale`'s existing
+atomicity is untouched: the signal insert is still inside the same
+`db.immediate()` transaction as the inventory `UPDATE`, the cash `INSERT`,
+and the `sale.committed` event.
+
+### Property 3 — The canonical creation transaction
+
+`Organization.create_pulse_work` (`src/sovereign_agent/organization.py`) is
+the single production path from a fired wake decision to durable, governed
+work:
+
+1. It attempts an `INSERT` into `pulse_wake_decisions`, whose
+   `UNIQUE(source_signal_id)` constraint (migration 15) **is** the "one
+   canonical wake decision per source signal" enforcement — at the SQLite
+   boundary, not a preflight `SELECT`. Two concurrent callers racing the
+   same signal both attempt this insert inside their own `db.immediate()`;
+   exactly one wins.
+2. The winner reuses `create_sow`, `ready_sow`, and `assign` — the exact
+   same production methods manual dispatch uses, never a copied or
+   Pulse-only fork.
+3. It appends a genuine `pulse.work_created` event and inserts one
+   `pulse_origins` row tying the wake decision, the event, the SOW, and the
+   assignment together.
+4. A concurrent loser, having lost the `UNIQUE` race, polls briefly
+   (bounded, local SQLite reads only) for the winner's own `pulse_origins`
+   row to land, then returns the **same** SOW and assignment identifiers —
+   never a second, competing pair.
+
+`create_sow` itself was changed to insert an explicit origin row — `manual`
+by default — for **every** SOW at creation time, deferred to the Pulse
+transaction's own `pulse` row only when called from
+`create_pulse_work` (via a private `_pulse_origin_pending` flag). This is
+what makes Property 5 below true: absence of a row is never the definition
+of manual, because no SOW is ever created without one.
+
+### Property 4 — The Pulse component and the Store's own wake gate
+
+`sovereign_agent.pulse.run_pulse_once` is one deterministic pass:
+
+1. Resume every already-fired signal whose canonical assignment is still
+   `CREATED` — the crash-window case: canonical creation committed, but no
+   process ever reached `run_assignment` for it.
+2. Read every signal with no wake decision yet, oldest first.
+3. Ask the caller-supplied `WakeGate` callback whether each one fires.
+4. For each that fires, call `create_pulse_work`, then invoke
+   `Organization.run_assignment()` for a `CREATED` assignment through the
+   exact same path the `run` CLI command and the supervisor's own recovery
+   path use — never bypassing Unit 8's actor-lease or execution-attempt
+   fencing. A `RUNNING` assignment is reported, not re-invoked; `COMPLETED`,
+   `BLOCKED`, and `FAILED` are terminal and never rerun or replaced.
+5. Return a structured `PulseReport` naming what was created, replayed,
+   skipped, refused, or already running.
+
+The wake gate itself is intentionally **not** in `sovereign_agent.pulse`:
+`store_wake_gate` (`src/reference_organizations/store/pulse_gate.py`) lives
+outside `sovereign_agent`'s own module budget, exactly as the governing SOW
+asks ("a Store-specific gate over parallel abstractions"). It fails closed
+on every ambiguity the SOW names: a non-sale-origin or non-`inventory.changed`
+signal, a subject no longer below reorder (re-checked live, never trusted
+from the signal's own stale `severity`), and zero or more than one matching
+`ACTIVE` outcome.
+
+### Property 5 — Pulse attribution is a column, never an inference
+
+`src/sovereign_agent/models.py`'s `PulseOrigin` and
+`Organization.pulse_origin_for_sow` expose, for any SOW: `origin_kind`
+(`"manual"` or `"pulse"`), `sow_id`, `assignment_id`, `wake_decision_id`,
+`pulse_event_id`. Every SOW — created before this unit (backfilled by
+migration 15) or after (via `create_sow`'s own insert) — has exactly one
+`pulse_origins` row, enforced by `UNIQUE(sow_id)`. "No Pulse-origin row
+exists" is not a state this schema can represent: it never happens.
+
+## Persistence and migration
+
+Migration 15 (`src/sovereign_agent/database.py`) adds two tables, both
+append-only (the same three guards migration 12's pattern established,
+applied here and folded into `APPEND_ONLY_TABLES`):
+
+| Table | Enforces |
+| --- | --- |
+| `pulse_wake_decisions` | `UNIQUE(source_signal_id)` — one canonical decision per signal; `FOREIGN KEY` to `signals(id)` |
+| `pulse_origins` | `UNIQUE(sow_id)`, `UNIQUE(assignment_id)`, `UNIQUE(wake_decision_id)`, `UNIQUE(pulse_event_id)`; `FOREIGN KEY`s to `sows`, `assignments`, `pulse_wake_decisions`; a `CHECK` constraint tying `origin_kind` to which of `wake_decision_id`/`pulse_event_id` may be non-null |
+
+Every SOW that existed before migration 15 is backfilled an explicit
+`'manual'` origin row at migration time, keyed off the SOW's own
+`created_at`. A SOW with zero or more than one assignment gets `NULL`
+`assignment_id` rather than a guessed binding — `origin_kind` stays
+`'manual'` regardless. Malformed pre-existing SOW data (unparseable JSON)
+rolls the whole migration back, unstamped, per this project's forward-only,
+fail-closed discipline — proven directly by
+`test_migration_15_rolls_back_on_malformed_unattributable_sow_data`.
+
+## How to run the foreground one-pass command
+
+```bash
+sovereign-agent init --root /tmp/pulse-check
+# ... seed a Store, activate an outcome, commit a sale that crosses reorder ...
+sovereign-agent pulse --once --root /tmp/pulse-check
+```
+
+`--once` is required; no other shape exists. The command prints one line per
+signal evaluated (its status: `created`, `replayed`, `skipped`, `refused`,
+or `already_running`) and a one-line summary.
+
+## How to query attribution without reading JSON
+
+```bash
+sqlite3 /tmp/pulse-check/.sovereign/organization.db <<'SQL'
+SELECT po.origin_kind, po.sow_id, po.assignment_id,
+       wd.source_signal_id, wd.source_event_id
+FROM pulse_origins po
+LEFT JOIN pulse_wake_decisions wd ON wd.id = po.wake_decision_id
+ORDER BY po.created_at;
+SQL
+```
+
+Or, from Python, `Organization.pulse_origin_for_sow(sow_id)` returns a
+typed `PulseOrigin`.
+
+## Required proof matrix — how to check this document against the repository
+
+```bash
+# Baseline, still green after Unit 9 lands
+python -m pytest -q
+python scripts/verify_source_budget.py
+python scripts/verify_curriculum.py
+python scripts/verify_runtime_dependencies.py
+
+# Property 1 -- separate mechanism: pulse --once works; supervisor.tick()
+# still creates no work and emits no Pulse event even with a qualifying
+# sale already committed; pulse.py never imports supervisor, statically
+python -m pytest -q tests/test_pulse.py -k \
+  "test_pulse_once_works or test_supervisor_tick_still_creates_no_work_and_emits_no_pulse_event or test_pulse_never_imports_supervisor"
+
+# No creation from nothing: empty organization, seeded with no sale, and a
+# sale that stays above reorder all create no work
+python -m pytest -q tests/test_pulse.py -k "creates_no_work"
+
+# Qualification and current-state check: a real crossing sale creates
+# canonical work; a formerly-qualifying signal does not fire once resolved
+python -m pytest -q tests/test_pulse.py -k \
+  "crossing_the_threshold or does_not_fire_after"
+
+# Attribution: the full source event -> signal -> decision -> pulse event ->
+# SOW -> assignment walk, and manual attribution (fresh and migrated)
+python -m pytest -q tests/test_pulse.py -k "attribution or manual"
+
+# Replay and restart: same-process replay and a reopened database both
+# return the same identifiers, counts stay at one
+python -m pytest -q tests/test_pulse.py -k "replay or reopening"
+
+# Concurrency and crash window: a REAL two-connection threading.Barrier race
+# for the same signal creates exactly one canonical SOW; a CREATED
+# assignment left by a simulated crash resumes without duplication
+python -m pytest -q tests/test_pulse.py -k \
+  "two_real_processes or survives_restart"
+
+# Existing RUNNING work and terminal work: Pulse never bypasses Unit 8
+# fencing; COMPLETED/BLOCKED/FAILED canonical assignments are never rerun
+python -m pytest -q tests/test_pulse.py -k \
+  "does_not_bypass or is_not_rerun"
+
+# Source integrity and ledger integrity: missing source event, fabricated
+# signal id, no/ambiguous matching outcome, FK/uniqueness/append-only
+python -m pytest -q tests/test_pulse.py -k \
+  "fails_closed or refused_by_the_foreign_key or cannot_name_the_same_sow or append_only"
+
+# Recurrence: THE decisive signal-stability property -- a later genuine sale
+# reaching a previously-seen inventory level retains the earlier signal and
+# creates distinct new work of its own
+python -m pytest -q tests/test_pulse.py -k "recurrence or retains_the_old_signal"
+
+# Real mechanism, full teaching slice, CLI artifact
+python -m pytest -q tests/test_pulse.py -k \
+  "real_signal_object or full_teaching_slice or cli"
+
+# Migration 15: fresh install, populated upgrade, manual backfill (including
+# the null-assignment case), rollback on malformed data, rollback on a
+# simulated SQL failure, FK/uniqueness/append-only, idempotent re-open
+python -m pytest -q tests/test_persistence.py -k "migration_15"
+
+# Credential absence confirmed -- must be empty, same as every prior unit
+env | grep -Ei "ANTHROPIC|CLAUDE_CODE_OAUTH|CODEX_API|CURSOR_API" || true
+
+# CLI artifact, from a built wheel outside the source tree
+python -m build --wheel -o /tmp/sovereign-agent-unit9-dist
+python -m venv /tmp/sovereign-agent-unit9-venv
+/tmp/sovereign-agent-unit9-venv/bin/pip install \
+  /tmp/sovereign-agent-unit9-dist/sovereign_agent-*.whl
+/tmp/sovereign-agent-unit9-venv/bin/sovereign-agent --help
+/tmp/sovereign-agent-unit9-venv/bin/sovereign-agent doctor
+/tmp/sovereign-agent-unit9-venv/bin/sovereign-agent pulse --once \
+  --root /tmp/sovereign-agent-unit9
+```
+
+## Mutation checking
+
+Every decisive property above was falsified before being reported as done:
+the fix was reverted, the specific test that names the property was
+confirmed to go red, the mutated file was confirmed byte-identical to its
+pristine state (`diff`) before restoring, and green was re-confirmed.
+
+1. **The database uniqueness boundary** (`UNIQUE(source_signal_id)` on
+   `pulse_wake_decisions`, migration 15) — removed;
+   `tests/test_pulse.py::test_two_real_processes_evaluating_the_same_signal_create_one_canonical_sow`
+   and `test_create_pulse_work_called_twice_for_the_same_signal_returns_the_same_identifiers`
+   both went red (a second, competing SOW was created). Restored.
+2. **The no-qualifying-signal guard** (`store_wake_gate`'s live
+   `below_reorder` re-check) — removed;
+   `test_a_formerly_qualifying_signal_does_not_fire_after_the_condition_resolves`
+   and `test_sale_remaining_above_reorder_creates_no_work` both went red
+   (work was created for a signal whose condition had already resolved).
+   Restored.
+3. **Structured origin, replaced with inference** (`create_sow`'s own
+   explicit `'manual'` origin insert) — removed;
+   `test_manually_created_work_says_manual_explicitly` went red
+   (`pulse_origin_for_sow` returned `None` for a freshly created manual
+   SOW — the exact "absence of a row means manual" shape the governing
+   ruling forbids). Restored.
+4. **Pulse behaviour inserted into `Supervisor.tick()`** — a call to
+   `run_pulse_once` was added inside `tick()`. Unit 8's own existing test
+   (`test_tick_never_creates_a_new_outcome_sow_or_assignment`) stayed
+   green, because it runs against a completely empty organization with no
+   qualifying signal for Pulse to act on — a real gap the mutation exposed
+   rather than a false negative. This unit's own
+   `test_supervisor_tick_still_creates_no_work_and_emits_no_pulse_event`
+   (which runs `tick()` against an organization carrying a genuinely
+   qualifying, already-committed sale) went red under the same mutation.
+   Restored.
+
+## Budget impact
+
+Reproduced by `scripts/verify_source_budget.py`, before and after this
+unit's change, both figures read from the script's own printed output.
+
+| | modules | nonblank lines | root exports |
+| --- | --- | --- | --- |
+| Before (Unit 8 accepted, `95ceb8d6`) | 26/40 | 5473/6000 | 7/30 |
+| After (this unit) | 27/40 | 5991/6000 | 7/30 |
+
+One new module in the budgeted package: `src/sovereign_agent/pulse.py`. No
+new root export — `pulse` is called internally by `cli.py`; nothing from it
+is re-exported from the package root. `src/reference_organizations/store/`
+(the Store's own wake gate and the Pulse reference demo) is **not** counted
+by this budget, per the script's own scope
+(`PACKAGE = ROOT / "src" / "sovereign_agent"`), matching the governing SOW's
+own preference for a Store-specific gate living outside the budgeted
+package rather than a parallel abstraction inside it.
+
+Headroom remaining: 13 modules, 9 nonblank lines, 23 root exports. The
+9-line margin is real and was watched continuously during implementation,
+not discovered at the end — no code was compressed to fit it.
+
+## What this unit did not do
+
+- **No OS service, no scheduling, no cron, no webhooks.** `pulse --once` is
+  the only shape; there is no looping mode, unlike `supervisor` (which has
+  both `--once` and a foreground loop). A future foreground runtime that
+  wants to run both `supervisor` and `pulse` on an interval composes them
+  as two distinct external invocations; nothing in this unit builds that
+  composition.
+- **No automatic retry policy.** A `BLOCKED` or `FAILED` canonical
+  assignment is reported as terminal and left alone. Recovery or
+  reassignment continues through the existing governed
+  `assign`/`run_assignment` path, exactly as Unit 8 already established for
+  supervisor-recovered work.
+- **No weakening of any existing fencing, confinement, review, or
+  acceptance boundary.** `create_pulse_work` reuses `create_sow`,
+  `ready_sow`, and `assign` unchanged; `run_pulse_once` invokes
+  `run_assignment` unchanged. Unit 8's actor-lease and execution-attempt
+  fencing apply to a Pulse-created assignment exactly as they apply to a
+  manually created one — proven directly by
+  `test_pulse_does_not_bypass_actor_leases_or_execution_attempt_fencing`.
+- **No credentialed provider evidence.** Every test in this unit's proof
+  matrix uses the Scripted provider. The 9 deselected `live`-marked tests
+  are unchanged, unrun, and remain deferred to Unit 12.
+- **No Unit 10 curriculum work.** Chapters 0-3 are updated only with
+  additive historical notes (see below); no new chapter, no new exercise,
+  no editorial pass over existing chapter prose beyond naming that Pulse
+  now exists as a separate, real command.
+- **No change to the runtime dependency surface.** Still exactly `pydantic`
+  plus the standard library — `scripts/verify_runtime_dependencies.py`
+  reports `pydantic` before and after.
+- **`sovereign-agent demo`'s own CLI surface was not extended** with a
+  `--mode pulse` flag. The reference Store Pulse scenario
+  (`run_pulse_simulated`, `src/reference_organizations/store/demo.py`) is
+  reachable directly (as this unit's own tests do) and proven by
+  `test_full_teaching_slice_reaches_verified_reviewed_truthful_acceptance`,
+  but is not wired to a new CLI flag — not required by the governing SOW's
+  "add an offline reference scenario," and budget headroom did not permit
+  it without risk of overshooting the 6000-line ceiling.
+
+## Related documents
+
+- [SOW: Sovereign Agent 1.x — Unit 9 Pulse and proactive governed work](sows/sovereign-agent-v1-unit9-pulse-proactive-work.md)
+- [Ruling: Unit 9 Pulse is a separate mechanism from the supervisor; attribution is structured and durable](rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md)
+- [Unit 8: supervisor, fencing, and hard-kill recovery](v1-unit8-supervisor-fencing-recovery.md)
+- [Unit 7: workspace lifecycle](v1-unit7-workspace-lifecycle.md)
+- [Units 0-6 contract](units-0-6-contract.md)

--- a/docs/v1-unit9-pulse-proactive-work.md
+++ b/docs/v1-unit9-pulse-proactive-work.md
@@ -11,6 +11,20 @@
 - **governing ruling:**
   [`docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md`](rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md)
 - **applies_to:** Sovereign Agent 1.x, Unit 9
+- **review history:** PR #35, first head `690e8ddd`. Sparring's independent
+  review found F-U9-1: `Organization.create_pulse_work` was five separate
+  SQLite commits, not the one atomic transaction the governing SOW
+  explicitly requires — an ordinary exception between any two of them left
+  a wake decision durably stranded, with `source_signal_id`'s own `UNIQUE`
+  constraint then permanently refusing every retry. The Principal
+  independently reproduced the defect before routing it back. Corrected at
+  this head by composing the wake decision, the SOW's creation and
+  transitions, the assignment, the event, and the origin row into one
+  `db.immediate()` transaction, plus in-transaction revalidation — see
+  Property 3 below for the full account, and the mutation-checking section
+  for the falsification. The correction also raised the source-line budget
+  from 6000 to 6250 (module and export ceilings unchanged) — see Budget
+  impact below.
 
 This document follows `docs/v1-unit8-supervisor-fencing-recovery.md` and
 `docs/v1-unit7-workspace-lifecycle.md`'s own shape: a contract stated as
@@ -92,24 +106,66 @@ and the `sale.committed` event.
 
 `Organization.create_pulse_work` (`src/sovereign_agent/organization.py`) is
 the single production path from a fired wake decision to durable, governed
-work:
+work. It composes, inside **one** `db.immediate()` transaction:
 
-1. It attempts an `INSERT` into `pulse_wake_decisions`, whose
-   `UNIQUE(source_signal_id)` constraint (migration 15) **is** the "one
-   canonical wake decision per source signal" enforcement — at the SQLite
-   boundary, not a preflight `SELECT`. Two concurrent callers racing the
-   same signal both attempt this insert inside their own `db.immediate()`;
-   exactly one wins.
-2. The winner reuses `create_sow`, `ready_sow`, and `assign` — the exact
-   same production methods manual dispatch uses, never a copied or
-   Pulse-only fork.
-3. It appends a genuine `pulse.work_created` event and inserts one
-   `pulse_origins` row tying the wake decision, the event, the SOW, and the
-   assignment together.
-4. A concurrent loser, having lost the `UNIQUE` race, polls briefly
-   (bounded, local SQLite reads only) for the winner's own `pulse_origins`
-   row to land, then returns the **same** SOW and assignment identifiers —
-   never a second, competing pair.
+1. Revalidation, when the caller supplies one, run INSIDE the open
+   transaction, immediately before anything is written — the qualifying
+   condition could have changed between the caller's own read and this
+   transaction actually acquiring its write lock.
+2. An `INSERT` into `pulse_wake_decisions`, whose `UNIQUE(source_signal_id)`
+   constraint (migration 15) **is** the "one canonical wake decision per
+   source signal" enforcement — at the SQLite boundary, not a preflight
+   `SELECT`. Two concurrent callers racing the same signal both attempt this
+   insert on the same connection-level lock; `db.immediate()`'s own
+   `BEGIN IMMEDIATE` means one blocks until the other's ENTIRE transaction
+   — not just this one insert — has committed or rolled back.
+3. The SOW's creation and its `READY`/`ASSIGNED` transitions, and the
+   assignment's creation.
+4. A genuine `pulse.work_created` event.
+5. One `pulse_origins` row tying the wake decision, the event, the SOW, and
+   the assignment together.
+
+**F-U9-1, corrected.** The original implementation split this across FIVE
+separate commits: the `pulse_wake_decisions` insert in its own
+`db.immediate()`, then `create_sow`'s, `ready_sow`'s, and `assign`'s own
+individually-transactional calls in sequence, then a final `db.transaction()`
+for the origin row — despite this same section, at the time, claiming "the
+INSERT above committed synchronously as its own transaction" as though that
+were a safe, deliberate design rather than the defect it was. Sparring found,
+and the Principal independently reproduced (PR #35), that an ordinary
+exception between any two of those five commits — no crash required, any
+`Refusal` or bug anywhere in the sequence — left the wake decision durably
+stranded: `pulse_wake_decisions` had a row, `pulse_origins`/`sows`/
+`assignments` had none. Because `source_signal_id` is `UNIQUE`, no retry
+could ever re-claim that signal afterward — `_wait_for_pulse_origin` found
+no origin row to resolve to and raised `wake_decision_contended` instead of
+recovering. The signal was orphaned permanently, with no automatic or manual
+recovery short of direct database surgery. (This was never the SOW's own
+named "crash after canonical creation but before provider invocation" case —
+`pulse.py`'s `_resumable_signals` already handled that one correctly; F-U9-1
+was a narrower, unnamed window strictly inside canonical creation itself.)
+
+Fixed by extracting `_create_sow_on`/`_ready_sow_on`/`_assign_on` — the same
+writes `create_sow`/`ready_sow`/`assign` perform, taking an already-open
+connection instead of opening their own — and composing all five steps above
+on one connection, inside one `db.immediate()`. `create_sow`, `ready_sow`,
+and `assign` themselves are unchanged as public, single-call entry points:
+each is now a thin wrapper that opens its own transaction, delegates to its
+`_on` helper, commits, and projects — manual dispatch calls the exact same
+production methods it always did, and nothing here forks a Pulse-only path.
+Projection happens only after `create_pulse_work`'s transaction commits,
+never folded into it, matching every other write path in this class.
+
+A concurrent loser — genuinely arriving after the winner's full transaction
+has committed, not merely after its first statement — polls briefly
+(bounded, local SQLite reads only) for the winner's own `pulse_origins` row
+to land, then returns the **same** SOW and assignment identifiers, never a
+second, competing pair. This concurrency behavior is unchanged in substance
+from before the fix and re-verified as its own named property under the new
+atomic design (see the proof matrix below) — `db.immediate()`'s reserved
+lock, taken up front, is what always made two callers unable to interleave
+their writes for one signal; composing more work inside that same lock does
+not weaken it.
 
 `create_sow` itself was changed to insert an explicit origin row — `manual`
 by default — for **every** SOW at creation time, deferred to the Pulse
@@ -264,6 +320,18 @@ python -m pytest -q tests/test_pulse.py -k \
 # simulated SQL failure, FK/uniqueness/append-only, idempotent re-open
 python -m pytest -q tests/test_persistence.py -k "migration_15"
 
+# F-U9-1: the canonical creation transaction is genuinely atomic. A fault at
+# EVERY remaining write boundary (SOW creation, the READY transition,
+# assignment creation, the pulse.work_created event) rolls back the ENTIRE
+# chain, not just the wake decision; a signal orphaned by such a fault
+# remains eligible and a retry creates exactly one canonical chain, driven
+# both directly and through the real run_pulse_once entry point; two real
+# processes still converge on one canonical creation and the loser still
+# reads the winner's committed identifiers, both re-verified under the new
+# atomic design; in-transaction revalidation prevents stale work; and the
+# provider is never invoked against an incomplete origin chain
+python -m pytest -q tests/test_pulse.py -k   "fault_at_every or remains_eligible_after or recovers_a_signal_orphaned or converge_on_one_canonical_creation_under_the_atomic or losing_contender_reads_the_winners or revalidation_inside or provider_invocation_never_sees"
+
 # Credential absence confirmed -- must be empty, same as every prior unit
 env | grep -Ei "ANTHROPIC|CLAUDE_CODE_OAUTH|CODEX_API|CURSOR_API" || true
 
@@ -313,6 +381,23 @@ pristine state (`diff`) before restoring, and green was re-confirmed.
    qualifying, already-committed sale) went red under the same mutation.
    Restored.
 
+A fifth round followed Sparring's own independent finding on PR #35,
+F-U9-1, confirmed by the Principal's own direct reproduction before routing
+to this stream:
+
+5. **The atomic transaction, re-split into two** — `create_pulse_work`'s
+   single `db.immediate()` block was deliberately re-divided into the
+   wake-decision `INSERT`'s own separately-committing transaction followed
+   by a second transaction for the SOW/assignment/event/origin writes,
+   reproducing F-U9-1's original defect shape exactly.
+   `test_a_fault_at_every_creation_boundary_rolls_back_the_entire_chain`
+   (parametrized across all four remaining write boundaries),
+   `test_the_signal_remains_eligible_after_a_full_rollback_and_a_retry_creates_exactly_one_chain`,
+   and `test_run_pulse_once_recovers_a_signal_orphaned_by_a_mid_transaction_fault`
+   all went red — each reproducing the exact stranded shape the original
+   report named (`pulse_wake_decisions: 1`, every other table `0`).
+   Restored, confirmed byte-identical via `diff` before re-confirming green.
+
 ## Budget impact
 
 Reproduced by `scripts/verify_source_budget.py`, before and after this
@@ -321,7 +406,8 @@ unit's change, both figures read from the script's own printed output.
 | | modules | nonblank lines | root exports |
 | --- | --- | --- | --- |
 | Before (Unit 8 accepted, `95ceb8d6`) | 26/40 | 5473/6000 | 7/30 |
-| After (this unit) | 27/40 | 5991/6000 | 7/30 |
+| After (initial implementation, PR #35 first head) | 27/40 | 5991/6000 | 7/30 |
+| After (F-U9-1 correction; ceiling raised to 6250) | 27/40 | 6139/6250 | 7/30 |
 
 One new module in the budgeted package: `src/sovereign_agent/pulse.py`. No
 new root export — `pulse` is called internally by `cli.py`; nothing from it
@@ -332,9 +418,24 @@ by this budget, per the script's own scope
 own preference for a Store-specific gate living outside the budgeted
 package rather than a parallel abstraction inside it.
 
-Headroom remaining: 13 modules, 9 nonblank lines, 23 root exports. The
-9-line margin is real and was watched continuously during implementation,
-not discovered at the end — no code was compressed to fit it.
+**The ceiling itself changed.** Principal ruling on PR #35 (F-U9-1, see
+Property 3 above): the initial implementation's canonical creation
+transaction was five separate SQLite commits, not one atomic transaction,
+despite the governing SOW's explicit requirement — a defect that could
+durably strand a wake decision with no recovery path. Closing it honestly
+required composing `create_sow`/`ready_sow`/`assign`'s own writes into
+connection-taking `_on` helpers `create_pulse_work` could share inside one
+`db.immediate()` block, plus the in-transaction revalidation the same
+ruling required. That composition did not fit the original 6000-line
+ceiling without cramping the code to force it, so the Principal raised
+`scripts/verify_source_budget.py`'s own `MAX_NONBLANK_LINES` from 6000 to
+6250 — module (40) and root-export (30) ceilings are unchanged — recorded
+in that script's own comment above the constant, not only here.
+
+Headroom remaining: 13 modules, 111 nonblank lines, 23 root exports. Both
+the original 9-line margin and this correction's own margin were watched
+continuously during implementation, not discovered at the end — no code was
+compressed to fit either ceiling.
 
 ## What this unit did not do
 

--- a/scripts/verify_source_budget.py
+++ b/scripts/verify_source_budget.py
@@ -9,7 +9,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 PACKAGE = ROOT / "src" / "sovereign_agent"
 MAX_MODULES = 40
-MAX_NONBLANK_LINES = 6_000
+# Raised from 6_000 to 6_250 by Principal ruling on PR #35 (F-U9-1): Unit 9's
+# canonical-creation transaction had to compose create_sow/ready_sow/assign's
+# own writes into one atomic db.immediate() block rather than five separate
+# commits -- the fix a stranded, unrecoverable wake decision required -- and
+# the honest cost of that composition (connection-taking _on helpers plus the
+# revalidation this same defect's fix also required) did not fit the prior
+# ceiling without cramping the code to force it. Module and export ceilings
+# are unchanged. See docs/v1-unit9-pulse-proactive-work.md's own budget
+# table for the before/after figures this ruling produced.
+MAX_NONBLANK_LINES = 6_250
 MAX_ROOT_EXPORTS = 30
 
 

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -102,23 +102,44 @@ def record_sale(db: Database, sku: str, quantity: int, unit_price_cents: int) ->
                 "Restock first.",
             )
         cash_id = new_id("cash")
+        signal_id = new_id("sig")
         signal = Signal(
-            id=new_id("sig"),
+            id=signal_id,
             kind="inventory.changed",
             source="sale",
             subject_ref=sku,
             severity="warning" if on_hand <= int(row["reorder_point"]) else "info",
             observed_at=utc_now(),
             payload_digest=sku,
-            dedupe_key=f"inventory:{sku}:{on_hand}",
+            # Unit 9, signal stability: the level a signal describes, not a
+            # deduplication key over time. The OLD dedupe_key was exactly
+            # "inventory:{sku}:{on_hand}", with no per-occurrence component --
+            # two DIFFERENT sales that happened to leave the same on_hand
+            # produced the SAME key, and `INSERT OR REPLACE` (below) let the
+            # second sale silently delete the first sale's own signal row.
+            # Pulse origin references a signal by durable id; a source row
+            # that can later disappear under a later, unrelated sale is not a
+            # safe thing to reference. Suffixing the signal's own id makes
+            # every committed signal's key genuinely unique per occurrence,
+            # so the plain INSERT below can never collide.
+            dedupe_key=f"inventory:{sku}:{on_hand}:{signal_id}",
         )
         connection.execute("UPDATE inventory SET on_hand = ? WHERE sku = ?", (on_hand, sku))
         connection.execute(
             "INSERT INTO cash_entries(id, amount_cents, record) VALUES (?, ?, ?)",
             (cash_id, quantity * unit_price_cents, json.dumps({"sku": sku, "qty": quantity})),
         )
+        # Plain INSERT, not INSERT OR REPLACE: a committed sale signal is now
+        # append-only, matching the discipline every other proof-bearing
+        # table in this database already uses. `dedupe_key` remains UNIQUE
+        # (migration 1) as a genuine safety net -- it can never fire in
+        # practice now that the key carries its own per-occurrence
+        # component, but a bug that regressed it back to a colliding shape
+        # would raise sqlite3.IntegrityError here rather than silently
+        # replacing history, which is the fail-closed direction this fix
+        # exists to guarantee.
         connection.execute(
-            "INSERT OR REPLACE INTO signals(id, dedupe_key, record) VALUES (?, ?, ?)",
+            "INSERT INTO signals(id, dedupe_key, record) VALUES (?, ?, ?)",
             (signal.id, signal.dedupe_key, signal.model_dump_json()),
         )
         append_event(

--- a/src/reference_organizations/store/demo.py
+++ b/src/reference_organizations/store/demo.py
@@ -1,6 +1,7 @@
-"""Deterministic simulated store demo: manual replenishment, no Pulse.
+"""Deterministic simulated store demos: manual replenishment, and Pulse.
 
-The loop this runs, end to end:
+`run_simulated`'s loop, end to end -- unchanged since Unit 5, describing
+accurately what was true when it was written:
 
     sale -> inventory falls below the reorder point -> durable signal
       -> governed outcome and SOW -> assignment to an operator actor
@@ -9,8 +10,16 @@ The loop this runs, end to end:
       -> deterministic checks execute -> check-bound evidence is stored
       -> an independent reviewer reviews -> the Principal accepts
 
-Nothing here wakes itself up. A human runs it. Proactive waking is Pulse, and
-Pulse arrives in Unit 9 — this demo does not pretend to have it.
+Nothing in THAT loop wakes itself up. A human runs it -- `create_sow`,
+`ready_sow`, and `assign` are called directly, by this function, not by
+anything reading a signal.
+
+Unit 9, additive: `run_pulse_simulated` below runs the SAME loop through the
+genuine `sovereign_agent.pulse` mechanism instead -- the SOW and assignment
+are created by `Organization.create_pulse_work` after a real wake-gate
+decision, never by a manual `create_sow`/`ready_sow`/`assign` call from this
+module. Both demos share every step after that (the same Scripted provider,
+the same `apply_restock` boundary, the same verify/review/accept chain).
 """
 
 from __future__ import annotations
@@ -25,9 +34,11 @@ from reference_organizations.store import (
     record_sale,
     seed,
 )
+from reference_organizations.store.pulse_gate import store_wake_gate
 from sovereign_agent.errors import Refusal
-from sovereign_agent.models import Role
+from sovereign_agent.models import AssignmentState, Role
 from sovereign_agent.organization import Organization
+from sovereign_agent.pulse import run_pulse_once
 
 SKU = "SKU-TEA"
 
@@ -113,5 +124,56 @@ def run_simulated(root: Path) -> str:
     # Verify FIRST: a reviewer with no evidence in front of them is rubber-stamping.
     org.verify_outcome(outcome.id, "verifier-course")
     org.review(sow.id, "sparring-course")
+    org.accept(outcome.id, "principal-human")
+    return org.status_text(outcome.id)
+
+
+def run_pulse_simulated(root: Path) -> str:
+    """The same slice as `run_simulated`, but PROACTIVE: no `create_sow`,
+    `ready_sow`, or `assign` call anywhere in this function. The SOW and
+    assignment come from a real wake-gate decision, through the genuine
+    production Pulse mechanism, exactly as the governing SOW's reference
+    Store proof requires (section 7)."""
+    org = Organization.init(root)
+    seed(org.db)
+    outcome = org.create_outcome(
+        title="Keep the tea jar stocked",
+        desired_state=(
+            "On-hand tea is at or above the reorder point, the purchase is "
+            "reconciled, and the replenishment is on the ledger."
+        ),
+        checks=[
+            "inventory_at_or_above_reorder_point",
+            "cash_reconciles",
+            "replenishment_event_exists",
+        ],
+        owner="principal-human",
+        subject=SKU,
+    )
+    org.activate(outcome.id, "master-course")
+
+    signal = record_sale(org.db, SKU, 2, 400)
+    if not below_reorder(org.db):
+        raise RuntimeError("fixture sale should cross the reorder point")
+
+    report = run_pulse_once(org, store_wake_gate)
+    created = [item for item in report.items if item.signal_id == signal.id]
+    if not created or created[0].status != "created" or created[0].sow_id is None:
+        raise RuntimeError(f"pulse should have created work for {signal.id}: {report.items}")
+    sow_id = created[0].sow_id
+    assignment_id = created[0].assignment_id
+    assert assignment_id is not None
+    assignment = org._assignment(assignment_id)  # noqa: SLF001 -- demo, same module family
+    if assignment.state != AssignmentState.COMPLETED:
+        raise RuntimeError(f"pulse-created assignment did not complete: {assignment.state}")
+
+    report_path = (
+        root / ".sovereign" / "runs" / assignment.workspace_id / ".sovereign-out" / "report.json"
+    )
+    proposal = propose_restock_from_report(report_path, SKU)
+    apply_restock(org.db, proposal, assignment.id, signal.id)
+
+    org.verify_outcome(outcome.id, "verifier-course")
+    org.review(sow_id, "sparring-course")
     org.accept(outcome.id, "principal-human")
     return org.status_text(outcome.id)

--- a/src/reference_organizations/store/pulse_gate.py
+++ b/src/reference_organizations/store/pulse_gate.py
@@ -1,0 +1,59 @@
+"""The Store's own wake gate: a genuine sale-origin signal, still below
+reorder, mapped unambiguously to one active governed outcome.
+
+Lives outside `sovereign_agent`'s own budget on purpose (the governing SOW:
+"a Store-specific gate over parallel abstractions") -- this is domain logic
+about tea and shelves, not a general Pulse mechanism. `sovereign_agent.pulse`
+knows nothing about SKUs, reorder points, or the Store's actor roster; it
+only knows how to call a `WakeGate` and act atomically on what it returns.
+"""
+
+from __future__ import annotations
+
+import json
+
+from reference_organizations.store import below_reorder
+from sovereign_agent.models import OutcomeState, Role, Signal
+from sovereign_agent.organization import Organization
+from sovereign_agent.pulse import WakeDecision
+
+# The same actor roster the Store's own manual demo (`demo.py`) already uses.
+# Pulse dispatches through the identical production `assign`/`run_assignment`
+# path a human operator would, to the same actors -- no Pulse-only role.
+PLANNER_ACTOR_ID = "master-course"
+WORKER_ACTOR_ID = "operator-course"
+
+
+def store_wake_gate(org: Organization, signal: Signal) -> WakeDecision | None:
+    """Fail closed on every ambiguity named in the governing SOW.
+
+    A qualifying trigger is a genuine sale-origin `inventory.changed` signal
+    whose subject is CURRENTLY below its reorder point (re-checked now, not
+    trusted from the signal's own `severity` at the time it was written --
+    stock may have already been replenished since) and maps to EXACTLY one
+    ACTIVE outcome naming that subject.
+    """
+    if signal.kind != "inventory.changed" or signal.source != "sale":
+        return None
+    sku = signal.subject_ref
+    if sku not in below_reorder(org.db):
+        return None  # the condition that triggered this signal has already resolved
+
+    rows = org.db.connection.execute("SELECT record FROM outcomes").fetchall()
+    matching = []
+    for row in rows:
+        record = json.loads(row["record"])
+        if record.get("subject") == sku and record.get("state") == OutcomeState.ACTIVE.value:
+            matching.append(record)
+    if len(matching) != 1:
+        return None  # zero or ambiguous -- no durable rule disambiguates more than one
+
+    outcome_id = str(matching[0]["id"])
+    return WakeDecision(
+        outcome_id=outcome_id,
+        scope=f"Pulse-dispatched replenishment after signal {signal.id}",
+        role=Role.OPERATOR,
+        planner_id=PLANNER_ACTOR_ID,
+        worker_id=WORKER_ACTOR_ID,
+        required_effect_kind="replenishment",
+    )

--- a/src/sovereign_agent/cli.py
+++ b/src/sovereign_agent/cli.py
@@ -202,11 +202,37 @@ def _supervisor(namespace: argparse.Namespace) -> int:
     daemonization: this never forks, never detaches from its terminal, and
     never installs itself as an OS service. Distinct from the not-yet-built
     `service` (future OS-level install/status/uninstall, unimplemented) and
-    `pulse` (future proactive wake, Unit 9, unimplemented) -- this command is
-    the supervisor itself, the only one of the three this unit builds.
+    from `pulse` (Unit 9's own separate proactive-wake mechanism, implemented
+    below but never called from here -- see
+    docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md) --
+    this command is the supervisor itself, and it still never reads a Pulse
+    signal or fires a wake gate.
     """
     org = Organization(_root(namespace))
     return run_supervisor(org, once=namespace.once)
+
+
+def _pulse(namespace: argparse.Namespace) -> int:
+    """Unit 9: sale -> signal -> deterministic wake gate -> proactive work.
+
+    A distinct mechanism from `supervisor`, never called from it and never
+    calling it (see the governing ruling). `--once` is the only shape this
+    unit builds: one deterministic pass over durable signals, then exit --
+    no looping, no scheduling, no OS service.
+    """
+    from reference_organizations.store.pulse_gate import store_wake_gate
+    from sovereign_agent.pulse import run_pulse_once
+
+    org = Organization(_root(namespace))
+    report = run_pulse_once(org, store_wake_gate)
+    for item in report.items:
+        print(
+            f"{item.signal_id} {item.status}"
+            + (f" sow={item.sow_id} assignment={item.assignment_id}" if item.sow_id else "")
+            + (f" ({item.detail})" if item.detail else "")
+        )
+    print(f"pulse: {len(report.created)} created, {len(report.items)} signal(s) evaluated")
+    return 0
 
 
 def _demo(namespace: argparse.Namespace) -> int:
@@ -319,8 +345,8 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "reconcile leases, expired claims, and hard-killed assignments "
             "(the runtime loop; not 'service' [future OS hosting, "
-            "unimplemented] or 'pulse' [future proactive wake, Unit 9, "
-            "unimplemented])"
+            "unimplemented] or 'pulse' [the separate proactive-wake command "
+            "below, never called from here])"
         ),
     )
     supervisor.add_argument(
@@ -329,6 +355,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="run a single deterministic reconciliation tick and exit, instead of looping",
     )
     supervisor.set_defaults(handler=_supervisor)
+
+    pulse = subparsers.add_parser(
+        "pulse",
+        parents=[shared],
+        help=(
+            "sale -> signal -> deterministic wake gate -> proactive governed "
+            "work, created without a human prompt (distinct from 'supervisor'; "
+            "'--once' is the only shape this command has)"
+        ),
+    )
+    pulse.add_argument(
+        "--once",
+        action="store_true",
+        required=True,
+        help="run a single deterministic pulse pass and exit (the only supported mode)",
+    )
+    pulse.set_defaults(handler=_pulse)
     return parser
 
 

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -323,6 +323,8 @@ APPEND_ONLY_TABLES: tuple[str, ...] = (
     "verifications",
     "reviews",
     "evidence",
+    "pulse_wake_decisions",
+    "pulse_origins",
 )
 
 
@@ -531,6 +533,107 @@ ALTER TABLE execution_attempts ADD COLUMN actor_lease_fencing_token INTEGER;
 """
 
 
+MIGRATION_15 = """
+-- Unit 9: Pulse origin attribution. Ruling 2026-08-29-unit9-pulse-is-
+-- separate-from-supervisor, holding 2: "created without a human prompt"
+-- must be provable in the ledger after the fact, never inferred from the
+-- absence of a manual-origin row or the absence of a CLI invocation.
+
+-- One row per source signal that has ever been evaluated to a canonical
+-- firing decision. UNIQUE(source_signal_id) IS the "one canonical wake
+-- decision per source signal" enforcement -- at the SQLite boundary, not a
+-- preflight SELECT: two concurrent evaluators racing the same signal both
+-- attempt this INSERT: one wins, one hits the UNIQUE constraint and reads
+-- the winner's row back.
+CREATE TABLE IF NOT EXISTS pulse_wake_decisions (
+    id TEXT PRIMARY KEY,
+    source_signal_id TEXT NOT NULL UNIQUE REFERENCES signals(id),
+    source_event_id TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    decided_at TEXT NOT NULL
+);
+
+-- One row per genuine pulse.* event, and per SOW/assignment it created.
+-- sow_id and assignment_id are UNIQUE: a wake decision creates AT MOST one
+-- initial SOW and one initial assignment, ever -- replay must resolve to
+-- the same identifiers, never mint a second pair.
+CREATE TABLE IF NOT EXISTS pulse_origins (
+    id TEXT PRIMARY KEY,
+    origin_kind TEXT NOT NULL DEFAULT 'manual',
+    wake_decision_id TEXT UNIQUE REFERENCES pulse_wake_decisions(id),
+    pulse_event_id TEXT UNIQUE,
+    sow_id TEXT NOT NULL UNIQUE REFERENCES sows(id),
+    assignment_id TEXT UNIQUE REFERENCES assignments(id),
+    created_at TEXT NOT NULL,
+    CHECK (
+        (origin_kind = 'manual'
+            AND wake_decision_id IS NULL AND pulse_event_id IS NULL)
+        OR
+        (origin_kind = 'pulse'
+            AND wake_decision_id IS NOT NULL AND pulse_event_id IS NOT NULL)
+    )
+);
+CREATE INDEX IF NOT EXISTS pulse_origins_by_sow ON pulse_origins(sow_id);
+
+-- Proof-bearing: once a wake decision or an origin row exists, it is
+-- history. Appended to APPEND_ONLY_TABLES's own three guards below, matching
+-- the discipline every other proof-bearing table in this database already
+-- uses (migration 12).
+CREATE TRIGGER IF NOT EXISTS pulse_wake_decisions_no_update
+BEFORE UPDATE ON pulse_wake_decisions
+BEGIN
+    SELECT RAISE(ABORT, 'pulse_wake_decisions are append-only: update refused');
+END;
+CREATE TRIGGER IF NOT EXISTS pulse_wake_decisions_no_delete
+BEFORE DELETE ON pulse_wake_decisions
+BEGIN
+    SELECT RAISE(ABORT, 'pulse_wake_decisions are append-only: delete refused');
+END;
+CREATE TRIGGER IF NOT EXISTS pulse_wake_decisions_no_replace
+BEFORE INSERT ON pulse_wake_decisions
+WHEN EXISTS (SELECT 1 FROM pulse_wake_decisions WHERE id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, 'pulse_wake_decisions are append-only: replace refused');
+END;
+
+CREATE TRIGGER IF NOT EXISTS pulse_origins_no_update
+BEFORE UPDATE ON pulse_origins
+BEGIN
+    SELECT RAISE(ABORT, 'pulse_origins are append-only: update refused');
+END;
+CREATE TRIGGER IF NOT EXISTS pulse_origins_no_delete
+BEFORE DELETE ON pulse_origins
+BEGIN
+    SELECT RAISE(ABORT, 'pulse_origins are append-only: delete refused');
+END;
+CREATE TRIGGER IF NOT EXISTS pulse_origins_no_replace
+BEFORE INSERT ON pulse_origins
+WHEN EXISTS (SELECT 1 FROM pulse_origins WHERE id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, 'pulse_origins are append-only: replace refused');
+END;
+
+-- Every SOW created before this unit is explicit manual-origin history, not
+-- an absence. "No Pulse-origin row exists" must never be the definition of
+-- manual (the governing ruling's own words) -- so every pre-existing SOW
+-- gets its own explicit 'manual' row here, at migration time, rather than
+-- leaving manual-vs-unattributed as two things this schema cannot tell
+-- apart. assignment_id is backfilled when exactly one assignment exists for
+-- the SOW; a SOW with zero or more than one assignment gets NULL there
+-- (still explicitly 'manual' on origin_kind, which is the fact this
+-- migration must not lose) rather than guessing which assignment to bind.
+INSERT INTO pulse_origins(id, origin_kind, sow_id, assignment_id, created_at)
+SELECT
+    'porg_manual_' || sows.id,
+    'manual',
+    sows.id,
+    (SELECT a.id FROM assignments a WHERE a.sow_id = sows.id
+     GROUP BY a.sow_id HAVING COUNT(*) = 1),
+    COALESCE(sows.record ->> '$.created_at', datetime('now'))
+FROM sows;
+"""
+
+
 MIGRATIONS: tuple[tuple[int, str], ...] = (
     (1, MIGRATION_1),
     (2, MIGRATION_2),
@@ -546,6 +649,7 @@ MIGRATIONS: tuple[tuple[int, str], ...] = (
     (12, MIGRATION_12),
     (13, MIGRATION_13),
     (14, MIGRATION_14),
+    (15, MIGRATION_15),
 )
 
 

--- a/src/sovereign_agent/models.py
+++ b/src/sovereign_agent/models.py
@@ -280,6 +280,25 @@ class ActorReport(StrictModel):
     notes: str = ""
 
 
+class PulseOrigin(StrictModel):
+    """The structured, queryable answer to "manual or Pulse, and from what?"
+
+    Ruling 2026-08-29-unit9-pulse-is-separate-from-supervisor, holding 2:
+    absence of a CLI invocation, process logs, or a manual-origin row is
+    NOT proof. Every SOW -- manually planned or Pulse-created -- gets
+    exactly one of these rows, so "which kind is this" is always a column
+    read, never an inference from what is missing.
+    """
+
+    id: str
+    origin_kind: str
+    sow_id: str
+    assignment_id: str | None = None
+    wake_decision_id: str | None = None
+    pulse_event_id: str | None = None
+    created_at: datetime
+
+
 class EventRecord(StrictModel):
     seq: int | None = None
     id: str

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -159,8 +160,9 @@ class Organization:
         self._save_outcome(outcome, "outcome.activated")
         return outcome
 
-    def create_sow(
+    def _create_sow_on(
         self,
+        connection: Any,
         outcome_id: str,
         scope: str,
         role: Role,
@@ -169,14 +171,19 @@ class Organization:
         *,
         _pulse_origin_pending: bool = False,
     ) -> StatementOfWork:
-        """Create a SOW. Every caller gets an explicit origin row -- `manual`
-        here, unless `_pulse_origin_pending` (set only by
-        `create_pulse_work`, never by a public caller) defers that insert to
-        the Pulse creation transaction's own `pulse` row a few statements
-        later. Ruling 2026-08-29-unit9-pulse-is-separate-from-supervisor,
-        holding 2: "no Pulse-origin row exists" must never be the
-        definition of manual -- every SOW gets a row, at creation time,
-        never inferred later from absence.
+        """The writes `create_sow` performs, on an ALREADY-OPEN connection.
+
+        Extracted so `create_pulse_work` can compose this write with the SOW
+        transition, the assignment creation, and the origin insert inside
+        ONE `db.immediate()` transaction (F-U9-1's fix) rather than each
+        method opening and committing its own -- the shape that left a wake
+        decision durably stranded with nothing else on a fault between
+        commits. `create_sow` (below) is the thin public wrapper: it opens
+        its own transaction, calls this, and projects afterward. This
+        function itself never opens or commits a transaction and never
+        projects -- both are the caller's responsibility, so a caller
+        composing several of these into one larger transaction controls
+        exactly when the commit (and the projection after it) happens.
         """
         actor = self.actor(actor_id)
         require_authority(actor.role, "plan")
@@ -192,29 +199,85 @@ class Organization:
             state=SowState.DRAFT,
             created_at=utc_now(),
         )
-        with self.db.transaction():
-            self.db.put("sows", sow.id, sow.model_dump(mode="json"))
-            append_event(self.db, "sow.created", {"id": sow.id})
-            if not _pulse_origin_pending:
-                self.db.connection.execute(
-                    "INSERT INTO pulse_origins(id, origin_kind, sow_id, created_at) "
-                    "VALUES (?, 'manual', ?, ?)",
-                    (new_id("porg"), sow.id, sow.created_at.isoformat()),
-                )
+        connection.execute(
+            "INSERT OR REPLACE INTO sows(id, outcome_id, record) VALUES (?, ?, ?)",
+            (sow.id, sow.outcome_id, sow.model_dump_json()),
+        )
+        append_event(self.db, "sow.created", {"id": sow.id})
+        # Ruling 2026-08-29-unit9-pulse-is-separate-from-supervisor, holding
+        # 2: "no Pulse-origin row exists" must never be the definition of
+        # manual -- every SOW gets a row, at creation time, never inferred
+        # later from absence. Deferred here (not inserted) when
+        # _pulse_origin_pending: create_pulse_work inserts the real `pulse`
+        # row itself, inside this SAME transaction, a few statements later.
+        if not _pulse_origin_pending:
+            connection.execute(
+                "INSERT INTO pulse_origins(id, origin_kind, sow_id, created_at) "
+                "VALUES (?, 'manual', ?, ?)",
+                (new_id("porg"), sow.id, sow.created_at.isoformat()),
+            )
+        return sow
+
+    def create_sow(
+        self,
+        outcome_id: str,
+        scope: str,
+        role: Role,
+        actor_id: str,
+        required_effect_kind: str | None = None,
+        *,
+        _pulse_origin_pending: bool = False,
+    ) -> StatementOfWork:
+        """Create a SOW. The public, single-call path: opens its own
+        transaction, delegates the writes to `_create_sow_on`, commits, then
+        projects. `create_pulse_work` calls `_create_sow_on` directly
+        instead, composing it with other writes inside one larger
+        transaction -- see that method's own docstring.
+        """
+        with self.db.transaction() as connection:
+            sow = self._create_sow_on(
+                connection,
+                outcome_id,
+                scope,
+                role,
+                actor_id,
+                required_effect_kind,
+                _pulse_origin_pending=_pulse_origin_pending,
+            )
         self._project_outcome(outcome_id)
+        return sow
+
+    def _ready_sow_on(self, connection: Any, sow: StatementOfWork) -> StatementOfWork:
+        """The write `ready_sow` performs, on an already-open connection.
+        See `_create_sow_on`'s docstring for why this split exists."""
+        sow.state = advance_sow(sow.state, SowState.READY)
+        connection.execute(
+            "INSERT OR REPLACE INTO sows(id, outcome_id, record) VALUES (?, ?, ?)",
+            (sow.id, sow.outcome_id, sow.model_dump_json()),
+        )
+        append_event(self.db, "sow.ready", {"id": sow.id, "state": sow.state})
         return sow
 
     def ready_sow(self, sow_id: str) -> StatementOfWork:
         sow = self._sow(sow_id)
-        sow.state = advance_sow(sow.state, SowState.READY)
-        self._save_sow(sow, "sow.ready")
+        with self.db.transaction() as connection:
+            sow = self._ready_sow_on(connection, sow)
+        self._project_outcome(sow.outcome_id)
         return sow
 
-    def assign(self, sow_id: str, actor_id: str, planner_id: str) -> Assignment:
+    def _assign_on(
+        self, connection: Any, sow: StatementOfWork, actor_id: str, planner_id: str
+    ) -> Assignment:
+        """The writes `assign` performs, on an already-open connection,
+        INCLUDING its own state re-check -- re-read here, not merely trusted
+        from an earlier read outside this transaction, so a caller composing
+        this into a larger `db.immediate()` transaction (`create_pulse_work`)
+        still gets the same "another connection cannot have claimed this SOW
+        first" guarantee `assign`'s own transaction always gave it. See
+        `_create_sow_on`'s docstring for why this split exists."""
         planner = self.actor(planner_id)
         require_authority(planner.role, "assign")
         worker = self.actor(actor_id)
-        sow = self._sow(sow_id)
         if worker.role != sow.assignee_role:
             raise Refusal(
                 "Role mismatch.",
@@ -222,26 +285,27 @@ class Organization:
                 "actor list",
                 "Pick an actor with the SOW role.",
             )
+        current = json.loads(
+            connection.execute("SELECT record FROM sows WHERE id = ?", (sow.id,)).fetchone()[
+                "record"
+            ]
+        )["state"]
         # READY -> ASSIGNED is the first attempt; CHANGES_REQUESTED -> ASSIGNED
-        # is recovery. Policy always allowed the second transition and nothing
-        # ever used it, so a SOW that had changes requested was terminal: the
-        # only way forward was to delete the organization and start over. That
-        # is the opposite of what Chapter 2 teaches about refusal.
-        # Refuse every source state except the two that can legitimately start
-        # work. `assign()` used to create a row from ANY state and only advance
-        # from these two, so a double-click left a second assignment that could
-        # never run -- and `_latest_assignment_id` immediately treated it as the
-        # proof identity, invalidating an otherwise sound outcome.
-        if sow.state not in {SowState.READY, SowState.CHANGES_REQUESTED}:
+        # is recovery. Refuse every source state except those two -- a
+        # double-click (or, for create_pulse_work's own composed use, a
+        # second contender that should never reach this far in the first
+        # place) must not silently create a second execution that can never
+        # run.
+        if current not in {SowState.READY.value, SowState.CHANGES_REQUESTED.value}:
             raise Refusal(
-                f"A SOW in {sow.state} cannot be assigned.",
+                f"A SOW in {current} cannot be assigned.",
                 "Only work that is ready, or that has had changes requested, "
                 "can be handed to an actor. A retry must not silently create a "
                 "second execution that can never run.",
                 "sovereign-agent status",
                 "Wait for the current execution, or request changes first.",
             )
-
+        sow.state = advance_sow(SowState(current), SowState.ASSIGNED)
         assignment = Assignment(
             id=new_id("asg"),
             sow_id=sow.id,
@@ -251,31 +315,23 @@ class Organization:
             state=AssignmentState.CREATED,
             created_at=utc_now(),
         )
+        connection.execute(
+            "INSERT OR REPLACE INTO sows(id, outcome_id, record) VALUES (?, ?, ?)",
+            (sow.id, sow.outcome_id, sow.model_dump_json()),
+        )
+        connection.execute(
+            "INSERT INTO assignments(id, sow_id, actor_id, record) VALUES (?, ?, ?, ?)",
+            (assignment.id, sow.id, actor_id, assignment.model_dump_json()),
+        )
+        append_event(self.db, "assignment.created", {"id": assignment.id, "actor_id": actor_id})
+        return assignment
+
+    def assign(self, sow_id: str, actor_id: str, planner_id: str) -> Assignment:
+        sow = self._sow(sow_id)
         # The state check, the transition and the insert share one immediate
         # transaction, so two connections cannot both pass the check.
         with self.db.immediate() as connection:
-            current = json.loads(
-                connection.execute("SELECT record FROM sows WHERE id = ?", (sow.id,)).fetchone()[
-                    "record"
-                ]
-            )["state"]
-            if current not in {SowState.READY.value, SowState.CHANGES_REQUESTED.value}:
-                raise Refusal(
-                    f"A SOW in {current} cannot be assigned.",
-                    "Another connection claimed this SOW first.",
-                    "sovereign-agent status",
-                    "Wait for the current execution.",
-                )
-            sow.state = advance_sow(SowState(current), SowState.ASSIGNED)
-            connection.execute(
-                "INSERT OR REPLACE INTO sows(id, outcome_id, record) VALUES (?, ?, ?)",
-                (sow.id, sow.outcome_id, sow.model_dump_json()),
-            )
-            connection.execute(
-                "INSERT INTO assignments(id, sow_id, actor_id, record) VALUES (?, ?, ?, ?)",
-                (assignment.id, sow.id, actor_id, assignment.model_dump_json()),
-            )
-            append_event(self.db, "assignment.created", {"id": assignment.id, "actor_id": actor_id})
+            assignment = self._assign_on(connection, sow, actor_id, planner_id)
         self._project_outcome(sow.outcome_id)
         return assignment
 
@@ -330,34 +386,93 @@ class Organization:
         planner_id: str,
         worker_id: str,
         required_effect_kind: str | None = None,
-    ) -> tuple[StatementOfWork, Assignment, bool]:
+        revalidate: Callable[[], bool] | None = None,
+    ) -> tuple[StatementOfWork, Assignment, bool] | None:
         """The canonical creation transaction (Unit 9, SOW section 3).
 
-        Returns (sow, assignment, created) -- `created` is False on a replay,
-        where the caller already won this exact source_signal_id earlier and
-        this call returns the SAME identifiers rather than minting new ones.
+        Returns `(sow, assignment, created)` -- `created` is False on a
+        replay, where the caller already won this exact `source_signal_id`
+        earlier and this call returns the SAME identifiers rather than
+        minting new ones. Returns `None` only when `revalidate` is given and
+        reports the condition no longer holds (see below) -- no decision,
+        no SOW, no assignment, nothing durable.
 
-        `pulse_wake_decisions.source_signal_id` is UNIQUE (migration 15) --
-        that constraint, not a preflight SELECT, IS the "one canonical wake
-        decision per source signal" guarantee: two concurrent callers racing
-        the same signal both attempt this INSERT inside their own
-        `db.immediate()`; SQLite's reserved lock serializes them, exactly one
-        wins, and the loser reads the winner's own row back rather than
-        creating a second, parallel SOW and assignment.
+        **F-U9-1, corrected.** The wake decision, the SOW's creation and its
+        READY/ASSIGNED transitions, the assignment, the genuine
+        `pulse.work_created` event, and the origin row now commit inside
+        ONE `db.immediate()` transaction -- not five separate ones. The
+        original implementation opened `pulse_wake_decisions`' own INSERT
+        in its own `db.immediate()` block, then called the (individually
+        transactional) `create_sow`, `ready_sow`, and `assign` in sequence,
+        then wrote the origin row in a final `db.transaction()`. An
+        ordinary exception between any two of those five commits (Sparring's
+        finding F-U9-1, reproduced directly: patch `create_sow` to raise
+        immediately after the decision commits) left the wake decision
+        durably stranded -- `decisions=1 origins=0 sows=0` -- and, because
+        `pulse_wake_decisions.source_signal_id` is `UNIQUE`, a retry could
+        never re-claim that signal: `_wait_for_pulse_origin` found no
+        origin row to resolve to and raised `wake_decision_contended`
+        instead of recovering. The signal was orphaned permanently, with no
+        automatic or manual recovery short of direct database surgery. This
+        was never the SOW's own "crash after canonical creation but before
+        provider invocation" case (Sparring confirmed that one already
+        worked, via `pulse.py`'s `_resumable_signals`) -- it was a narrower,
+        unnamed window strictly INSIDE canonical creation itself, one this
+        docstring's own prior claim ("the INSERT above committed
+        synchronously as its own transaction") had wrongly treated as safe
+        to leave uncomposed.
 
-        Everything after the winning INSERT reuses the SAME production
-        methods manual dispatch uses -- `create_sow`, `ready_sow`, `assign`
-        -- never a copied or Pulse-only fork (the governing SOW's explicit
-        instruction). Those methods are each already individually safe
-        (Unit 3's and Unit 8's own proof matrices), and by the time this
-        function calls them only the ONE winning caller for this signal is
-        still running, so no second, competing SOW/assignment pair can be
-        created for the same decision.
+        Fixed by extracting `_create_sow_on`/`_ready_sow_on`/`_assign_on` --
+        the same writes `create_sow`/`ready_sow`/`assign` perform, taking an
+        already-open connection instead of opening their own. This function
+        composes all three plus the wake-decision insert, the event, and
+        the origin insert on ONE connection, inside ONE `db.immediate()`.
+        `create_sow`/`ready_sow`/`assign` themselves are unchanged as public
+        single-call entry points -- each now a thin wrapper that opens its
+        own transaction and delegates to its `_on` helper -- so manual
+        dispatch is untouched and still calls the same production methods
+        it always did; nothing here forks a Pulse-only path.
+
+        `revalidate`, when given, is called ONCE, INSIDE the open
+        transaction, immediately before the wake-decision INSERT -- not
+        merely before this method was entered. The qualifying condition
+        (e.g. "is this SKU still below reorder") could have changed between
+        the caller's own read and this transaction actually acquiring its
+        write lock; re-checking only after the lock is held is what makes
+        the check mean something at the moment it matters. A `False`
+        result rolls the transaction back (nothing is written -- no
+        decision, no SOW, no assignment, no event, no origin) and this
+        method returns `None`, distinct from a `Refusal`: the condition
+        resolving on its own between read and lock is not an error, it is
+        exactly the "no creation from nothing" property this unit's proof
+        matrix already established for the ordinary un-locked case, applied
+        here to the locked one too.
+
+        Concurrency is preserved exactly as before: `pulse_wake_decisions.
+        source_signal_id`'s `UNIQUE` constraint is still what a concurrent
+        contender's own `db.immediate()` collides against -- `db.immediate()`
+        takes SQLite's reserved lock UP FRONT (before any statement runs),
+        so two callers still cannot interleave their writes for the same
+        signal; one blocks until the other's transaction commits or rolls
+        back, then either finds the row already there (loses the race
+        normally) or, if the winner rolled back (revalidation failed, or
+        any exception), finds nothing and proceeds to become the winner
+        itself. A losing contender that arrives after a genuine commit
+        polls briefly (`_wait_for_pulse_origin`) and returns the SAME
+        identifiers -- unchanged from before this fix, and re-verified by
+        this unit's own concurrency tests under the new atomic design.
         """
         decision_id = new_id("pdec")
         now = utc_now()
         won = True
+        sow: StatementOfWork | None = None
+        assignment: Assignment | None = None
         with self.db.immediate() as connection:
+            if revalidate is not None and not revalidate():
+                # Nothing is written; the `with` block's own COMMIT below
+                # commits an empty transaction, which is harmless -- no row
+                # anywhere reflects this attempt.
+                return None
             try:
                 connection.execute(
                     "INSERT INTO pulse_wake_decisions"
@@ -369,72 +484,83 @@ class Organization:
                 if "UNIQUE" not in str(error) and "unique" not in str(error):
                     raise
                 won = False
-        if not won:
-            # A concurrent caller already holds the canonical decision for
-            # this signal. Its own SOW/assignment/origin write is a few
-            # sequential, purely local SQLite transactions (create_sow,
-            # ready_sow, assign, then the origin insert below) -- no
-            # external I/O -- so a short bounded wait, re-reading the join
-            # each attempt, resolves the real but narrow window between
-            # "the decision row committed" and "the origin row naming its
-            # sow/assignment committed" without ever guessing an identifier
-            # or creating a second, competing SOW.
-            existing = self._wait_for_pulse_origin(source_signal_id)
-            if existing is None:
-                raise Refusal(
-                    f"A wake decision for signal {source_signal_id!r} is being "
-                    "created by another process right now.",
-                    "Exactly one canonical decision may exist per source "
-                    "signal; this attempt lost the race and the winner's own "
-                    "work did not become durable within the wait budget.",
-                    "sovereign-agent pulse --once --root PATH",
-                    "Retry the pulse pass.",
-                    category="wake_decision_contended",
+            if won:
+                sow = self._create_sow_on(
+                    connection,
+                    outcome_id,
+                    scope,
+                    role,
+                    planner_id,
+                    required_effect_kind=required_effect_kind,
+                    _pulse_origin_pending=True,
                 )
-            sow = self._sow(str(existing["sow_id"]))
-            assignment = (
-                self._assignment(str(existing["assignment_id"]))
-                if existing["assignment_id"]
-                else None
-            )
+                sow = self._ready_sow_on(connection, sow)
+                assignment = self._assign_on(connection, sow, worker_id, planner_id)
+                pulse_event = append_event(
+                    self.db,
+                    "pulse.work_created",
+                    {
+                        "wake_decision_id": decision_id,
+                        "source_signal_id": source_signal_id,
+                        "source_event_id": source_event_id,
+                        "sow_id": sow.id,
+                        "assignment_id": assignment.id,
+                    },
+                )
+                origin_id = new_id("porg")
+                connection.execute(
+                    "INSERT INTO pulse_origins(id, origin_kind, wake_decision_id, "
+                    "pulse_event_id, sow_id, assignment_id, created_at) "
+                    "VALUES (?, 'pulse', ?, ?, ?, ?, ?)",
+                    (
+                        origin_id,
+                        decision_id,
+                        pulse_event.id,
+                        sow.id,
+                        assignment.id,
+                        now.isoformat(),
+                    ),
+                )
+        # Projection happens only AFTER the transaction above has committed
+        # -- never folded into it, matching every other write path in this
+        # class (`create_sow`, `ready_sow`, `assign` each project only after
+        # their own transaction exits).
+        if won:
+            assert sow is not None
             assert assignment is not None
-            return sow, assignment, False
+            self._project_outcome(outcome_id)
+            return sow, assignment, True
 
-        # This process alone now owns decision_id -- the INSERT above
-        # committed synchronously as its own transaction (db.immediate exits
-        # its `with` block on the successful path), so a second contender
-        # racing behind this one already sees the UNIQUE row and takes the
-        # branch above instead.
-        sow = self.create_sow(
-            outcome_id,
-            scope,
-            role,
-            planner_id,
-            required_effect_kind=required_effect_kind,
-            _pulse_origin_pending=True,
-        )
-        self.ready_sow(sow.id)
-        assignment = self.assign(sow.id, worker_id, planner_id)
-
-        pulse_event = append_event(
-            self.db,
-            "pulse.work_created",
-            {
-                "wake_decision_id": decision_id,
-                "source_signal_id": source_signal_id,
-                "source_event_id": source_event_id,
-                "sow_id": sow.id,
-                "assignment_id": assignment.id,
-            },
-        )
-        origin_id = new_id("porg")
-        with self.db.transaction() as connection:
-            connection.execute(
-                "INSERT INTO pulse_origins(id, origin_kind, wake_decision_id, pulse_event_id, "
-                "sow_id, assignment_id, created_at) VALUES (?, 'pulse', ?, ?, ?, ?, ?)",
-                (origin_id, decision_id, pulse_event.id, sow.id, assignment.id, now.isoformat()),
+        # A concurrent caller already holds the canonical decision for this
+        # signal (or the UNIQUE insert above lost the race to one that
+        # committed between this transaction's own BEGIN IMMEDIATE and its
+        # write -- impossible under db.immediate()'s up-front lock, but the
+        # UNIQUE catch is kept as the actual enforcement rather than trusted
+        # from the lock alone, matching this codebase's own "the database is
+        # the boundary" discipline). Poll briefly for that winner's own
+        # origin row -- committed by now, since db.immediate()'s lock meant
+        # this transaction could not even begin until the winner's own
+        # transaction (revalidation, decision, SOW, assignment, event,
+        # origin -- all of it) had already committed or rolled back in
+        # full.
+        existing = self._wait_for_pulse_origin(source_signal_id)
+        if existing is None:
+            raise Refusal(
+                f"A wake decision for signal {source_signal_id!r} is being "
+                "created by another process right now.",
+                "Exactly one canonical decision may exist per source "
+                "signal; this attempt lost the race and the winner's own "
+                "work did not become durable within the wait budget.",
+                "sovereign-agent pulse --once --root PATH",
+                "Retry the pulse pass.",
+                category="wake_decision_contended",
             )
-        return sow, assignment, True
+        existing_sow = self._sow(str(existing["sow_id"]))
+        existing_assignment = (
+            self._assignment(str(existing["assignment_id"])) if existing["assignment_id"] else None
+        )
+        assert existing_assignment is not None
+        return existing_sow, existing_assignment, False
 
     def run_assignment(self, assignment_id: str) -> Assignment:
         assignment = self._assignment(assignment_id)

--- a/src/sovereign_agent/organization.py
+++ b/src/sovereign_agent/organization.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import shutil
+import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +34,7 @@ from sovereign_agent.models import (
     Message,
     Outcome,
     OutcomeState,
+    PulseOrigin,
     Receipt,
     Review,
     Role,
@@ -163,7 +166,18 @@ class Organization:
         role: Role,
         actor_id: str,
         required_effect_kind: str | None = None,
+        *,
+        _pulse_origin_pending: bool = False,
     ) -> StatementOfWork:
+        """Create a SOW. Every caller gets an explicit origin row -- `manual`
+        here, unless `_pulse_origin_pending` (set only by
+        `create_pulse_work`, never by a public caller) defers that insert to
+        the Pulse creation transaction's own `pulse` row a few statements
+        later. Ruling 2026-08-29-unit9-pulse-is-separate-from-supervisor,
+        holding 2: "no Pulse-origin row exists" must never be the
+        definition of manual -- every SOW gets a row, at creation time,
+        never inferred later from absence.
+        """
         actor = self.actor(actor_id)
         require_authority(actor.role, "plan")
         sow = StatementOfWork(
@@ -181,6 +195,12 @@ class Organization:
         with self.db.transaction():
             self.db.put("sows", sow.id, sow.model_dump(mode="json"))
             append_event(self.db, "sow.created", {"id": sow.id})
+            if not _pulse_origin_pending:
+                self.db.connection.execute(
+                    "INSERT INTO pulse_origins(id, origin_kind, sow_id, created_at) "
+                    "VALUES (?, 'manual', ?, ?)",
+                    (new_id("porg"), sow.id, sow.created_at.isoformat()),
+                )
         self._project_outcome(outcome_id)
         return sow
 
@@ -258,6 +278,163 @@ class Organization:
             append_event(self.db, "assignment.created", {"id": assignment.id, "actor_id": actor_id})
         self._project_outcome(sow.outcome_id)
         return assignment
+
+    def pulse_origin_for_sow(self, sow_id: str) -> PulseOrigin | None:
+        """The structured origin row for one SOW -- manual or Pulse, and from what."""
+        row = self.db.connection.execute(
+            "SELECT id, origin_kind, sow_id, assignment_id, wake_decision_id, pulse_event_id, "
+            "created_at FROM pulse_origins WHERE sow_id = ?",
+            (sow_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return PulseOrigin(
+            id=row["id"],
+            origin_kind=row["origin_kind"],
+            sow_id=row["sow_id"],
+            assignment_id=row["assignment_id"],
+            wake_decision_id=row["wake_decision_id"],
+            pulse_event_id=row["pulse_event_id"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def _wait_for_pulse_origin(self, source_signal_id: str) -> Any:
+        """Poll briefly for the winning contender's origin row to land.
+
+        Local SQLite transactions, not network I/O: a few short retries
+        cover the ordinary case, and a genuinely stuck winner (a crash mid-
+        creation, Unit 9's own "crash window" case) is left to the next
+        pulse pass entirely, not guessed at here.
+        """
+        for _ in range(20):
+            row = self.db.connection.execute(
+                "SELECT wd.id AS decision_id, po.sow_id, po.assignment_id FROM "
+                "pulse_wake_decisions wd JOIN pulse_origins po "
+                "ON po.wake_decision_id = wd.id WHERE wd.source_signal_id = ?",
+                (source_signal_id,),
+            ).fetchone()
+            if row is not None:
+                return row
+            time.sleep(0.02)
+        return None
+
+    def create_pulse_work(
+        self,
+        *,
+        source_signal_id: str,
+        source_event_id: str,
+        subject: str,
+        outcome_id: str,
+        scope: str,
+        role: Role,
+        planner_id: str,
+        worker_id: str,
+        required_effect_kind: str | None = None,
+    ) -> tuple[StatementOfWork, Assignment, bool]:
+        """The canonical creation transaction (Unit 9, SOW section 3).
+
+        Returns (sow, assignment, created) -- `created` is False on a replay,
+        where the caller already won this exact source_signal_id earlier and
+        this call returns the SAME identifiers rather than minting new ones.
+
+        `pulse_wake_decisions.source_signal_id` is UNIQUE (migration 15) --
+        that constraint, not a preflight SELECT, IS the "one canonical wake
+        decision per source signal" guarantee: two concurrent callers racing
+        the same signal both attempt this INSERT inside their own
+        `db.immediate()`; SQLite's reserved lock serializes them, exactly one
+        wins, and the loser reads the winner's own row back rather than
+        creating a second, parallel SOW and assignment.
+
+        Everything after the winning INSERT reuses the SAME production
+        methods manual dispatch uses -- `create_sow`, `ready_sow`, `assign`
+        -- never a copied or Pulse-only fork (the governing SOW's explicit
+        instruction). Those methods are each already individually safe
+        (Unit 3's and Unit 8's own proof matrices), and by the time this
+        function calls them only the ONE winning caller for this signal is
+        still running, so no second, competing SOW/assignment pair can be
+        created for the same decision.
+        """
+        decision_id = new_id("pdec")
+        now = utc_now()
+        won = True
+        with self.db.immediate() as connection:
+            try:
+                connection.execute(
+                    "INSERT INTO pulse_wake_decisions"
+                    "(id, source_signal_id, source_event_id, subject, decided_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (decision_id, source_signal_id, source_event_id, subject, now.isoformat()),
+                )
+            except Exception as error:
+                if "UNIQUE" not in str(error) and "unique" not in str(error):
+                    raise
+                won = False
+        if not won:
+            # A concurrent caller already holds the canonical decision for
+            # this signal. Its own SOW/assignment/origin write is a few
+            # sequential, purely local SQLite transactions (create_sow,
+            # ready_sow, assign, then the origin insert below) -- no
+            # external I/O -- so a short bounded wait, re-reading the join
+            # each attempt, resolves the real but narrow window between
+            # "the decision row committed" and "the origin row naming its
+            # sow/assignment committed" without ever guessing an identifier
+            # or creating a second, competing SOW.
+            existing = self._wait_for_pulse_origin(source_signal_id)
+            if existing is None:
+                raise Refusal(
+                    f"A wake decision for signal {source_signal_id!r} is being "
+                    "created by another process right now.",
+                    "Exactly one canonical decision may exist per source "
+                    "signal; this attempt lost the race and the winner's own "
+                    "work did not become durable within the wait budget.",
+                    "sovereign-agent pulse --once --root PATH",
+                    "Retry the pulse pass.",
+                    category="wake_decision_contended",
+                )
+            sow = self._sow(str(existing["sow_id"]))
+            assignment = (
+                self._assignment(str(existing["assignment_id"]))
+                if existing["assignment_id"]
+                else None
+            )
+            assert assignment is not None
+            return sow, assignment, False
+
+        # This process alone now owns decision_id -- the INSERT above
+        # committed synchronously as its own transaction (db.immediate exits
+        # its `with` block on the successful path), so a second contender
+        # racing behind this one already sees the UNIQUE row and takes the
+        # branch above instead.
+        sow = self.create_sow(
+            outcome_id,
+            scope,
+            role,
+            planner_id,
+            required_effect_kind=required_effect_kind,
+            _pulse_origin_pending=True,
+        )
+        self.ready_sow(sow.id)
+        assignment = self.assign(sow.id, worker_id, planner_id)
+
+        pulse_event = append_event(
+            self.db,
+            "pulse.work_created",
+            {
+                "wake_decision_id": decision_id,
+                "source_signal_id": source_signal_id,
+                "source_event_id": source_event_id,
+                "sow_id": sow.id,
+                "assignment_id": assignment.id,
+            },
+        )
+        origin_id = new_id("porg")
+        with self.db.transaction() as connection:
+            connection.execute(
+                "INSERT INTO pulse_origins(id, origin_kind, wake_decision_id, pulse_event_id, "
+                "sow_id, assignment_id, created_at) VALUES (?, 'pulse', ?, ?, ?, ?, ?)",
+                (origin_id, decision_id, pulse_event.id, sow.id, assignment.id, now.isoformat()),
+            )
+        return sow, assignment, True
 
     def run_assignment(self, assignment_id: str) -> Assignment:
         assignment = self._assignment(assignment_id)

--- a/src/sovereign_agent/pulse.py
+++ b/src/sovereign_agent/pulse.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import partial
 
 from sovereign_agent.errors import Refusal
 from sovereign_agent.models import Assignment, AssignmentState, Role, Signal
@@ -148,6 +149,14 @@ def _source_event_id(org: Organization, signal_id: str) -> str | None:
     return str(row["id"]) if row is not None else None
 
 
+def _still_qualifies(org: Organization, gate: WakeGate, signal: Signal) -> bool:
+    """The `revalidate` callback `create_pulse_work` calls INSIDE its own
+    open transaction (F-U9-1's fix) -- re-asks the SAME gate a second time,
+    under the write lock, rather than trusting the read `run_pulse_once`
+    took before the transaction existed."""
+    return gate(org, signal) is not None
+
+
 def run_pulse_once(org: Organization, gate: WakeGate) -> PulseReport:
     """One deterministic pass. No sleeping, no looping, no retry policy."""
     items: list[PulseItem] = []
@@ -168,8 +177,16 @@ def run_pulse_once(org: Organization, gate: WakeGate) -> PulseReport:
         if decision is None:
             items.append(PulseItem(signal.id, "skipped", detail="wake gate did not fire"))
             continue
+        # F-U9-1's fix: re-ask the SAME gate again, INSIDE create_pulse_work's
+        # own open transaction, immediately before anything is written. The
+        # condition this gate checked a moment ago (read outside any lock)
+        # could have changed by the time the transaction actually acquires
+        # its write lock -- a concurrent apply_restock resolving the exact
+        # signal this pass is about to act on, for instance. Re-checking
+        # only under the lock is what makes "still qualifies" mean something
+        # at the moment it is acted on, not merely at the moment it was read.
         try:
-            sow, assignment, created = org.create_pulse_work(
+            result = org.create_pulse_work(
                 source_signal_id=signal.id,
                 source_event_id=source_event_id,
                 subject=signal.subject_ref,
@@ -179,10 +196,21 @@ def run_pulse_once(org: Organization, gate: WakeGate) -> PulseReport:
                 planner_id=decision.planner_id,
                 worker_id=decision.worker_id,
                 required_effect_kind=decision.required_effect_kind,
+                revalidate=partial(_still_qualifies, org, gate, signal),
             )
         except Refusal as error:
             items.append(PulseItem(signal.id, "refused", detail=str(error)))
             continue
+        if result is None:
+            items.append(
+                PulseItem(
+                    signal.id,
+                    "skipped",
+                    detail="wake gate no longer fired once the transaction's lock was held",
+                )
+            )
+            continue
+        sow, assignment, created = result
         items.append(_invoke_or_report(org, signal.id, sow.id, assignment, created))
     return PulseReport(tuple(items))
 

--- a/src/sovereign_agent/pulse.py
+++ b/src/sovereign_agent/pulse.py
@@ -1,0 +1,232 @@
+"""Pulse: sale -> signal -> deterministic wake gate -> proactive governed work.
+
+A distinct mechanism from `supervisor.py`, per the governing ruling
+(`docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md`):
+`Supervisor.tick()` never imports this module, never calls it, and this
+module never imports `supervisor.py`. The two compose only through a
+foreground caller running each as its own separate operation with its own
+separate receipt -- never as a fourth reconciliation step.
+
+One deterministic pass (`run_pulse_once`) does exactly what the governing SOW
+requires, in order:
+
+1. Resume every already-fired signal whose canonical assignment is still
+   `CREATED` -- the crash-window case: canonical creation committed, but no
+   process ever reached `run_assignment` for it.
+2. Read durable signals not yet evaluated to a wake decision, oldest first.
+3. Ask the caller-supplied wake gate whether each one fires.
+4. Atomically claim the canonical decision and create the SOW, assignment,
+   Pulse event, and origin links (`Organization.create_pulse_work`).
+5. Invoke the existing production `Organization.run_assignment()` for a
+   newly created or safely resumable assignment.
+6. Return a structured report.
+
+The wake gate itself is intentionally NOT here: this module is
+domain-agnostic (a signal in, a decision or nothing out), and the Store's own
+gate -- "is this SKU still below reorder, does exactly one active outcome
+match" -- lives in `reference_organizations/store`, outside this package's
+budget, exactly as the governing SOW asks ("a Store-specific gate over
+parallel abstractions").
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from sovereign_agent.errors import Refusal
+from sovereign_agent.models import Assignment, AssignmentState, Role, Signal
+from sovereign_agent.organization import Organization
+
+
+@dataclass(frozen=True)
+class WakeDecision:
+    """What the wake gate decided, when a signal qualifies to fire.
+
+    Carries everything `Organization.create_pulse_work` needs to create the
+    canonical SOW and assignment -- the gate decides the WHAT (which
+    outcome, which scope, which actors); `create_pulse_work` alone decides
+    the HOW (atomically, exactly once per source signal).
+    """
+
+    outcome_id: str
+    scope: str
+    role: Role
+    planner_id: str
+    worker_id: str
+    required_effect_kind: str | None = None
+
+
+WakeGate = Callable[[Organization, Signal], WakeDecision | None]
+
+
+@dataclass(frozen=True)
+class PulseItem:
+    """One signal's outcome for this pass, for the structured report."""
+
+    signal_id: str
+    status: str  # created | replayed | skipped | refused | already_running
+    sow_id: str | None = None
+    assignment_id: str | None = None
+    assignment_state: str | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class PulseReport:
+    items: tuple[PulseItem, ...] = field(default_factory=tuple)
+
+    @property
+    def created(self) -> tuple[PulseItem, ...]:
+        return tuple(item for item in self.items if item.status == "created")
+
+
+def _unevaluated_signals(org: Organization) -> list[Signal]:
+    """Every durable signal with no wake decision yet, oldest first.
+
+    A signal that already has a `pulse_wake_decisions` row (fired or not --
+    the row exists the instant this process wins the CAS, before the SOW
+    itself is created) is never re-offered to the GATE: re-evaluating it
+    would either race the canonical creation transaction pointlessly or, for
+    a signal the gate would now refuse, produce no new information. Read
+    fresh, from the current authoritative Store state, exactly as the SOW
+    requires -- this is a live SELECT, not a cached list. A signal that
+    already fired but whose assignment has not yet reached a terminal or
+    running state is picked up separately, by `_resumable_signals` below --
+    this function is only ever about NEW gate evaluations.
+    """
+    rows = org.db.connection.execute(
+        "SELECT s.record AS record FROM signals s "
+        "LEFT JOIN pulse_wake_decisions wd ON wd.source_signal_id = s.id "
+        "WHERE wd.id IS NULL ORDER BY s.rowid"
+    ).fetchall()
+    return [Signal.model_validate_json(row["record"]) for row in rows]
+
+
+def _resumable_signals(org: Organization) -> list[tuple[Signal, str, Assignment]]:
+    """Every signal that already fired but whose canonical assignment is
+    still `CREATED` -- the crash-window case: canonical creation committed,
+    but no process ever reached `run_assignment` for it (a hard kill between
+    the two, or simply a prior pass that created it and exited). Resuming
+    invokes that SAME assignment; it never creates a second one, because the
+    signal already has its one, unique `pulse_wake_decisions` row.
+    """
+    rows = org.db.connection.execute(
+        "SELECT s.record AS signal_record, po.sow_id, po.assignment_id, a.record AS asg_record "
+        "FROM signals s "
+        "JOIN pulse_wake_decisions wd ON wd.source_signal_id = s.id "
+        "JOIN pulse_origins po ON po.wake_decision_id = wd.id "
+        "JOIN assignments a ON a.id = po.assignment_id "
+        "WHERE json_extract(a.record, '$.state') = 'CREATED' "
+        "ORDER BY s.rowid"
+    ).fetchall()
+    return [
+        (
+            Signal.model_validate_json(row["signal_record"]),
+            str(row["sow_id"]),
+            Assignment.model_validate_json(row["asg_record"]),
+        )
+        for row in rows
+    ]
+
+
+def _source_event_id(org: Organization, signal_id: str) -> str | None:
+    """The `sale.committed` event that this signal was minted alongside.
+
+    Looked up by the same `json_extract` pattern `organization.py`'s
+    `effect_kinds_for_execution` already uses -- the signal and its
+    committing event are two rows written inside ONE transaction
+    (`record_sale`), so an event that cannot be found here means the source
+    relationship is missing or inconsistent, which the wake gate's own
+    fail-closed contract (SOW section "Store wake gate") must refuse on.
+    """
+    row = org.db.connection.execute(
+        "SELECT id FROM events WHERE kind = 'sale.committed' "
+        "AND json_extract(payload, '$.signal_id') = ?",
+        (signal_id,),
+    ).fetchone()
+    return str(row["id"]) if row is not None else None
+
+
+def run_pulse_once(org: Organization, gate: WakeGate) -> PulseReport:
+    """One deterministic pass. No sleeping, no looping, no retry policy."""
+    items: list[PulseItem] = []
+    for signal, sow_id, assignment in _resumable_signals(org):
+        items.append(_invoke_or_report(org, signal.id, sow_id, assignment, created=False))
+    for signal in _unevaluated_signals(org):
+        source_event_id = _source_event_id(org, signal.id)
+        if source_event_id is None:
+            items.append(
+                PulseItem(
+                    signal.id,
+                    "skipped",
+                    detail="no source sale.committed event found for this signal",
+                )
+            )
+            continue
+        decision = gate(org, signal)
+        if decision is None:
+            items.append(PulseItem(signal.id, "skipped", detail="wake gate did not fire"))
+            continue
+        try:
+            sow, assignment, created = org.create_pulse_work(
+                source_signal_id=signal.id,
+                source_event_id=source_event_id,
+                subject=signal.subject_ref,
+                outcome_id=decision.outcome_id,
+                scope=decision.scope,
+                role=decision.role,
+                planner_id=decision.planner_id,
+                worker_id=decision.worker_id,
+                required_effect_kind=decision.required_effect_kind,
+            )
+        except Refusal as error:
+            items.append(PulseItem(signal.id, "refused", detail=str(error)))
+            continue
+        items.append(_invoke_or_report(org, signal.id, sow.id, assignment, created))
+    return PulseReport(tuple(items))
+
+
+def _invoke_or_report(
+    org: Organization, signal_id: str, sow_id: str, assignment: Assignment, created: bool
+) -> PulseItem:
+    """Run the canonical assignment if it is CREATED; otherwise report its
+    current terminal or in-flight state without bypassing Unit 8 fencing.
+
+    `RUNNING` is reported, never invoked again -- a second `run_assignment`
+    call on an already-RUNNING assignment would go through the exact same
+    actor-lease and execution-attempt fencing every other caller does and
+    would simply be refused there; reporting it here avoids manufacturing
+    that refusal and is more honest about what this pass actually observed.
+    `COMPLETED`, `BLOCKED`, and `FAILED` are terminal: Pulse never guesses
+    success and never invents an automatic retry policy (SOW section 5).
+    """
+    if assignment.state == AssignmentState.RUNNING:
+        return PulseItem(
+            signal_id,
+            "already_running",
+            sow_id,
+            assignment.id,
+            assignment.state.value,
+            "an execution attempt is already live for this canonical assignment",
+        )
+    if assignment.state != AssignmentState.CREATED:
+        return PulseItem(
+            signal_id,
+            "replayed",
+            sow_id,
+            assignment.id,
+            assignment.state.value,
+            "canonical work is terminal; not re-invoked",
+        )
+    try:
+        ran = org.run_assignment(assignment.id)
+    except Refusal as error:
+        return PulseItem(signal_id, "refused", sow_id, assignment.id, None, str(error))
+    return PulseItem(
+        signal_id,
+        "created" if created else "replayed",
+        sow_id,
+        ran.id,
+        ran.state.value,
+    )

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -925,3 +925,281 @@ def test_migration_14_rolls_back_completely_on_a_simulated_failure(tmp_path: Pat
         ).fetchone()["c"]
         == 1
     )
+
+
+# === Migration 15 (Unit 9: Pulse origin attribution) =======================
+
+
+def _build_unit8_shaped_database(path: Path) -> None:
+    """Migrations 1-14 by hand, with a real pre-Unit-9 SOW and assignment on
+    disk -- the shape a real Unit-8-era organization.db would have the
+    moment before migration 15 first runs against it."""
+    import sovereign_agent.database as database_module
+
+    connection = sqlite3.connect(path)
+    for version, script in database_module.MIGRATIONS:
+        if version > 14:
+            break
+        for statement in database_module._split_statements(script):  # noqa: SLF001
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, datetime('now'))",
+            (version,),
+        )
+    connection.execute("INSERT INTO actors(id, record) VALUES ('operator-course', '{}')")
+    connection.execute("INSERT INTO outcomes(id, record) VALUES ('out_legacy', '{}')")
+    connection.execute(
+        "INSERT INTO sows(id, outcome_id, record) VALUES ('sow_legacy', 'out_legacy', ?)",
+        (json.dumps({"id": "sow_legacy", "created_at": "2026-01-01T00:00:00+00:00"}),),
+    )
+    connection.execute(
+        "INSERT INTO assignments(id, sow_id, actor_id, record) "
+        "VALUES ('asg_legacy', 'sow_legacy', 'operator-course', "
+        '\'{"id": "asg_legacy", "state": "COMPLETED"}\')'
+    )
+    connection.commit()
+    connection.close()
+
+
+def test_migration_15_fresh_install_creates_the_pulse_tables(tmp_path: Path) -> None:
+    path = tmp_path / "fresh.db"
+    db = Database(path)
+    assert 15 in db.applied_versions()
+    tables = {
+        row["name"]
+        for row in db.connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    assert "pulse_wake_decisions" in tables
+    assert "pulse_origins" in tables
+
+
+def test_migration_15_upgrade_from_a_populated_unit8_database_preserves_every_record(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "unit8.db"
+    _build_unit8_shaped_database(path)
+
+    db = Database(path)
+    assert db.applied_versions() == {version for version, _ in MIGRATIONS}
+    assert (
+        db.connection.execute("SELECT COUNT(*) AS c FROM sows WHERE id = 'sow_legacy'").fetchone()[
+            "c"
+        ]
+        == 1
+    ), "the upgrade destroyed a pre-existing SOW"
+    assert (
+        db.connection.execute(
+            "SELECT COUNT(*) AS c FROM assignments WHERE id = 'asg_legacy'"
+        ).fetchone()["c"]
+        == 1
+    ), "the upgrade destroyed a pre-existing assignment"
+
+
+def test_migration_15_backfills_an_explicit_manual_origin_for_every_pre_existing_sow(
+    tmp_path: Path,
+) -> None:
+    """Preservation and explicit manual-origin backfill: a SOW that existed
+    before Pulse was ever built gets its own 'manual' row, not silence."""
+    path = tmp_path / "unit8.db"
+    _build_unit8_shaped_database(path)
+
+    db = Database(path)
+    row = db.connection.execute(
+        "SELECT origin_kind, assignment_id, created_at FROM pulse_origins "
+        "WHERE sow_id = 'sow_legacy'"
+    ).fetchone()
+    assert row is not None, "no origin row was backfilled for a pre-existing SOW"
+    assert row["origin_kind"] == "manual"
+    assert row["assignment_id"] == "asg_legacy"
+    assert row["created_at"] == "2026-01-01T00:00:00+00:00"
+
+
+def test_migration_15_backfill_leaves_assignment_id_null_when_a_sow_has_no_single_assignment(
+    tmp_path: Path,
+) -> None:
+    """A SOW with zero (or more than one) assignment cannot be honestly bound
+    to exactly one -- NULL there, never a guess, while origin_kind stays
+    explicitly 'manual' regardless."""
+    import sovereign_agent.database as database_module
+
+    path = tmp_path / "unit8.db"
+    connection = sqlite3.connect(path)
+    for version, script in database_module.MIGRATIONS:
+        if version > 14:
+            break
+        for statement in database_module._split_statements(script):  # noqa: SLF001
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, datetime('now'))",
+            (version,),
+        )
+    connection.execute("INSERT INTO outcomes(id, record) VALUES ('out_legacy', '{}')")
+    connection.execute(
+        "INSERT INTO sows(id, outcome_id, record) VALUES ('sow_orphan', 'out_legacy', '{}')"
+    )
+    connection.commit()
+    connection.close()
+
+    db = Database(path)
+    row = db.connection.execute(
+        "SELECT origin_kind, assignment_id FROM pulse_origins WHERE sow_id = 'sow_orphan'"
+    ).fetchone()
+    assert row is not None
+    assert row["origin_kind"] == "manual"
+    assert row["assignment_id"] is None
+
+
+def test_migration_15_rolls_back_on_malformed_unattributable_sow_data(tmp_path: Path) -> None:
+    """Fail closed, without stamping the migration, when a pre-existing SOW's
+    record cannot be honestly read -- rather than silently fabricating a
+    created_at or skipping the row."""
+    import sovereign_agent.database as database_module
+
+    path = tmp_path / "unit8.db"
+    connection = sqlite3.connect(path)
+    for version, script in database_module.MIGRATIONS:
+        if version > 14:
+            break
+        for statement in database_module._split_statements(script):  # noqa: SLF001
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, datetime('now'))",
+            (version,),
+        )
+    connection.execute("INSERT INTO outcomes(id, record) VALUES ('out_legacy', '{}')")
+    connection.execute(
+        "INSERT INTO sows(id, outcome_id, record) VALUES "
+        "('sow_bad', 'out_legacy', 'not valid json')"
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(sqlite3.OperationalError):
+        Database(path)
+
+    inspector = sqlite3.connect(path)
+    try:
+        stamped = [
+            int(row[0]) for row in inspector.execute("SELECT version FROM schema_migrations")
+        ]
+        assert 14 in stamped
+        assert 15 not in stamped, "a failed migration was stamped as applied"
+        table_names = {
+            row[0]
+            for row in inspector.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+        assert "pulse_origins" not in table_names, (
+            "a partially-applied migration left a table behind"
+        )
+        assert (
+            inspector.execute("SELECT COUNT(*) FROM sows WHERE id = 'sow_bad'").fetchone()[0] == 1
+        ), "the migration's own rollback destroyed the pre-existing (malformed) row"
+    finally:
+        inspector.close()
+
+    # A hand-repaired row lets a fresh open succeed and stamp 15 normally.
+    repair = sqlite3.connect(path)
+    repair.execute(
+        "UPDATE sows SET record = ? WHERE id = 'sow_bad'",
+        (json.dumps({"id": "sow_bad", "created_at": "2026-01-01T00:00:00+00:00"}),),
+    )
+    repair.commit()
+    repair.close()
+    recovered = Database(path)
+    assert 15 in recovered.applied_versions()
+
+
+def test_migration_15_rolls_back_completely_on_a_simulated_sql_failure(tmp_path: Path) -> None:
+    import sovereign_agent.database as database_module
+
+    path = tmp_path / "unit8.db"
+    _build_unit8_shaped_database(path)
+
+    broken_migration_15 = database_module.MIGRATION_15 + "\nSELECT this_is_not_valid_sql_syntax;"
+    broken_migrations = tuple(
+        (15, broken_migration_15) if version == 15 else (version, script)
+        for version, script in database_module.MIGRATIONS
+    )
+    with patch.object(database_module, "MIGRATIONS", broken_migrations):
+        with pytest.raises(sqlite3.OperationalError):
+            Database(path)
+
+    inspector = sqlite3.connect(path)
+    try:
+        stamped = [
+            int(row[0]) for row in inspector.execute("SELECT version FROM schema_migrations")
+        ]
+        assert 15 not in stamped
+        table_names = {
+            row[0]
+            for row in inspector.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+        assert "pulse_wake_decisions" not in table_names
+        assert (
+            inspector.execute("SELECT COUNT(*) FROM sows WHERE id = 'sow_legacy'").fetchone()[0]
+            == 1
+        )
+    finally:
+        inspector.close()
+
+    recovered = Database(path)
+    assert 15 in recovered.applied_versions()
+
+
+def test_migration_15_foreign_key_uniqueness_and_append_only_enforcement(tmp_path: Path) -> None:
+    from reference_organizations.store import record_sale, seed
+    from reference_organizations.store.pulse_gate import store_wake_gate
+    from sovereign_agent.organization import Organization
+    from sovereign_agent.pulse import run_pulse_once
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "t", "d", ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA"
+    )
+    org.activate(outcome.id, "master-course")
+    signal = record_sale(org.db, "SKU-TEA", 2, 400)
+    source_event_id = org.db.connection.execute(
+        "SELECT id FROM events WHERE kind = 'sale.committed'"
+    ).fetchone()["id"]
+    db = org.db
+
+    with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+        db.connection.execute(
+            "INSERT INTO pulse_wake_decisions(id, source_signal_id, source_event_id, "
+            "subject, decided_at) VALUES ('pdec_x', 'sig_missing', 'evt_missing', "
+            "'SKU-TEA', datetime('now'))"
+        )
+
+    # A real, production-created decision and origin row, through the same
+    # mechanism the rest of the proof matrix uses -- gives this test a real
+    # row to enforce append-only and duplicate-prevention against.
+    report = run_pulse_once(org, store_wake_gate)
+    assert len(report.created) == 1
+
+    with pytest.raises(sqlite3.IntegrityError, match="UNIQUE"):
+        db.connection.execute(
+            "INSERT INTO pulse_wake_decisions(id, source_signal_id, source_event_id, "
+            "subject, decided_at) VALUES ('pdec_dup', ?, ?, 'SKU-TEA', datetime('now'))",
+            (signal.id, source_event_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        db.connection.execute(
+            "DELETE FROM pulse_wake_decisions WHERE source_signal_id = ?", (signal.id,)
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        db.connection.execute("UPDATE pulse_origins SET origin_kind = 'manual'")
+
+
+def test_migration_15_is_idempotently_recognized_after_success(tmp_path: Path) -> None:
+    path = tmp_path / "fresh.db"
+    first = Database(path)
+    stamps_first = first.connection.execute(
+        "SELECT applied_at FROM schema_migrations WHERE version = 15"
+    ).fetchall()
+
+    second = Database(path)
+    stamps_second = second.connection.execute(
+        "SELECT applied_at FROM schema_migrations WHERE version = 15"
+    ).fetchall()
+    assert [tuple(row) for row in stamps_first] == [tuple(row) for row in stamps_second]

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -1,0 +1,800 @@
+"""Unit 9 proof matrix: sale -> signal -> wake gate -> Pulse event -> work.
+
+Every test here drives the REAL mechanism -- a genuine sale through
+`record_sale`, a genuine wake-gate decision through `store_wake_gate`, a
+genuine canonical creation through `Organization.create_pulse_work`, and a
+genuine `pulse.*` event through `append_event` called ONLY by that
+production code path. No test fabricates a `pulse.*` event, inserts a
+pre-classified wake result, or calls `append_event("pulse....")` directly --
+the governing SOW's own "genuine Pulse events only" requirement.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from reference_organizations.store import apply_restock, record_sale, seed
+from reference_organizations.store.demo import propose_restock_from_report, run_pulse_simulated
+from reference_organizations.store.pulse_gate import store_wake_gate
+from sovereign_agent import supervisor as supervisor_module
+from sovereign_agent.database import Database
+from sovereign_agent.models import AssignmentState, Role
+from sovereign_agent.organization import Organization
+from sovereign_agent.pulse import WakeDecision, run_pulse_once
+
+SKU = "SKU-TEA"
+
+
+def _seeded_active_org(root: Path) -> tuple[Organization, str]:
+    org = Organization.init(root)
+    seed(org.db)
+    outcome = org.create_outcome(
+        "Keep the tea jar stocked",
+        "On-hand tea stays at or above the reorder point.",
+        [
+            "inventory_at_or_above_reorder_point",
+            "cash_reconciles",
+            "replenishment_event_exists",
+        ],
+        "principal-human",
+        SKU,
+    )
+    org.activate(outcome.id, "master-course")
+    return org, outcome.id
+
+
+# === Separate mechanism =====================================================
+
+
+def test_pulse_once_works(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    report = run_pulse_once(org, store_wake_gate)
+    assert len(report.created) == 1
+
+
+def test_supervisor_tick_still_creates_no_work_and_emits_no_pulse_event(tmp_path: Path) -> None:
+    """THE decisive separation property: Pulse is a distinct mechanism.
+    `supervisor.tick()` -- run against the SAME organization a Pulse-
+    qualifying sale was just committed to -- must still create no work and
+    emit no `pulse.*` event. This is the property the governing ruling
+    exists to protect: Unit 8's accepted "never fires a wake gate" claim
+    must remain literally true after Unit 9 lands."""
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    before_sows = org.db.connection.execute("SELECT COUNT(*) AS c FROM sows").fetchone()["c"]
+    before_assignments = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM assignments"
+    ).fetchone()["c"]
+
+    supervisor_module.tick(org)
+
+    after_sows = org.db.connection.execute("SELECT COUNT(*) AS c FROM sows").fetchone()["c"]
+    after_assignments = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM assignments"
+    ).fetchone()["c"]
+    pulse_events = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM events WHERE kind LIKE 'pulse.%'"
+    ).fetchone()["c"]
+    assert after_sows == before_sows
+    assert after_assignments == before_assignments
+    assert pulse_events == 0
+
+
+def test_pulse_never_imports_supervisor() -> None:
+    """A static proof, not merely a behavioural one: pulse.py's own AST must
+    contain no import of supervisor.py -- the module the governing ruling
+    forbids Pulse from disguising itself as a step of."""
+    import ast
+
+    import sovereign_agent.pulse as pulse_module
+
+    tree = ast.parse(Path(pulse_module.__file__).read_text(encoding="utf-8"))
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module)
+    assert not any("supervisor" in name for name in imported_modules)
+
+
+# === No creation from nothing ===============================================
+
+
+def test_empty_organization_creates_no_work(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.items == ()
+
+
+def test_seeded_store_with_no_sale_creates_no_work(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.items == ()
+
+
+def test_sale_remaining_above_reorder_creates_no_work(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    # Seed leaves on_hand=4, reorder_point=3: raise the shelf well above
+    # reorder first, then sell a small amount that still leaves it above.
+    org.db.connection.execute("UPDATE inventory SET on_hand = 20 WHERE sku = ?", (SKU,))
+    org.db.connection.commit()
+    record_sale(org.db, SKU, 1, 400)  # on_hand: 20 -> 19, still far above reorder_point=3
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.created == ()
+    assert report.items[0].status == "skipped"
+
+
+# === Qualification ===========================================================
+
+
+def test_a_real_sale_crossing_the_threshold_creates_canonical_proactive_work(
+    tmp_path: Path,
+) -> None:
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    report = run_pulse_once(org, store_wake_gate)
+    assert len(report.created) == 1
+    item = report.created[0]
+    assert item.signal_id == signal.id
+    assert item.sow_id is not None
+    sow = org._sow(item.sow_id)  # noqa: SLF001
+    assert sow.outcome_id == outcome_id
+
+
+# === Current-state check =====================================================
+
+
+def test_a_formerly_qualifying_signal_does_not_fire_after_the_condition_resolves(
+    tmp_path: Path,
+) -> None:
+    """The wake gate re-checks CURRENT state, not the signal's own stale
+    severity at write time. A signal recorded while below reorder must not
+    fire once the shelf has already been restocked by other means."""
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)  # on_hand=2, below reorder_point=3
+    org.db.connection.execute("UPDATE inventory SET on_hand = 10 WHERE sku = ?", (SKU,))
+    org.db.connection.commit()
+
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.created == ()
+    assert report.items[0].signal_id == signal.id
+    assert report.items[0].status == "skipped"
+
+
+# === Attribution ==============================================================
+
+
+def test_attribution_walks_source_event_to_signal_to_decision_to_pulse_event_to_sow_to_assignment(
+    tmp_path: Path,
+) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    report = run_pulse_once(org, store_wake_gate)
+    item = report.created[0]
+    assert item.sow_id is not None
+    assert item.assignment_id is not None
+
+    origin = org.pulse_origin_for_sow(item.sow_id)
+    assert origin is not None
+    assert origin.origin_kind == "pulse"
+    assert origin.sow_id == item.sow_id
+    assert origin.assignment_id == item.assignment_id
+
+    decision = org.db.connection.execute(
+        "SELECT source_signal_id, source_event_id FROM pulse_wake_decisions WHERE id = ?",
+        (origin.wake_decision_id,),
+    ).fetchone()
+    assert decision["source_signal_id"] == signal.id
+
+    source_event = org.db.connection.execute(
+        "SELECT kind, payload FROM events WHERE id = ?", (decision["source_event_id"],)
+    ).fetchone()
+    assert source_event["kind"] == "sale.committed"
+    assert json.loads(source_event["payload"])["signal_id"] == signal.id
+
+    pulse_event = org.db.connection.execute(
+        "SELECT kind FROM events WHERE id = ?", (origin.pulse_event_id,)
+    ).fetchone()
+    assert pulse_event["kind"] == "pulse.work_created"
+
+    assert org._sow(origin.sow_id).id == item.sow_id  # noqa: SLF001
+    assert org._assignment(origin.assignment_id).id == item.assignment_id  # noqa: SLF001
+
+
+# === Manual attribution ======================================================
+
+
+def test_manually_created_work_says_manual_explicitly(tmp_path: Path) -> None:
+    org, outcome_id = _seeded_active_org(tmp_path)
+    sow = org.create_sow(outcome_id, "manual scope", Role.OPERATOR, "master-course")
+    origin = org.pulse_origin_for_sow(sow.id)
+    assert origin is not None
+    assert origin.origin_kind == "manual"
+    assert origin.wake_decision_id is None
+    assert origin.pulse_event_id is None
+
+
+def test_existing_migrated_work_says_manual_explicitly(tmp_path: Path) -> None:
+    """A SOW that existed BEFORE migration 15 gets an explicit manual row at
+    migration time -- absence of a Pulse-origin row must never be the
+    definition of manual (the governing ruling's own words)."""
+    import sovereign_agent.database as database_module
+
+    path = tmp_path / "legacy.db"
+    connection = sqlite3.connect(path)
+    for version, script in database_module.MIGRATIONS:
+        if version > 14:
+            break
+        for statement in database_module._split_statements(script):  # noqa: SLF001
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, datetime('now'))",
+            (version,),
+        )
+    connection.execute("INSERT INTO outcomes(id, record) VALUES ('out1', '{}')")
+    connection.execute(
+        "INSERT INTO sows(id, outcome_id, record) VALUES ('sow_legacy', 'out1', ?)",
+        (json.dumps({"created_at": "2026-01-01T00:00:00+00:00"}),),
+    )
+    connection.commit()
+    connection.close()
+
+    db = Database(path)
+    row = db.connection.execute(
+        "SELECT origin_kind FROM pulse_origins WHERE sow_id = 'sow_legacy'"
+    ).fetchone()
+    assert row is not None
+    assert row["origin_kind"] == "manual"
+
+
+# === Replay ===================================================================
+
+
+def test_same_process_replay_returns_the_same_identifiers_and_counts_remain_one(
+    tmp_path: Path,
+) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    first = run_pulse_once(org, store_wake_gate)
+    second = run_pulse_once(org, store_wake_gate)
+
+    assert len(first.created) == 1
+    # The signal already has a wake decision after the first pass, so the
+    # second pass finds nothing left to evaluate -- it never re-offers an
+    # already-decided signal to the gate at all.
+    assert second.items == ()
+
+    sows = org.db.connection.execute("SELECT COUNT(*) AS c FROM sows").fetchone()["c"]
+    decisions = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM pulse_wake_decisions"
+    ).fetchone()["c"]
+    assert sows == 1
+    assert decisions == 1
+
+
+def test_create_pulse_work_called_twice_for_the_same_signal_returns_the_same_identifiers(
+    tmp_path: Path,
+) -> None:
+    """Isolates the canonical-creation transaction itself, independent of
+    run_pulse_once's own signal-selection skip -- proves create_pulse_work is
+    idempotent on its own terms, not merely "never called twice" by its
+    caller."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    source_event_id = org.db.connection.execute(
+        "SELECT id FROM events WHERE kind = 'sale.committed'"
+    ).fetchone()["id"]
+
+    kwargs = dict(
+        source_signal_id=signal.id,
+        source_event_id=source_event_id,
+        subject=SKU,
+        outcome_id=outcome_id,
+        scope="pulse replenishment",
+        role=Role.OPERATOR,
+        planner_id="master-course",
+        worker_id="operator-course",
+        required_effect_kind="replenishment",
+    )
+    sow1, assignment1, created1 = org.create_pulse_work(**kwargs)  # type: ignore[arg-type]
+    sow2, assignment2, created2 = org.create_pulse_work(**kwargs)  # type: ignore[arg-type]
+    assert created1 is True
+    assert created2 is False
+    assert sow1.id == sow2.id
+    assert assignment1.id == assignment2.id
+
+
+# === Restart ==================================================================
+
+
+def test_reopening_the_database_and_replaying_keeps_counts_at_one(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    run_pulse_once(org, store_wake_gate)
+    org.db.close()
+
+    reopened = Organization(tmp_path)
+    second = run_pulse_once(reopened, store_wake_gate)
+    assert second.items == ()
+    sows = reopened.db.connection.execute("SELECT COUNT(*) AS c FROM sows").fetchone()["c"]
+    assert sows == 1
+
+
+# === Concurrency ==============================================================
+
+
+def test_two_real_processes_evaluating_the_same_signal_create_one_canonical_sow(
+    tmp_path: Path,
+) -> None:
+    """A REAL two-connection proof, matching this project's own standing
+    discipline (test_concurrency.py, test_fencing.py): two genuinely
+    separate `Organization` instances, opened on separate SQLite
+    connections against the SAME root, race `create_pulse_work` for the
+    SAME source signal via a real threading.Barrier. Exactly one must
+    create the canonical SOW; the other must return the SAME identifiers."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    source_event_id = org.db.connection.execute(
+        "SELECT id FROM events WHERE kind = 'sale.committed'"
+    ).fetchone()["id"]
+    org.db.close()
+
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, str, bool]] = []
+    lock = threading.Lock()
+
+    def contend() -> None:
+        contender = Organization(tmp_path)
+        contender.db.connection.execute("PRAGMA busy_timeout = 5000")
+        barrier.wait()
+        sow, assignment, created = contender.create_pulse_work(
+            source_signal_id=signal.id,
+            source_event_id=source_event_id,
+            subject=SKU,
+            outcome_id=outcome_id,
+            scope="pulse replenishment",
+            role=Role.OPERATOR,
+            planner_id="master-course",
+            worker_id="operator-course",
+            required_effect_kind="replenishment",
+        )
+        with lock:
+            results.append((sow.id, assignment.id, created))
+        contender.db.close()
+
+    threads = [threading.Thread(target=contend) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    sow_ids = {r[0] for r in results}
+    assignment_ids = {r[1] for r in results}
+    created_flags = [r[2] for r in results]
+    assert len(sow_ids) == 1, f"two different SOWs were created: {results}"
+    assert len(assignment_ids) == 1
+    assert sorted(created_flags) == [False, True]
+
+    inspector = Organization(tmp_path)
+    sow_count = inspector.db.connection.execute("SELECT COUNT(*) AS c FROM sows").fetchone()["c"]
+    decision_count = inspector.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM pulse_wake_decisions"
+    ).fetchone()["c"]
+    assert sow_count == 1
+    assert decision_count == 1
+
+
+# === Crash window =============================================================
+
+
+def test_canonical_created_work_survives_restart_and_resumes_without_duplication(
+    tmp_path: Path,
+) -> None:
+    """Simulates a crash after canonical creation but before provider
+    invocation: create_pulse_work runs (the SOW/assignment/origin/pulse
+    event are durable), but run_assignment never happens -- the assignment
+    is left at CREATED, as it genuinely would be after a hard kill between
+    the two. A fresh pass must invoke that SAME assignment, never create a
+    second one."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    source_event_id = org.db.connection.execute(
+        "SELECT id FROM events WHERE kind = 'sale.committed'"
+    ).fetchone()["id"]
+    sow, assignment, created = org.create_pulse_work(
+        source_signal_id=signal.id,
+        source_event_id=source_event_id,
+        subject=SKU,
+        outcome_id=outcome_id,
+        scope="pulse replenishment",
+        role=Role.OPERATOR,
+        planner_id="master-course",
+        worker_id="operator-course",
+        required_effect_kind="replenishment",
+    )
+    assert created is True
+    assert assignment.state == AssignmentState.CREATED
+    org.db.close()
+
+    resumed = Organization(tmp_path)
+    report = run_pulse_once(resumed, store_wake_gate)
+    # The signal already has a wake decision, so the gate is never
+    # re-consulted -- but its CREATED assignment is resumed, invoking the
+    # SAME canonical assignment rather than minting a second one.
+    assert len(report.items) == 1
+    assert report.items[0].signal_id == signal.id
+    assert report.items[0].assignment_id == assignment.id
+    assert report.items[0].assignment_state == AssignmentState.COMPLETED.value
+
+    final = resumed._assignment(assignment.id)  # noqa: SLF001
+    assert final.state == AssignmentState.COMPLETED
+    sow_count = resumed.db.connection.execute("SELECT COUNT(*) AS c FROM sows").fetchone()["c"]
+    assert sow_count == 1
+    assignment_count = resumed.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM assignments"
+    ).fetchone()["c"]
+    assert assignment_count == 1
+
+
+# === Existing RUNNING work ====================================================
+
+
+def test_pulse_does_not_bypass_actor_leases_or_execution_attempt_fencing(tmp_path: Path) -> None:
+    """The canonical assignment is genuinely RUNNING (a live, unexpired
+    execution attempt and a live actor lease already held by a DIFFERENT
+    process) when a second pulse pass reaches it -- proves Pulse reports
+    the in-flight state rather than invoking run_assignment a second time,
+    which would go through the exact same fencing every other caller does
+    and be refused there."""
+    from sovereign_agent import fencing
+
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    source_event_id = org.db.connection.execute(
+        "SELECT id FROM events WHERE kind = 'sale.committed'"
+    ).fetchone()["id"]
+    sow, assignment, _created = org.create_pulse_work(
+        source_signal_id=signal.id,
+        source_event_id=source_event_id,
+        subject=SKU,
+        outcome_id=outcome_id,
+        scope="pulse replenishment",
+        role=Role.OPERATOR,
+        planner_id="master-course",
+        worker_id="operator-course",
+        required_effect_kind="replenishment",
+    )
+    other_process = fencing.new_process_identity()
+    lease = fencing.acquire_actor_lease(org.db, "operator-course", other_process)
+    fencing.acquire_execution_attempt(
+        org.db, assignment.id, "operator-course", other_process, lease.fencing_token
+    )
+    org.db.connection.execute(
+        "UPDATE assignments SET record = json_set(record, '$.state', 'RUNNING') WHERE id = ?",
+        (assignment.id,),
+    )
+    org.db.connection.commit()
+
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.items == (), "the signal already has a wake decision; nothing left to evaluate"
+
+    # Isolate the reporting behaviour directly against the RUNNING assignment,
+    # independent of the signal-skip above.
+    from sovereign_agent.pulse import _invoke_or_report
+
+    running = org._assignment(assignment.id)  # noqa: SLF001
+    assert running.state == AssignmentState.RUNNING
+    item = _invoke_or_report(org, signal.id, sow.id, running, False)
+    assert item.status == "already_running"
+
+
+# === Terminal work =============================================================
+
+
+def test_completed_canonical_assignment_is_not_rerun(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    first = run_pulse_once(org, store_wake_gate)
+    assert first.created[0].assignment_state == AssignmentState.COMPLETED.value
+
+    with patch(
+        "sovereign_agent.organization.Organization.run_assignment",
+        side_effect=AssertionError("must not be invoked again"),
+    ):
+        second = run_pulse_once(org, store_wake_gate)
+    assert second.items == ()
+
+
+def test_blocked_and_failed_canonical_assignments_are_not_rerun_or_replaced(
+    tmp_path: Path,
+) -> None:
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    source_event_id = org.db.connection.execute(
+        "SELECT id FROM events WHERE kind = 'sale.committed'"
+    ).fetchone()["id"]
+    sow, assignment, _created = org.create_pulse_work(
+        source_signal_id=signal.id,
+        source_event_id=source_event_id,
+        subject=SKU,
+        outcome_id=outcome_id,
+        scope="pulse replenishment",
+        role=Role.OPERATOR,
+        planner_id="master-course",
+        worker_id="operator-course",
+        required_effect_kind="replenishment",
+    )
+    org.db.connection.execute(
+        "UPDATE assignments SET record = json_set(record, '$.state', 'FAILED') WHERE id = ?",
+        (assignment.id,),
+    )
+    org.db.connection.commit()
+
+    from sovereign_agent.pulse import _invoke_or_report
+
+    failed = org._assignment(assignment.id)  # noqa: SLF001
+    item = _invoke_or_report(org, signal.id, sow.id, failed, False)
+    assert item.status == "replayed"
+    assert item.assignment_state == AssignmentState.FAILED.value
+    still_failed = org._assignment(assignment.id)  # noqa: SLF001
+    assert still_failed.state == AssignmentState.FAILED
+
+
+# === Source integrity =========================================================
+
+
+def test_missing_source_event_fails_closed(tmp_path: Path) -> None:
+    """A signal with no matching sale.committed event (source relationship
+    missing or inconsistent -- events are append-only, so this is simulated
+    by inserting a signal row with no corresponding event, the honest shape
+    a source-relationship gap could ever actually take in this ledger)
+    must be skipped, not fabricated a source_event_id."""
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    from sovereign_agent.models import Signal
+
+    orphan = Signal(
+        id="sig_orphan",
+        kind="inventory.changed",
+        source="sale",
+        subject_ref=SKU,
+        severity="warning",
+        observed_at=org.db.connection.execute("SELECT datetime('now') AS n").fetchone()["n"],
+        payload_digest=SKU,
+        dedupe_key="inventory:SKU-TEA:orphan",
+    )
+    org.db.connection.execute(
+        "INSERT INTO signals(id, dedupe_key, record) VALUES (?, ?, ?)",
+        (orphan.id, orphan.dedupe_key, orphan.model_dump_json()),
+    )
+    org.db.connection.commit()
+
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.created == ()
+    assert report.items[0].status == "skipped"
+    assert "no source" in report.items[0].detail
+
+
+def test_fabricated_source_signal_id_is_refused_by_the_foreign_key(tmp_path: Path) -> None:
+    org, outcome_id = _seeded_active_org(tmp_path)
+    with pytest.raises(Exception, match="FOREIGN KEY"):
+        org.create_pulse_work(
+            source_signal_id="sig_does_not_exist",
+            source_event_id="evt_does_not_exist",
+            subject=SKU,
+            outcome_id=outcome_id,
+            scope="pulse replenishment",
+            role=Role.OPERATOR,
+            planner_id="master-course",
+            worker_id="operator-course",
+            required_effect_kind="replenishment",
+        )
+
+
+def test_no_active_outcome_matching_the_subject_creates_no_work(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    # No outcome created at all for SKU-TEA.
+    record_sale(org.db, SKU, 2, 400)
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.created == ()
+
+
+def test_more_than_one_matching_active_outcome_creates_no_work(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    second = org.create_outcome(
+        "A second outcome about the same SKU",
+        "Also tea.",
+        ["inventory_at_or_above_reorder_point"],
+        "principal-human",
+        SKU,
+    )
+    org.activate(second.id, "master-course")
+    record_sale(org.db, SKU, 2, 400)
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.created == ()
+
+
+# === Ledger integrity ==========================================================
+
+
+def test_pulse_origins_and_wake_decisions_are_append_only(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    run_pulse_once(org, store_wake_gate)
+
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        org.db.connection.execute("UPDATE pulse_wake_decisions SET subject = 'tampered' WHERE 1=1")
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        org.db.connection.execute("DELETE FROM pulse_origins")
+
+
+def test_two_pulse_origin_rows_cannot_name_the_same_sow(tmp_path: Path) -> None:
+    org, outcome_id = _seeded_active_org(tmp_path)
+    sow = org.create_sow(outcome_id, "manual scope", Role.OPERATOR, "master-course")
+    with pytest.raises(sqlite3.IntegrityError):
+        org.db.connection.execute(
+            "INSERT INTO pulse_origins(id, origin_kind, sow_id, created_at) "
+            "VALUES ('porg_dup', 'manual', ?, datetime('now'))",
+            (sow.id,),
+        )
+
+
+def test_a_pulse_origin_row_without_a_real_sow_is_refused_by_the_foreign_key(
+    tmp_path: Path,
+) -> None:
+    org = Organization.init(tmp_path)
+    with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+        org.db.connection.execute(
+            "INSERT INTO pulse_origins(id, origin_kind, sow_id, created_at) "
+            "VALUES ('porg_x', 'manual', 'sow_does_not_exist', datetime('now'))"
+        )
+
+
+def test_indexed_pulse_origin_agrees_with_the_organization_method(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    report = run_pulse_once(org, store_wake_gate)
+    item = report.created[0]
+    assert item.sow_id is not None
+    origin = org.pulse_origin_for_sow(item.sow_id)
+    row = org.db.connection.execute(
+        "SELECT sow_id, assignment_id, origin_kind FROM pulse_origins WHERE sow_id = ?",
+        (item.sow_id,),
+    ).fetchone()
+    assert origin is not None
+    assert origin.sow_id == row["sow_id"]
+    assert origin.assignment_id == row["assignment_id"]
+    assert origin.origin_kind == row["origin_kind"]
+
+
+# === Recurrence ================================================================
+
+
+def test_a_later_sale_reaching_a_previously_seen_level_retains_the_old_signal_and_can_fire_again(
+    tmp_path: Path,
+) -> None:
+    """THE decisive signal-stability property. Before the fix, a second sale
+    reaching the SAME on_hand level replaced the first signal's row via
+    INSERT OR REPLACE keyed on dedupe_key -- so Pulse origin referencing the
+    first signal's id would find it silently gone. Two DISTINCT sales here
+    both leave on_hand at 2 (buy back up to 4 between them); both signals
+    must survive, and each is a genuine, independent opportunity for
+    Pulse-created work."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    first_signal = record_sale(org.db, SKU, 2, 400)  # on_hand: 4 -> 2
+
+    first_report = run_pulse_once(org, store_wake_gate)
+    assert len(first_report.created) == 1
+    first_assignment_id = first_report.created[0].assignment_id
+    assert first_assignment_id is not None
+    assignment = org._assignment(first_assignment_id)  # noqa: SLF001
+    report_path = (
+        tmp_path
+        / ".sovereign"
+        / "runs"
+        / assignment.workspace_id
+        / ".sovereign-out"
+        / "report.json"
+    )
+    proposal = propose_restock_from_report(report_path, SKU)
+    apply_restock(org.db, proposal, first_assignment_id, first_signal.id)
+
+    row = org.db.connection.execute(
+        "SELECT on_hand FROM inventory WHERE sku = ?", (SKU,)
+    ).fetchone()
+    on_hand_after_restock = int(row["on_hand"])
+    # Sell back down to exactly the same level the first signal recorded.
+    quantity = on_hand_after_restock - 2
+    second_signal = record_sale(org.db, SKU, quantity, 400)
+    assert second_signal.id != first_signal.id
+
+    still_present = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM signals WHERE id = ?", (first_signal.id,)
+    ).fetchone()["c"]
+    assert still_present == 1, "the earlier signal that already caused work was overwritten"
+
+    second_report = run_pulse_once(org, store_wake_gate)
+    assert len(second_report.created) == 1
+    assert second_report.created[0].signal_id == second_signal.id
+    assert second_report.created[0].sow_id != first_report.created[0].sow_id
+
+    signal_count = org.db.connection.execute("SELECT COUNT(*) AS c FROM signals").fetchone()["c"]
+    assert signal_count == 2
+
+
+# === Real mechanism =============================================================
+
+
+def test_no_pulse_event_exists_before_pulse_runs(tmp_path: Path) -> None:
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    count = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM events WHERE kind LIKE 'pulse.%'"
+    ).fetchone()["c"]
+    assert count == 0
+
+
+def test_wake_gate_receives_a_real_signal_object_read_from_the_database(tmp_path: Path) -> None:
+    """Proves the gate is called with the genuine persisted Signal, not a
+    hand-built stand-in -- a spy gate records what it was actually given."""
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    seen: list[str] = []
+
+    def spy_gate(spy_org: Organization, spy_signal) -> WakeDecision | None:  # type: ignore[no-untyped-def]
+        seen.append(spy_signal.id)
+        return store_wake_gate(spy_org, spy_signal)
+
+    run_pulse_once(org, spy_gate)
+    assert seen == [signal.id]
+
+
+# === Full teaching slice =========================================================
+
+
+def test_full_teaching_slice_reaches_verified_reviewed_truthful_acceptance(
+    tmp_path: Path,
+) -> None:
+    text = run_pulse_simulated(tmp_path)
+    assert "ACCEPTED" in text
+    org = Organization(tmp_path)
+    outcome_row = org.db.connection.execute("SELECT record FROM outcomes").fetchone()
+    outcome = json.loads(outcome_row["record"])
+    assert outcome["state"] == "ACCEPTED"
+    sow_row = org.db.connection.execute("SELECT id FROM sows").fetchone()
+    origin = org.pulse_origin_for_sow(sow_row["id"])
+    assert origin is not None
+    assert origin.origin_kind == "pulse"
+
+
+# === CLI artifact ================================================================
+
+
+def test_pulse_once_requires_the_flag(tmp_path: Path) -> None:
+    from sovereign_agent.cli import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--root", str(tmp_path), "pulse"])
+
+
+def test_pulse_cli_handler_reports_created_work(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    from sovereign_agent.cli import main
+
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+    org.db.close()
+
+    exit_code = main(["pulse", "--root", str(tmp_path), "--once"])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "created" in out
+    assert "1 created" in out

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -24,7 +24,7 @@ from reference_organizations.store.demo import propose_restock_from_report, run_
 from reference_organizations.store.pulse_gate import store_wake_gate
 from sovereign_agent import supervisor as supervisor_module
 from sovereign_agent.database import Database
-from sovereign_agent.models import AssignmentState, Role
+from sovereign_agent.models import Assignment, AssignmentState, Role
 from sovereign_agent.organization import Organization
 from sovereign_agent.pulse import WakeDecision, run_pulse_once
 
@@ -744,7 +744,14 @@ def test_no_pulse_event_exists_before_pulse_runs(tmp_path: Path) -> None:
 
 def test_wake_gate_receives_a_real_signal_object_read_from_the_database(tmp_path: Path) -> None:
     """Proves the gate is called with the genuine persisted Signal, not a
-    hand-built stand-in -- a spy gate records what it was actually given."""
+    hand-built stand-in -- a spy gate records what it was actually given.
+
+    Called TWICE for one qualifying signal, both times with the same real
+    Signal: once by run_pulse_once itself (the ordinary read), and once
+    again by create_pulse_work's own `revalidate` callback, INSIDE its open
+    transaction (F-U9-1's fix -- see organization.py's create_pulse_work).
+    Both calls see the identical persisted signal id; only the call COUNT
+    changed, not what either call was given."""
     org, _outcome_id = _seeded_active_org(tmp_path)
     signal = record_sale(org.db, SKU, 2, 400)
     seen: list[str] = []
@@ -754,7 +761,7 @@ def test_wake_gate_receives_a_real_signal_object_read_from_the_database(tmp_path
         return store_wake_gate(spy_org, spy_signal)
 
     run_pulse_once(org, spy_gate)
-    assert seen == [signal.id]
+    assert seen == [signal.id, signal.id]
 
 
 # === Full teaching slice =========================================================
@@ -798,3 +805,287 @@ def test_pulse_cli_handler_reports_created_work(tmp_path: Path, capsys) -> None:
     out = capsys.readouterr().out
     assert "created" in out
     assert "1 created" in out
+
+
+# === F-U9-1: the canonical creation transaction is genuinely atomic ========
+#
+# Sparring's finding, confirmed independently by the Principal: the ORIGINAL
+# create_pulse_work was five separate commits (the wake-decision INSERT in
+# its own db.immediate(), then create_sow's, ready_sow's, and assign's own
+# transactions in sequence, then a final db.transaction() for the origin
+# row), not one atomic transaction, despite the governing SOW's explicit
+# "must become durable atomically" requirement. An ordinary exception
+# between any two of those commits left the wake decision durably stranded
+# -- decisions=1, everything else=0 -- and, because source_signal_id is
+# UNIQUE, no retry could ever re-claim that signal: it was orphaned
+# permanently. Every test below drives the REAL, now-single, db.immediate()
+# transaction in organization.py's create_pulse_work -- no test injects a
+# fault by editing SQL directly; each patches a real internal method
+# (_create_sow_on, _ready_sow_on, _assign_on) or a real module-level
+# function (append_event) to raise, the same "reproduce the real defect
+# shape" discipline this project's own falsification history uses.
+
+
+def _full_chain_counts(org: Organization) -> dict[str, int]:
+    counts = {}
+    for table in ("pulse_wake_decisions", "pulse_origins", "sows", "assignments"):
+        counts[table] = org.db.connection.execute(f"SELECT COUNT(*) AS c FROM {table}").fetchone()[
+            "c"
+        ]
+    counts["pulse_events"] = org.db.connection.execute(
+        "SELECT COUNT(*) AS c FROM events WHERE kind = 'pulse.work_created'"
+    ).fetchone()["c"]
+    return counts
+
+
+def _create_pulse_work_kwargs(org: Organization, outcome_id: str, signal) -> dict:  # type: ignore[no-untyped-def]
+    source_event_id = org.db.connection.execute(
+        "SELECT id FROM events WHERE kind = 'sale.committed'"
+    ).fetchone()["id"]
+    return dict(
+        source_signal_id=signal.id,
+        source_event_id=source_event_id,
+        subject=SKU,
+        outcome_id=outcome_id,
+        scope="pulse replenishment",
+        role=Role.OPERATOR,
+        planner_id="master-course",
+        worker_id="operator-course",
+        required_effect_kind="replenishment",
+    )
+
+
+@pytest.mark.parametrize(
+    "patch_target",
+    [
+        "sovereign_agent.organization.Organization._create_sow_on",
+        "sovereign_agent.organization.Organization._ready_sow_on",
+        "sovereign_agent.organization.Organization._assign_on",
+        "sovereign_agent.organization.append_event",
+    ],
+)
+def test_a_fault_at_every_creation_boundary_rolls_back_the_entire_chain(
+    tmp_path: Path, patch_target: str
+) -> None:
+    """A fault injected at EACH of the four remaining write boundaries
+    inside the now-single transaction (SOW creation, the READY transition,
+    assignment creation, and the pulse.work_created event -- the origin
+    insert has nothing after it to fault before) leaves NO partial chain:
+    every one of decisions/origins/sows/assignments/pulse_events is zero,
+    not just the wake decision. Before F-U9-1's fix, only the FIRST of
+    these boundaries was even reachable as a discrete commit to fault
+    between; this parametrization proves the fix holds at every boundary
+    the new single transaction actually has, not just the one the original
+    report reproduced."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    kwargs = _create_pulse_work_kwargs(org, outcome_id, signal)
+
+    with patch(patch_target, side_effect=RuntimeError("simulated fault")):
+        with pytest.raises(RuntimeError, match="simulated fault"):
+            org.create_pulse_work(**kwargs)
+
+    counts = _full_chain_counts(org)
+    assert counts == {
+        "pulse_wake_decisions": 0,
+        "pulse_origins": 0,
+        "sows": 0,
+        "assignments": 0,
+        "pulse_events": 0,
+    }, f"a partial chain survived a fault at {patch_target}: {counts}"
+
+
+def test_the_signal_remains_eligible_after_a_full_rollback_and_a_retry_creates_exactly_one_chain(
+    tmp_path: Path,
+) -> None:
+    """The decisive recovery property F-U9-1 named as missing: after a fault
+    rolls the whole chain back, the signal is NOT permanently orphaned -- a
+    retry succeeds (not a Refusal) and creates exactly one canonical chain,
+    not a duplicate of anything the failed attempt might have left behind."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    kwargs = _create_pulse_work_kwargs(org, outcome_id, signal)
+
+    with patch.object(Organization, "_ready_sow_on", side_effect=RuntimeError("simulated fault")):
+        with pytest.raises(RuntimeError, match="simulated fault"):
+            org.create_pulse_work(**kwargs)
+    assert _full_chain_counts(org) == {
+        "pulse_wake_decisions": 0,
+        "pulse_origins": 0,
+        "sows": 0,
+        "assignments": 0,
+        "pulse_events": 0,
+    }
+
+    sow, assignment, created = org.create_pulse_work(**kwargs)
+    assert created is True
+    counts = _full_chain_counts(org)
+    assert counts == {
+        "pulse_wake_decisions": 1,
+        "pulse_origins": 1,
+        "sows": 1,
+        "assignments": 1,
+        "pulse_events": 1,
+    }
+    origin = org.pulse_origin_for_sow(sow.id)
+    assert origin is not None
+    assert origin.assignment_id == assignment.id
+
+
+def test_run_pulse_once_recovers_a_signal_orphaned_by_a_mid_transaction_fault(
+    tmp_path: Path,
+) -> None:
+    """The same recovery property, driven through the real run_pulse_once
+    entry point rather than calling create_pulse_work directly -- a signal
+    that failed to create canonical work on one pass is still
+    _unevaluated_ (no wake decision survived the rollback) and is picked
+    up cleanly on the very next pass."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+
+    with patch.object(Organization, "_assign_on", side_effect=RuntimeError("simulated fault")):
+        with pytest.raises(RuntimeError, match="simulated fault"):
+            run_pulse_once(org, store_wake_gate)
+    assert _full_chain_counts(org) == {
+        "pulse_wake_decisions": 0,
+        "pulse_origins": 0,
+        "sows": 0,
+        "assignments": 0,
+        "pulse_events": 0,
+    }
+
+    report = run_pulse_once(org, store_wake_gate)
+    assert len(report.created) == 1
+    assert report.created[0].signal_id == signal.id
+    assert _full_chain_counts(org)["sows"] == 1
+
+
+def test_two_real_processes_still_converge_on_one_canonical_creation_under_the_atomic_design(
+    tmp_path: Path,
+) -> None:
+    """Sparring's own named dual: does making create_pulse_work atomic
+    correctly PRESERVE the concurrent-race behaviour the separate-commit
+    design was originally built around? A real two-connection
+    threading.Barrier race, same shape as the pre-fix proof
+    (test_two_real_processes_evaluating_the_same_signal_create_one_canonical_sow
+    above) -- re-run here explicitly under the new single-db.immediate()
+    design as its own named property, not merely relied upon via the
+    unchanged original test still passing."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    kwargs = _create_pulse_work_kwargs(org, outcome_id, signal)
+    org.db.close()
+
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, str, bool]] = []
+    lock = threading.Lock()
+
+    def contend() -> None:
+        contender = Organization(tmp_path)
+        contender.db.connection.execute("PRAGMA busy_timeout = 5000")
+        barrier.wait()
+        sow, assignment, created = contender.create_pulse_work(**kwargs)
+        with lock:
+            results.append((sow.id, assignment.id, created))
+        contender.db.close()
+
+    threads = [threading.Thread(target=contend) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    sow_ids = {r[0] for r in results}
+    assignment_ids = {r[1] for r in results}
+    created_flags = sorted(r[2] for r in results)
+    assert len(sow_ids) == 1, f"two different SOWs were created: {results}"
+    assert len(assignment_ids) == 1
+    assert created_flags == [False, True]
+
+    inspector = Organization(tmp_path)
+    counts = _full_chain_counts(inspector)
+    assert counts["sows"] == 1
+    assert counts["pulse_wake_decisions"] == 1
+
+
+def test_the_losing_contender_reads_the_winners_committed_identifiers_under_the_atomic_design(
+    tmp_path: Path,
+) -> None:
+    """Isolates the loser's own read path: a first, real create_pulse_work
+    call commits the full chain; a SECOND call for the same signal (the
+    ordinary replay shape, standing in for a losing concurrent contender
+    that arrives after the winner's transaction already committed) must
+    return the SAME identifiers, never mint a second SOW."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    kwargs = _create_pulse_work_kwargs(org, outcome_id, signal)
+
+    sow1, assignment1, created1 = org.create_pulse_work(**kwargs)
+    sow2, assignment2, created2 = org.create_pulse_work(**kwargs)
+    assert created1 is True
+    assert created2 is False
+    assert sow1.id == sow2.id
+    assert assignment1.id == assignment2.id
+    assert _full_chain_counts(org)["sows"] == 1
+
+
+def test_revalidation_inside_the_transaction_prevents_stale_work(tmp_path: Path) -> None:
+    """The condition can resolve between run_pulse_once's own gate read and
+    create_pulse_work's transaction acquiring its lock. revalidate is
+    called INSIDE that lock and, when it reports the condition no longer
+    holds, create_pulse_work writes NOTHING and returns None -- proven
+    directly against the primitive, not merely inferred from the gate's own
+    ordinary re-check."""
+    org, outcome_id = _seeded_active_org(tmp_path)
+    signal = record_sale(org.db, SKU, 2, 400)
+    kwargs = _create_pulse_work_kwargs(org, outcome_id, signal)
+
+    result = org.create_pulse_work(**kwargs, revalidate=lambda: False)
+    assert result is None
+    assert _full_chain_counts(org) == {
+        "pulse_wake_decisions": 0,
+        "pulse_origins": 0,
+        "sows": 0,
+        "assignments": 0,
+        "pulse_events": 0,
+    }
+
+    # The signal is still eligible -- a subsequent call with no revalidation
+    # failure creates the canonical chain normally.
+    sow, assignment, created = org.create_pulse_work(**kwargs)
+    assert created is True
+    assert _full_chain_counts(org)["sows"] == 1
+
+
+def test_provider_invocation_never_sees_an_incomplete_pulse_origin_chain(tmp_path: Path) -> None:
+    """run_assignment (which invokes the provider) must never be called
+    until create_pulse_work's own transaction has fully committed --
+    decision, SOW, assignment, event, AND origin all durable together. Spies
+    on Organization.run_assignment and, at the moment it is first called,
+    independently re-reads the ledger through a SEPARATE connection (not
+    the same in-process object, so a would-be uncommitted write is
+    genuinely invisible if it is not yet durable) to confirm the complete
+    chain is already there."""
+    org, _outcome_id = _seeded_active_org(tmp_path)
+    record_sale(org.db, SKU, 2, 400)
+
+    observed: dict[str, object] = {}
+    real_run_assignment = Organization.run_assignment
+
+    def spying_run_assignment(self: Organization, assignment_id: str) -> Assignment:
+        checker = Organization(tmp_path)
+        observed["counts"] = _full_chain_counts(checker)
+        checker.db.close()
+        return real_run_assignment(self, assignment_id)
+
+    with patch.object(Organization, "run_assignment", spying_run_assignment):
+        report = run_pulse_once(org, store_wake_gate)
+
+    assert len(report.created) == 1
+    assert observed["counts"] == {
+        "pulse_wake_decisions": 1,
+        "pulse_origins": 1,
+        "sows": 1,
+        "assignments": 1,
+        "pulse_events": 1,
+    }


### PR DESCRIPTION
## Summary

Implements the Unit 9 SOW (`docs/sows/sovereign-agent-v1-unit9-pulse-proactive-work.md`) per the governing ruling (`docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md`). Base: `95ceb8d66b0734a3942d71d3510660c0f4109eb5` (Units 0-8 ACCEPTED, Unit 9 SOW reviewed and merged).

**The pipeline closed:** sale → durable inventory signal → deterministic wake gate → genuine durable Pulse event → replenishment work created without a human prompt → Scripted Operator → deterministic effect boundary → evidence → review → acceptance.

- **Pulse is a separate mechanism** (`src/sovereign_agent/pulse.py`), never imported by `supervisor.py`, never touching `Supervisor.tick()`. Unit 8's accepted "never reads a Pulse signal, never fires a wake gate" claims remain literally true — verified unmodified in both `supervisor.py` and the accepted doc.
- **Store wake gate** (`src/reference_organizations/store/pulse_gate.py`, outside the budgeted package per the SOW's own instruction) fails closed on every named ambiguity: no qualifying signal, condition already resolved (re-checked live against current state, not the signal's stale severity), missing/inconsistent source event, no/ambiguous matching outcome.
- **Canonical creation transaction**: `Organization.create_pulse_work` claims one wake decision per source signal via a `UNIQUE(source_signal_id)` constraint at the SQLite boundary, reuses `create_sow`/`ready_sow`/`assign` unchanged (no forked teaching path), a concurrent loser returns identical identifiers.
- **Signal stability**: `record_sale`'s signal insert changed from `INSERT OR REPLACE` to a plain, append-only `INSERT`, with `dedupe_key` made unique per occurrence (previously two different sales reaching the same inventory level produced the same key, and the second silently deleted the first's signal row). `UNIQUE` on `dedupe_key` is kept as a fail-closed safety net. `record_sale`'s existing single-transaction atomicity is unchanged.
- **Structured, queryable Pulse-origin**: every SOW — manual or Pulse, new or migration-backfilled — carries an explicit `pulse_origins` row at creation time; absence of a row is never the definition of manual.
- **Migration 15**: `pulse_wake_decisions`, `pulse_origins`, both append-only with FK/uniqueness enforcement, fail-closed rollback on unattributable legacy data.
- **CLI**: `sovereign-agent pulse --once --root PATH`.
- **Reference Store proof**: `run_pulse_simulated` — real sale, real Pulse-created SOW/assignment, real Scripted execution, real `apply_restock`, real verify/review/accept, reaching `ACCEPTED`.

## Independent verification (Master, this exact head — not a restatement of the implementer's report)

- Confirmed `main`/`origin/main` untouched throughout (byte-identical to `95ceb8d6`), correct branch ancestry, clean working tree.
- Full gate reproduced green, twice consecutively: 322 passed / 9 deselected, `mypy --strict` clean, budget `27/40 modules, 5991/6000 lines, 7/30 exports` (9 lines of headroom — confirmed honest, not silently overshot or padded), curriculum sound, `git diff --check` clean, credentials confirmed absent.
- **Independently mutation-checked all four required decisive properties myself, from scratch** (not a re-run of the implementer's claimed mutations):
  1. Removed `UNIQUE` from `pulse_wake_decisions.source_signal_id` — both concurrency/idempotency tests went red with two genuinely distinct SOWs created under a real race; restored byte-identical; confirmed green.
  2. Removed the wake gate's live `below_reorder` re-check — both "condition already resolved" tests went red (real unwanted work created); confirmed the correctly-unaffected empty-organization tests stayed green (different guard clause); restored byte-identical; confirmed green.
  3. Removed `create_sow`'s manual-origin insert — the attribution test went red; restored byte-identical; confirmed green.
  4. Inserted a real Pulse call into `Supervisor.tick()` — the new decisive test (`test_supervisor_tick_still_creates_no_work_and_emits_no_pulse_event`, deliberately run against an organization with an already-committed qualifying sale) went red; confirmed the pre-existing Unit 8 test's real blind spot (it runs against an empty org, so it stayed green under this exact mutation — correctly identified and separately closed by the new test, not silently left); restored byte-identical; confirmed green.
- Read the signal-stability fix directly, confirmed `record_sale`'s atomicity (inventory, cash, signal, event in one `db.immediate()`) is unchanged, confirmed the root-cause diagnosis and fix are sound.
- Ran the real two-process/two-connection concurrency test and the recurrence test live.
- Ran all 8 migration-15 tests live.
- **Ran every check-command in the documentation deliverable myself, verbatim** — including the foreground `pulse --once` walkthrough and the attribution SQL query, both reproduced from scratch and confirmed working, not merely re-reading the stream's claims.
- Built the wheel, installed into a genuinely fresh isolated venv (`uv venv`, not a possibly-stale reused one), ran `--help`, `doctor`, and `pulse --once` outside the source tree — all exit 0.

Credentialed provider tests remain deselected and unrun — stated explicitly, not inferred from a green offline gate.

## Test plan

- [x] `make verify` green at this exact head, twice consecutively
- [x] Full proof matrix present and passing: 33 tests in `tests/test_pulse.py`, 8 new migration tests in `tests/test_persistence.py`
- [x] All four required decisive properties independently mutation-checked by Master
- [x] Signal-stability fix read and verified directly (Sparring's highest-risk-area flag)
- [x] Real two-process concurrency proof run live
- [x] Clean wheel build + installed-CLI smoke outside source tree
- [x] Documentation check-commands reproduced verbatim
- [ ] Sparring review at this exact head
- [ ] Principal acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns