### PR TITLE
Release 1.1.0 — first-class OpenAI-compatible (ollama) provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ Repository: [`zeroemployeeorg/sovereign-agent`](https://github.com/zeroemployeeo
 
 ## Unreleased
 
+## [1.1.0] — 2026-09-01
+
+Adds a first-class **OpenAI-compatible provider** and makes the local-model
+configuration documentation true.
+
+- **New `ollama` provider.** A first-class provider that talks to any OpenAI
+  `/v1/chat/completions` endpoint — a local Ollama by default, or vLLM, LM
+  Studio, or OpenAI. Unlike the CLI-agent providers it speaks HTTP, but obeys
+  the same contract: the model only *proposes* an `ActorReport`, which the
+  organization re-validates against the ledger before anything commits. An
+  unreachable or malformed endpoint yields an honest `failed` report, never a
+  fabricated success. Bind an actor to it with `provider = "ollama"`.
+- **Real, documented configuration.** The provider reads exactly
+  `SOVEREIGN_AGENT_LLM_BASE_URL` (default `http://localhost:11434/v1`),
+  `SOVEREIGN_AGENT_LLM_MODEL` (default `qwen3`, with
+  `SOVEREIGN_AGENT_LLM_EXECUTOR_MODEL` accepted as an alias), and
+  `SOVEREIGN_AGENT_LLM_API_KEY` (optional; blank for local Ollama). These
+  variables were previously documented but implemented by no source file; the
+  documentation in `configuration.md`, `deployment.md`, `troubleshooting.md`,
+  and `.env.example` now matches the code, and the stale v0.x
+  `_PLANNER_MODEL` / `_API_KEY_ENV` variables are gone.
+- **Source-line budget raised 6,250 → 6,400** to fit the new provider
+  (~154 lines), sanctioned on the same precedent as the 6,000 → 6,250 raise.
+
 ## [1.0.0] — 2026-08-31
 
 First stable release. The package is an executable textbook: Chapters 0-12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sovereign-agent"
-version = "1.0.0"
+version = "1.1.0"
 description = "An executable textbook for learning Zero-Employee Organizations"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -10,7 +10,7 @@ from sovereign_agent.ids import new_id
 from sovereign_agent.models import Actor, Outcome, StatementOfWork
 from sovereign_agent.organization import Organization
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = [
     "Actor",

--- a/tests/test_clean_import.py
+++ b/tests/test_clean_import.py
@@ -23,4 +23,4 @@ print(json.dumps({'before': before, 'after': after, 'version': sovereign_agent._
         text=True,
     )
     observed = json.loads(result.stdout)
-    assert observed == {"before": [], "after": [], "version": "1.0.0"}
+    assert observed == {"before": [], "after": [], "version": "1.1.0"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,4 +33,4 @@ def test_module_entry_point_reports_version() -> None:
         capture_output=True,
         text=True,
     )
-    assert result.stdout.strip() == "sovereign-agent 1.0.0"
+    assert result.stdout.strip() == "sovereign-agent 1.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "sovereign-agent"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
**For Master review/merge.** Version bump + changelog for the **1.1.0** release. The feature itself (the `ollama` provider) already merged in PR #55 at 838988c; this is the release-prep commit.

**Please merge with a merge commit (NOT squash)** so the release commit stays a clean parent for the `v1.1.0` tag. After merge I'll tag `v1.1.0` on the merge commit (triggering the PyPI publish workflow) and cut the GitHub release.

## Contents (six files, release-prep only)
- `pyproject.toml`, `src/sovereign_agent/__init__.py`, `uv.lock`: `1.0.0` → `1.1.0`
- `tests/test_clean_import.py`, `tests/test_cli.py`: version-string assertions → `1.1.0`
- `CHANGELOG.md`: new `## [1.1.0] — 2026-09-01` entry (ollama provider; docs corrected; budget raise recorded)

## Verification
- **385 passed**, 10 deselected; `verify_source_budget.py` 28/40 · 6372/6400 · 7/30.
- **1.1.0 wheel built and clean-installed** into a fresh Python 3.14 venv with `zeocore==0.5.0`: `sovereign-agent --version` → `1.1.0`, `doctor` lists `ollama available qwen3 @ http://localhost:11434/v1`.

This is a minor, additive release: the four existing providers and all prior behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)