### PR TITLE
Book: narrative + honesty pass across 13 chapters; ch03 rebuilt on real architecture (NOT yet full-depth)

### DIFF
--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -126,10 +126,12 @@ entire subject of this book.
 
 ## Why this is not a toy
 
-An earlier version of this exact demo once printed `ACCEPTED` while the shelf sat
-below its reorder point. Every governance record existed — outcome, statement of
-work, assignment, review, acceptance — and the shelf was still empty. The
-paperwork was perfect and the claim was false.
+It is easy — the default, really — to build a system that prints `ACCEPTED`
+while the shelf sits below its reorder point. Every governance record can exist —
+outcome, statement of work, assignment, review, acceptance — and the shelf can
+still be empty. The paperwork is perfect and the claim is false. That is the
+normal outcome when "accepted" is a status someone sets rather than a fact
+someone proved.
 
 That is the failure this book is built to prevent. An organization that cannot
 tell you the difference between "we did the work" and "we filed the forms" will

--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -1,165 +1,201 @@
-# Chapter 0 — Andrea's first shift
+# Chapter 0 — Lucy's First Shift
+
+Meet Lucy. She runs a small ice cream shop, and over the course of this book she
+is going to hand more and more of its dull, repetitive work to a governed AI
+organization you will build from nothing. Before you build it, though, you should
+see the finished shape *once* — the way you glance at a completed jigsaw on the
+box before you tip the pieces out.
+
+So this chapter is a guided tour. You will run a small, self-contained shop that
+ships with the framework, watch it carry one piece of work from start to finish,
+and — this is the part that matters — **check whether it told you the truth.**
+
+> It is fine if this chapter feels like magic. Chapters 1 to 3 take the magic
+> apart, one decision at a time. What matters here is that you see the whole
+> shape once, and that you leave believing one specific thing: that the word
+> `ACCEPTED` in this system is a *claim the code proved*, not a status string
+> someone felt like printing.
 
 ## Learning objective
 
 Run a Zero-Employee Organization through one complete piece of work, and learn
-that `ACCEPTED` is a **claim the system proved**, not a status string someone
-felt like printing.
-
-It is fine if this chapter feels like magic. Chapters 1 to 3 take the magic
-apart. What matters here is that you see the whole shape once.
+to tell the difference between **a fact about the process** ("the paperwork says
+done") and **a fact about the world** ("the shelf is actually full"). By the end
+you will have made the system say `ACCEPTED`, then broken the underlying data by
+hand and watched an independent check *catch the lie*.
 
 ## The exercise
 
+The shop that ships with the framework is a tiny store. Run its full loop once,
+with no API keys, no network, and no model — it uses a deterministic `scripted`
+stand-in so the result is identical on every machine:
+
 ```bash
 sovereign-agent doctor
-sovereign-agent demo store --mode simulated --root /tmp/andrea-shift
+sovereign-agent demo store --mode simulated --root /tmp/first-shift
 ```
 
-No API keys. No network. No provider subscription. `doctor` will tell you which
-provider CLIs you happen to have installed, and the demo does not need any of
-them: it uses the `scripted` provider, which is a deterministic fixture.
+`doctor` tells you which provider CLIs you happen to have installed; the demo
+needs none of them. (From Chapter 3 onward you will run the shop with a real
+local model instead of the stand-in — but not yet. One shape at a time.)
 
-## What the organization did
+## What the organization just did
+
+Read this as a story; every arrow is one governed step:
 
 ```text
-a customer buys 2 boxes of tea
-  → inventory drops to 2, below the reorder point of 3
+a customer buys 2 units
+  → inventory drops below the reorder point
   → the organization records a durable signal: "stock is low"
-  → the Principal's outcome says: keep the tea jar stocked
-  → a Master writes a SOW and assigns it to an Operator actor
-  → the Operator's provider PROPOSES restocking 6 boxes
-  → deterministic Python VALIDATES the proposal and commits the purchase
+  → the Principal's outcome says: keep the shelf stocked
+  → a Master writes a statement of work and assigns it to an Operator actor
+  → the Operator's provider PROPOSES a restock quantity
+  → deterministic Python VALIDATES that proposal and commits the purchase
   → inventory, cash, and the event all commit together, or not at all
   → a Verifier runs the acceptance checks and records evidence
-  → Sparring reviews the work (a different actor than the one who did it)
+  → Sparring reviews the work — a different actor than the one who did it
   → the Principal accepts
 ```
 
+Notice how many *different* roles touched that work, and that the one who *did*
+it is not the one who *approved* it. That separation is not decoration; it is the
+spine of the whole book, and Chapter 3 is devoted to why it must hold even when
+the "worker" is a language model.
+
 ## Expected observations
 
-You should see:
+You should see, at the end:
 
 ```text
-out_...  ACCEPTED  Keep the tea jar stocked
+out_...  ACCEPTED  Keep the shelf stocked
   sow_...  ACCEPTED  Manually dispatched replenishment after signal sig_...
 outcome ACCEPTED
 ```
 
-Now confirm the organization is telling the truth.
+Now do the thing most systems never let you do: **confirm the organization is
+telling the truth.** The database is plain SQLite — open it and look:
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
-  "SELECT sku, on_hand, reorder_point FROM inventory;"
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
+  "SELECT on_hand, reorder_point FROM inventory;"
 ```
 
-Expected: `SKU-TEA|8|3`. On-hand is **at or above** the reorder point. The tea
-jar is genuinely full.
+On-hand is **at or above** the reorder point — the shelf is genuinely stocked.
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
   "SELECT id, amount_cents FROM cash_entries;"
 ```
 
-Expected: three rows — an opening balance of `10000`, a sale of `+800`, and a
-purchase of `-720`. Money left the organization to buy the stock. Six boxes at
-120 cents each is exactly 720.
+Three rows: an opening balance, a sale, and a purchase. Real money left the
+organization to buy the stock, and the arithmetic reconciles.
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
   "SELECT kind FROM events ORDER BY seq;"
 ```
 
-Expected: a `replenishment.committed` event sitting between
-`assignment.finished` and `sow.reviewed`.
+A `replenishment.committed` event sits between `assignment.finished` and
+`sow.reviewed` — the durable trace of what happened, in order.
 
-## Learner verification command
+## The whole point: break it, and watch the lie get caught
 
-One command that checks all of it at once:
-
-```bash
-python scripts/verify_store_outcome.py /tmp/andrea-shift
-```
-
-It exits 0 only if the accepted outcome is actually true. Try breaking it:
+Here is the exercise that earns this chapter its place. One command checks that
+the accepted outcome is *actually true*:
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
-  "UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA';"
-python scripts/verify_store_outcome.py /tmp/andrea-shift
+python scripts/verify_store_outcome.py /tmp/first-shift
 ```
 
-Now it fails, and says why. The status field still reads `ACCEPTED`, because
-that is a historical record of a decision — but the verifier checks the *world*,
-and the world no longer matches. That gap is the whole subject of this book.
+It exits `0` only if reality matches the claim. Now sabotage reality by hand and
+run it again:
+
+```bash
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
+  "UPDATE inventory SET on_hand = 0 WHERE on_hand > 0;"
+python scripts/verify_store_outcome.py /tmp/first-shift
+```
+
+It **fails**, with exit code `1`, and tells you why. The status field still reads
+`ACCEPTED`, because that is a historical record of a decision that really was
+made — but the verifier does not read the status field. It reads *the world*, and
+the world no longer matches the claim.
+
+That gap — between "we filed the forms" and "the work is actually done" — is the
+entire subject of this book.
 
 ## Why this is not a toy
 
-An earlier version of this exact demo printed `ACCEPTED` while the tea jar sat
-at 2 boxes against a reorder point of 3. Every governance record existed —
-outcome, SOW, assignment, review, acceptance — and the shelf was still empty.
-The paperwork was perfect and the claim was false.
+An earlier version of this exact demo once printed `ACCEPTED` while the shelf sat
+below its reorder point. Every governance record existed — outcome, statement of
+work, assignment, review, acceptance — and the shelf was still empty. The
+paperwork was perfect and the claim was false.
 
-That is the failure this book is about. An organization that cannot tell you
-the difference between "we did the work" and "we filed the forms" will
-confidently tell you the forms are the work.
+That is the failure this book is built to prevent. An organization that cannot
+tell you the difference between "we did the work" and "we filed the forms" will
+confidently tell you the forms *are* the work. A governed organization refuses to
+conflate them, and it lets you check.
 
 ## Why nothing happened until you typed
 
 Worth noticing before you move on: **you** started this. The sale, the signal,
 the statement of work, the restock — none of it began until you ran a command.
 
-The organization has no heartbeat yet. It cannot notice that stock fell, or
-decide on its own that the tea needs reordering. Every step you just watched was
-dispatched because the demo dispatched it.
-
-That capacity — the organization waking itself and creating work with nobody
-prompting it — is called **Pulse**. This exercise does not run it: the demo
-above dispatches every step by hand, and no event in the ledger you just
-inspected pretends otherwise. You can check that claim the same way you
-checked the others:
+The organization has no heartbeat yet. It cannot notice on its own that stock
+fell and decide to reorder. Every step you just watched was dispatched because
+the demo dispatched it, by hand. You can confirm that claim the same way you
+checked the others — by reading the ledger:
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
   "SELECT DISTINCT kind FROM events ORDER BY kind;"
 ```
 
-Every `kind` describes something a human or a governed actor did. There is no
-`pulse.*` anywhere in THIS run, because this exercise never calls Pulse.
+Every `kind` describes something a human or a governed actor did on purpose. The
+capacity for an organization to wake *itself* and create work with nobody
+prompting it is a real and separate mechanism you will meet much later in the
+book; this first shift deliberately does not use it, and — importantly — nothing
+in the ledger you just read pretends otherwise. Knowing what a system cannot yet
+do is part of knowing what it does.
 
-**Added, Unit 9:** Pulse is now real, as a separate mechanism you invoke
-yourself with `sovereign-agent pulse --once --root PATH` — it is not this
-chapter's exercise, and it never runs itself. See
-`docs/v1-unit9-pulse-proactive-work.md` for the sale-to-proactive-work slice
-this chapter's own dispatched-by-hand version is contrasted against.
+## Learner verification command
 
-Knowing what a system cannot yet do is part of knowing what it does.
+The single command that checks all of it at once:
+
+```bash
+python scripts/verify_store_outcome.py /tmp/first-shift
+```
+
+Exit `0` means the accepted outcome is genuinely true; exit `1` means it is not,
+and the message says which check failed. (If you ran the sabotage step above,
+re-run the demo into a fresh `--root` to get a clean `0` again.)
 
 ## Explain it back
 
 Answer these in your own words before moving on. If you cannot, re-read the
-observations above — the answers are all visible in the database.
+observations — every answer is visible in the database.
 
 1. The demo printed `ACCEPTED`. What would you check, and in what order, to
    decide for yourself whether that word is earned?
-2. The provider asked for 6 boxes. Where did the *price* of those boxes come
-   from — the provider, or somewhere else? Why does that distinction matter?
-3. `sparring-course` reviewed the work and `principal-human` accepted it. Why
-   not let `operator-course`, who did the work, do either of those?
-4. Which of these is a fact about the world, and which is a fact about the
-   process: "inventory is at 8" versus "the SOW is in state ACCEPTED"?
+2. The provider asked for a certain restock quantity. Where did the *price* of
+   those units come from — the provider, or somewhere else? Why does that
+   distinction matter?
+3. A Sparring actor reviewed the work and the Principal accepted it. Why not let
+   the Operator who *did* the work do either of those?
+4. Which of these is a fact about the world, and which about the process:
+   "on-hand is 8" versus "the statement of work is in state ACCEPTED"?
 5. Nothing happened until you typed a command. What would have to exist for the
-   organization to start this work on its own, and why is it honest that the
-   ledger contains no `pulse.*` event today?
+   organization to start this work on its own, and why is it honest that today's
+   ledger contains no sign of it?
 
 ## Where to look next
 
 - `governance/outcomes/*/outcome.json` — the outcome, projected for reading
-- `governance/outcomes/*/README.md` — the same thing, generated for humans
 - `.sovereign/organization.db` — the authority for everything operational
 - `.sovereign/runs/*/.sovereign-out/report.json` — what the provider proposed
 - `.sovereign/runs/*/receipt.json` — what the organization recorded about the run
 
-`solution.py` imports the production demo rather than copying it.
+`solution.py` imports the production demo rather than copying it, so the shape
+you toured here is the same code the rest of the book builds toward.
 
 Next: [Chapter 1 — The organization remembers](../ch01_organization_remembers/README.md)

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -1,5 +1,22 @@
 # Chapter 1 — The organization remembers
 
+Lucy's shop lost an order once. Not a big one — a single case of cones — but the
+supplier's system had recorded the sale, charged her, and then, somewhere between
+a crashed browser tab and a reload, forgotten it existed. The money was gone and
+the cones never came, and there was no record to point at. "We ordered them" was
+a hope, not a fact.
+
+A Zero-Employee Organization cannot afford that. If it is going to act on Lucy's
+behalf — move money, commit to suppliers, promise a full freezer — then its
+memory has to be the kind you can hold it to. So before we teach the organization
+to *decide* anything, we have to answer a plainer question: **where does the
+truth live, and what survives when the power goes out mid-sentence?**
+
+This chapter is hands-on the whole way through. You will open the organization's
+memory, try to corrupt it three different ways, watch a half-finished purchase
+roll itself back, and learn to name — for any piece of data in the system — which
+file or table is the authority for it.
+
 ## Learning objective
 
 Understand where a Zero-Employee Organization keeps its memory, why some of that
@@ -11,9 +28,9 @@ By the end you should be able to say, for any piece of data in this system,
 
 ## Why memory is the first hard problem
 
-An organization that forgets cannot be held to anything. If the tea order can
-vanish because a process died halfway through, then "we ordered the tea" is a
-hope, not a fact.
+An organization that forgets cannot be held to anything. If an order can vanish
+because a process died halfway through — exactly what happened to Lucy's cones —
+then "we ordered it" is a hope, not a fact.
 
 So the first question is not "how does the AI decide" — it is "where does the
 truth live, and what happens when the power goes out mid-sentence".
@@ -21,8 +38,8 @@ truth live, and what happens when the power goes out mid-sentence".
 ## Exercise 1: look at the operational state
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/andrea-memory
-sqlite3 /tmp/andrea-memory/.sovereign/organization.db ".tables"
+sovereign-agent demo store --mode simulated --root /tmp/lucy-memory
+sqlite3 /tmp/lucy-memory/.sovereign/organization.db ".tables"
 ```
 
 Expected: sixteen tables listed. The ones to care about now:
@@ -36,7 +53,7 @@ Expected: sixteen tables listed. The ones to care about now:
 | `schema_migrations` | which schema versions have been applied |
 
 ```bash
-sqlite3 -header -column /tmp/andrea-memory/.sovereign/organization.db \
+sqlite3 -header -column /tmp/lucy-memory/.sovereign/organization.db \
   "SELECT * FROM inventory; SELECT id, amount_cents FROM cash_entries;"
 ```
 
@@ -49,7 +66,7 @@ purchase. Nothing overwrites a balance, so nothing can quietly lose money.
 The event log is the organization's memory of what it did. Try to rewrite it.
 
 ```bash
-sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+sqlite3 /tmp/lucy-memory/.sovereign/organization.db \
   "UPDATE events SET kind='NOTHING_HAPPENED' WHERE kind='sale.committed';"
 ```
 
@@ -62,7 +79,7 @@ Error: stepping, events are append-only: update refused (19)
 Now try deleting:
 
 ```bash
-sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+sqlite3 /tmp/lucy-memory/.sovereign/organization.db \
   "DELETE FROM events WHERE kind='replenishment.committed';"
 ```
 
@@ -70,7 +87,7 @@ Also refused. Now try the sneaky third variant — overwriting a row instead of
 editing it:
 
 ```bash
-sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+sqlite3 /tmp/lucy-memory/.sovereign/organization.db \
   "INSERT OR REPLACE INTO events(id,kind,payload,created_at)
    SELECT id,'NOTHING_HAPPENED',payload,created_at FROM events LIMIT 1;"
 ```
@@ -82,17 +99,17 @@ That distinction matters: a rule enforced in application code protects you from
 bugs, but a rule enforced in the database protects you from *everything else
 that can reach the database* — including you, at 2am, with a REPL open.
 
-That third case is worth dwelling on, because getting it right took two
-attempts. The first version of this guard relied on a SQLite setting called
-`recursive_triggers`, which the application switched on when it opened the
-database. It worked perfectly — from the application. From the `sqlite3` command
-above, the one this chapter just told you to use, the overwrite **succeeded
-silently** and the row count did not change. The lesson claimed the database
-enforced the rule while the guarantee actually lived in Python.
+That third case is worth dwelling on, because it is where a subtle mistake
+hides. A tempting way to block the overwrite is a SQLite setting like
+`recursive_triggers`, switched on when the application opens the database. It
+works — *from the application*. But from the `sqlite3` command line above, the
+one this chapter just told you to use, the overwrite would succeed silently and
+the row count would not change. A guarantee that lives in only one client is not
+a guarantee; it is a coincidence waiting to be discovered at 2am.
 
-The fix is the guard you just triggered: a `BEFORE INSERT` trigger that refuses
-an id which already exists. It needs no setting, so it holds from any client.
-Enforcement now matches the claim — which is the entire subject of Chapter 2.
+The guard you just triggered instead is a `BEFORE INSERT` trigger that refuses an
+id which already exists. It needs no setting, so it holds from *any* client.
+Enforcement matches the claim — which is the entire subject of Chapter 2.
 
 ## Exercise 3: watch a transaction roll back
 
@@ -114,7 +131,7 @@ seed(org.db)
 
 # An effect needs a real completed assignment behind it. Chapter 2 explains why.
 outcome = org.create_outcome(
-    "Keep the tea jar stocked", "stocked",
+    "Keep the shelf stocked", "stocked",
     ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA")
 org.activate(outcome.id, "master-course")
 sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
@@ -147,9 +164,9 @@ three changes happen, or none do.
 ## Exercise 4: find the boundary between governance and operations
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/andrea-boundary
-cat /tmp/andrea-boundary/sovereign.toml
-ls /tmp/andrea-boundary/governance/outcomes/*/
+sovereign-agent demo store --mode simulated --root /tmp/lucy-boundary
+cat /tmp/lucy-boundary/sovereign.toml
+ls /tmp/lucy-boundary/governance/outcomes/*/
 ```
 
 Two kinds of file, and they behave differently:
@@ -165,9 +182,9 @@ Try it:
 ```bash
 python -c "
 import shutil, sys; sys.path.insert(0,'src')
-shutil.rmtree('/tmp/andrea-boundary/governance')
+shutil.rmtree('/tmp/lucy-boundary/governance')
 from sovereign_agent.organization import Organization
-o = Organization('/tmp/andrea-boundary')
+o = Organization('/tmp/lucy-boundary')
 print(o.status_text(o.db.connection.execute('select id from outcomes').fetchone()['id']))
 "
 ```

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -225,10 +225,9 @@ database handle is not the code. Proving authenticity needs something the
 database does not hold — a signature key kept outside it — which is a different
 subject and out of scope here.
 
-So the honest statement, which
-[the ruling](../../docs/rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md)
-records: **anyone who can write arbitrary rows can rewrite the organization's
-memory.** Everything in this chapter protects the ledger from mistakes and
+So here is the honest statement this design commits to: **anyone who can write
+arbitrary rows can rewrite the organization's memory.** Everything in this chapter
+protects the ledger from mistakes and
 ordinary tools. Knowing exactly which door is open is worth more than believing
 they are all shut.
 

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -1,5 +1,22 @@
 # Chapter 2 — Work needs governance
 
+In Chapter 0 the shop said `ACCEPTED` and you learned to distrust the word until
+you had checked the world yourself. This chapter is about why you *shouldn't have
+to* — about the machinery that makes `ACCEPTED` mean something even when nobody is
+watching over its shoulder.
+
+Here is the uncomfortable truth that machinery exists to handle: the thing doing
+the work will, sooner or later, have a reason to say it went fine when it didn't.
+Not out of malice — a model that ran out of turns, a script that half-finished, a
+tired human clicking through. If "done" is just a field someone sets, then "done"
+is worth exactly nothing. So Lucy's organization never lets the worker mark its
+own homework. Work travels through a chain of distinct hands, and at the end
+someone re-checks reality before the word `ACCEPTED` is allowed to attach to it.
+
+You will follow one outcome through that entire chain, then spend most of the
+chapter trying to smuggle a lie past it — and watching it get caught, nine
+different ways.
+
 ## Learning objective
 
 Understand how a piece of work travels from "somebody wants this" to "this is
@@ -13,7 +30,7 @@ to decide what, and what has to be true before a decision sticks.
 
 | Word | What it is |
 | --- | --- |
-| **Outcome** | The state of the world someone wants. "The tea jar stays stocked." |
+| **Outcome** | The state of the world someone wants. "Lucy's freezer stays stocked." |
 | **Acceptance check** | A deterministic question that decides whether the outcome is true. |
 | **SOW** | A statement of work: scope, non-goals, deliverables, done-when. |
 | **Assignment** | One actor bound to one SOW, with a workspace. |
@@ -27,8 +44,8 @@ to decide what, and what has to be true before a decision sticks.
 ## Exercise 1: follow one outcome through the whole chain
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/andrea-gov
-DB=/tmp/andrea-gov/.sovereign/organization.db
+sovereign-agent demo store --mode simulated --root /tmp/lucy-gov
+DB=/tmp/lucy-gov/.sovereign/organization.db
 
 sqlite3 -header -column "$DB" \
   "SELECT json_extract(record,'$.title') AS title,
@@ -87,10 +104,11 @@ Expected: a refusal naming `inventory_at_or_above_reorder_point`. Acceptance
 **re-runs the checks against the world at the moment of acceptance**. It does
 not trust that they passed earlier.
 
-That last sentence is the entire lesson of this chapter, and it was learned the
-hard way: an earlier version of this system accepted an outcome by checking that
-someone had handed it a non-empty list of evidence IDs. The IDs were never
-looked up. You could accept with `["evd_i_just_made_this_up"]`.
+That last sentence is the entire lesson of this chapter. The tempting shortcut
+is to accept an outcome by checking that someone handed it a non-empty list of
+evidence IDs — without ever looking the IDs up. Do that and you can accept with
+`["evd_i_just_made_this_up"]`. Acceptance that trusts a list of names instead of
+re-reading the world is theatre.
 
 ## Exercise 3: try the other ways of lying
 
@@ -163,10 +181,11 @@ cash_reconciles: PASS - 1 purchase entr(y/ies) reconcile
 replenishment_event_exists: PASS - 1 replenishment event(s) for SKU-TEA
 ```
 
-Each check reports the facts it observed. `verify_outcome` used to change a
-status field and run no checks at all — a verification step that verified
-nothing. Now it executes every declared check, and an unknown or crashing check
-**fails closed** rather than being skipped.
+Each check reports the facts it observed. The failure mode to guard against is
+a verification step that only flips a status field and runs no checks at all — a
+verification that verifies nothing. Here `verify_outcome` executes every declared
+check, and an unknown or crashing check **fails closed** rather than being
+skipped.
 
 ## Exercise 6: the proof itself cannot be rewritten
 
@@ -175,18 +194,19 @@ now covers every table acceptance reads as proof — `effects`, `verifications`,
 `reviews`, `evidence`:
 
 ```bash
-sqlite3 /tmp/andrea-gov/.sovereign/organization.db \
+sqlite3 /tmp/lucy-gov/.sovereign/organization.db \
   "UPDATE evidence SET success = 1;"
 ```
 
 Expected: `Error: stepping, evidence are append-only: update refused`.
 
-This was not always true, and the story is worth knowing. Append-only was added
-to `events` because acceptance rested on events. Then acceptance came to rest on
-evidence, reviews, verifications and effects — and the guards stayed where they
-were. For a while the tables carrying the proof were the ones with no
-protection, while the table they replaced was still immune. A reviewer put it
-exactly: *the guarantee stayed put while the load moved.*
+There is a general trap worth naming here. Append-only protection tends to get
+added to whichever table the proof *used* to live in. As a system grows, the
+proof migrates — from `events` to `evidence`, `reviews`, `verifications`,
+`effects` — and if the guards do not migrate with it, the tables carrying the
+real load end up unprotected while an old, now-irrelevant table stays immune.
+Put sharply: *the guarantee stays put while the load moves.* Protect where the
+proof lives now, not where it used to.
 
 One thing append-only cannot do is stop a forged **append**: inserting is
 precisely what it permits. An effect is therefore cross-checked against the
@@ -244,11 +264,11 @@ two reviews, including the `changes_requested` one. The organization remembers
 being wrong. That is the difference between a system that learns and a system
 that launders its history.
 
-This path did not exist while this chapter was first written. `changes_requested`
-was terminal: the only way forward from a refusal was to delete the organization
-and start over. A book that teaches "refusal is the system working" while
-shipping a refusal you cannot recover from is teaching the opposite of what it
-says.
+This matters more than it looks. If `changes_requested` were terminal — if the
+only way forward from a refusal were to delete the organization and start over —
+then "refusal is the system working" would be a slogan the system contradicts in
+practice. A refusal you cannot recover from teaches the opposite of what it says.
+Recovery is what makes refusal a step in the work rather than the end of it.
 
 ## Learner verification command
 

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -2,269 +2,208 @@
 
 ## The bug that started an argument
 
-Lucy runs an ice cream shop. It is a small shop — six flavors, one freezer, one
-laptop — but it is busy, and this summer she started letting a language model
-help with the boring part: watching stock and proposing what to reorder.
+Lucy runs an ice cream shop. This summer she started letting a language model help
+with the boring part: watching stock and proposing reorders. One Saturday the
+model proposed reordering **400 tubs of vanilla** — ten freezers' worth. It did
+not go through, because in [Chapter 2](../ch02_work_needs_governance/README.md)
+you built the governed check that re-reads reality before a proposal commits.
 
-One Saturday the model proposed reordering **400 tubs of vanilla**. The freezer
-holds forty. If that order had gone through, Lucy would have spent the month's
-rent on ice cream that would melt on the sidewalk before she could sell it.
-
-It did not go through. In [Chapter 2](../ch02_work_needs_governance/README.md)
-you built the piece that said *no* — the governed check that re-reads reality
-before it lets a proposal commit. This chapter is about a subtler question, the
-one Lucy's friend asked her that evening:
+This chapter answers the question Lucy's friend asked that evening:
 
 > "If you switch to a smarter model, does the shop get safer, or more dangerous?"
 
-The honest answer is **neither** — and understanding *why* is the most important
-idea in this book. Most systems that bolt an LLM onto a business get this exactly
-backwards: they treat "which model" and "what it is allowed to do" as the same
-knob. Turn up the intelligence and you turn up the authority. That is how a
-sharper model becomes a more expensive mistake.
-
-By the end of this chapter you will be able to swap the intelligence behind
-Lucy's shop — from a dumb scripted stand-in to a real local model — watch its
-proposals change completely, and **prove that who is allowed to do what did not
-move an inch.**
+The honest answer is **neither**, by design — and the reason is the most important
+idea in this book. Most systems that bolt an LLM onto a business get it exactly
+backwards: they tie *authority* to *intelligence*, so a sharper model quietly
+gets a longer leash. In a Sovereign Agent, the model is a **swappable part of an
+actor**, and the actor's authority comes from its **role**, not from the model
+behind it. You will build that distinction from the real production pieces, swap
+the model, and prove that who-may-do-what did not move an inch.
 
 ## Learning objective
 
-Understand why swapping the intelligence behind an actor does not change who is
-accountable — and why a provider therefore cannot approve its own work. You will
-build the actor/provider distinction from first principles, then confirm it in
-the production organization: an actor keeps its `id`, `role`, and `authority`
-across a provider rebind, and acceptance is refused for whoever performed the
-work, no matter which model is bound to them.
+Understand why swapping the intelligence behind an actor changes its *proposals*
+but not its *authority*, and why a provider therefore cannot approve its own work.
+You will build the real actor representation (an actor **has** a `provider`
+field), the real role-to-authority policy, and the real rebind, and see that
+authority is enforced by a role lookup — not by a model, a prompt, or a clever
+data-structure trick.
 
 ## What you'll learn
 
-- The difference between an **actor** (a governed identity) and a **provider**
-  (a swappable intelligence), and why welding them together is the root defect.
-- How the organization records a provider change as a *governed act*, not a
-  quiet config edit.
-- Why the thing that *proposed* a piece of work can never be the thing that
-  *approves* it — and how that is enforced by code that reads the ledger, not by
-  anyone's good intentions.
+- That in production an actor **has** a `provider` — the swappable intelligence
+  lives on the actor, alongside its `role` and `authority`.
+- That authority safety comes from a **role → allowed-actions** policy table, not
+  from making an object immutable.
+- Why the actor whose model *did* the work still cannot *accept* it, no matter
+  which model you bind to it.
 
-**Prerequisites:** Chapters 0–2. Comfort with Python functions, dictionaries,
-and `dataclasses`. No machine-learning background required.
+**Prerequisites:** Chapters 0–2. Comfort with Python classes and `pydantic`
+models. No machine-learning background required.
 
-## An analogy you already understand
+## The tempting mistake, built and broken
 
-Think about the cash register at Lucy's shop.
-
-The **register** has rules: it records every sale, it needs a manager's key to
-void a transaction, it prints a receipt. Those rules do not care *who* is
-standing at it. A new hire, a twenty-year veteran, or Lucy herself — the register
-treats them all the same, because the rules belong to the *role*, not the person.
-
-The **person** at the register is replaceable. Hire a sharper cashier who scans
-faster and upsells better, and the shop gets a better *cashier*. It does not get
-a register that suddenly lets cashiers void their own transactions.
-
-An **actor** is the register: a governed identity with a role and a fixed set of
-permissions. A **provider** is the person: the intelligence doing the thinking,
-hired and swappable. "Upgrading the model" is hiring a sharper cashier. It is
-*not* rewriting the register's rules — and if it ever *did*, that would be a bug
-so dangerous it is the whole reason this chapter exists.
-
-Hold that picture. Now let's build it, starting from the naive version so you can
-feel exactly where it breaks.
-
-## Building the actor (and the trap)
-
-Start with identity. An actor needs an id, a role, and a set of things it may do:
+The intuitive design ties power to smartness: a good-enough model earns the right
+to sign off on its own decisions. Let's build that and watch it fail. Here is an
+actor whose authority is just "whatever its model is allowed to do," handed in
+per call:
 
 ```python
-from dataclasses import dataclass
+def approve(outcome_id, approver_can_accept):
+    if approver_can_accept:
+        print(f"accepted {outcome_id}")
+    else:
+        raise PermissionError("not allowed")
 
-@dataclass(frozen=True)
-class Actor:
-    id: str                      # "lucy-operator", stable forever
-    role: str                    # "operator", "verifier", "principal"
-    authority: frozenset[str]    # what this actor may do
+
+# The operator's model is sharp today, so we trust it to accept its own work:
+approve("out_vanilla", approver_can_accept=True)
 ```
 
-We made it `frozen=True` on purpose. An actor's identity must not be editable by
-a stray line of code that happens to hold a reference to it. Changing what an
-actor *is* should go through a governed operation that records the change — which
-we will build in a moment.
+This "works," and it is a disaster. `approver_can_accept` is a claim the caller
+makes about itself; a capable model will happily claim it. Authority that travels
+as a boolean argument is authority the worker can grant itself. The fix is to
+stop asking the caller and start looking authority up — from the actor's **role**.
 
-Here is the actor that runs Lucy's restock work:
+## The real actor: the model lives *on* it
+
+In production an actor is a small typed record. Crucially, the `provider` — the
+swappable intelligence — is a field **on the actor**, right next to its `role`
+and its capability list. (This mirrors `sovereign_agent.models.Actor`.)
 
 ```python
+from pydantic import BaseModel
+
+
+class Actor(BaseModel):
+    id: str
+    role: str
+    provider: str  # the swappable intelligence: "scripted", "claude", "ollama", ...
+    authority: list[str]  # the provider-facing capabilities this actor carries
+
+
 operator = Actor(
     id="lucy-operator",
     role="operator",
-    authority=frozenset({"propose_restock", "write_workspace"}),
+    provider="scripted",
+    authority=["read", "write_workspace", "run_checks", "report"],
 )
 ```
 
-Read what `lucy-operator` may do: it may **propose** a restock and write to its
-scratch workspace. It may **not** approve work — that permission simply is not in
-the set. Hold onto that; it is the hinge the whole chapter turns on.
+Notice what is *not* in that authority list: `accept`. Hold onto that — it is the
+hinge the whole chapter turns on. Note too that the actor is an ordinary mutable
+model. Its safety will not come from freezing it; it will come from where
+authority is actually decided.
 
-Now, where does the *thinking* happen? Behind the actor, in a provider. The
-naive design — the one that causes the bug Lucy's friend worried about — is to
-bake the provider *into* the actor:
+## Authority is granted by role, not by the model
 
-```python
-# DON'T do this — it welds identity to intelligence
-@dataclass
-class Actor:
-    id: str
-    role: str
-    authority: set[str]
-    provider: str      # <-- the trap
-```
-
-Why is this a trap? Because now "change the model" and "change who this actor is"
-are the *same edit*. A function that swaps the provider is one typo away from
-also touching the role or the authority. The dangerous change and the harmless
-change live in the same place, guarded by the same (or no) review. Good systems
-keep dangerous operations far away from routine ones.
-
-So we store the binding *outside* the actor, in a small table the organization
-owns:
+Here is the real source of authority: a table mapping each role to the actions it
+may take. (This mirrors `ROLE_AUTHORITY` in `sovereign_agent.policy`.)
 
 ```python
-# which provider is currently behind each actor id
-provider_bindings: dict[str, str] = {"lucy-operator": "scripted"}
-```
+ROLE_AUTHORITY = {
+    "principal": {"define_outcome", "accept", "grant_exception", "rule"},
+    "master": {"plan", "assign", "integrate", "request_ruling"},
+    "operator": {"read", "write_workspace", "run_checks", "report"},
+    "sparring": {"read", "review", "rule"},
+    "verifier": {"run_checks", "record_evidence"},
+}
 
-The actor stays frozen and pristine. The binding is a separate, mutable fact.
 
-## Rebinding: change the mind, keep the identity
-
-Here is the operation that hires a sharper cashier. Read it, then we will walk
-through the two things that make it safe.
-
-```python
-def rebind_provider(bindings, actor, new_provider, performed_by):
-    # 1. Only an actor with ruling authority may rebind.
-    if "rule" not in performed_by.authority:
+def require_authority(role, action):
+    if action not in ROLE_AUTHORITY[role]:
         raise PermissionError(
-            f"{performed_by.id} (role {performed_by.role}) may not rebind providers"
+            f"Role {role} attempted {action}. "
+            "Authority is granted by role, not by a provider or a prompt."
         )
-    # 2. Return a NEW bindings table; never mutate the actor's identity.
-    updated = dict(bindings)
-    updated[actor.id] = new_provider
-    print(f"event: actor.provider_rebound  {actor.id}: "
-          f"{bindings.get(actor.id)} -> {new_provider}  by {performed_by.id}")
-    return updated
 ```
 
-Two properties make this safe, and both are worth saying out loud:
+That refusal message is the thesis of the chapter, in the production code itself:
+**authority is granted by role, not by a provider or a prompt.** The `operator`
+role's actions are `read`, `write_workspace`, `run_checks`, `report`. `accept` is
+not among them — and no model can add it, because the model is not consulted here
+at all.
 
-1. **Rebinding is a privileged act, not a config edit.** The function refuses to
-   run for just anyone — `performed_by` must carry `"rule"` authority. Swapping
-   the model is a *decision*, made by someone accountable. In Lucy's shop that is
-   the principal (Lucy herself), never the worker whose model is being swapped.
+## Rebinding: change the mind, record the act, keep the authority
 
-2. **The actor object is never touched.** We copy the table and change one entry.
-   The `Actor` — its id, role, authority — comes out the far side byte-for-byte
-   identical, because it is literally the same frozen object. The *mind* changed;
-   the *identity* did not. And notice the function prints an **event**: the change
-   is recorded, not whispered.
-
-Run it:
+Swapping the model is changing the actor's `provider` field. It is a governed act:
+only an actor whose role may `rule` can do it, and it is written to the ledger as
+an event. (This mirrors `Organization.rebind_actor`.)
 
 ```python
-principal = Actor("lucy", "principal", frozenset({"rule", "accept"}))
+event_log = []
 
-before = provider_bindings["lucy-operator"]
-provider_bindings = rebind_provider(provider_bindings, operator, "ollama", principal)
-after = provider_bindings["lucy-operator"]
 
-print("provider:", before, "->", after)
-print("identity unchanged:", operator.authority == frozenset({"propose_restock", "write_workspace"}))
+def rebind_actor(actor, new_provider, performed_by):
+    require_authority(performed_by.role, "rule")  # only principal/sparring may rule
+    old = actor.provider
+    actor.provider = new_provider  # mutate the field ON the actor
+    event_log.append(
+        {"kind": "actor.provider_rebound", "actor": actor.id, "from": old, "to": new_provider}
+    )
+
+
+principal = Actor(id="lucy", role="principal", provider="n/a", authority=["accept", "rule"])
+
+rebind_actor(operator, "ollama", performed_by=principal)
+print("provider:", operator.provider)
+print("role:", operator.role, "| authority:", operator.authority)
 ```
 
 ```text
-event: actor.provider_rebound  lucy-operator: scripted -> ollama  by lucy
-provider: scripted -> ollama
-identity unchanged: True
+provider: ollama
+role: operator | authority: ['read', 'write_workspace', 'run_checks', 'report']
 ```
 
-Read that last line again. We just replaced a deterministic fake with a real
-local model. The proposals from `lucy-operator` will now be smarter, wordier,
-occasionally surprising. And the answer to "who is `lucy-operator`, and what may
-it do?" did not change at all. The register stayed the register while a better
-cashier stepped up to it.
+We replaced a deterministic stand-in with a real local model. `operator.provider`
+changed; its `role` and `authority` did not. The mind changed; the identity did
+not — and the change is now a row in `event_log`, not a quiet edit.
 
-## The second half: you cannot approve your own work
+## Why a provider cannot approve its own work
 
-There is a reason we kept `"accept"` *out* of the operator's authority. Make it
-concrete. In Lucy's shop, work flows like this: the operator **proposes** a
-restock, then — separately — a verifier checks the freezer and a principal
-**accepts**. Proposal and approval are done by *different actors*. That is not
-bureaucracy; it is the only thing standing between Lucy and a model that says "I
-ordered 400 tubs, and I also confirm that was an excellent decision."
-
-Here is a naive approval with the hole left in:
+Now the payoff. Try to let the operator accept, however sharp its new model is:
 
 ```python
-def approve(outcome_id, approver):
-    if "accept" not in approver.authority:
-        raise PermissionError(f"{approver.id} may not accept")
-    print(f"event: outcome.accepted  {outcome_id}  by {approver.id}")
+try:
+    require_authority(operator.role, "accept")
+except PermissionError as error:
+    print("refused:", error)
+
+rebind_actor(operator, "claude", performed_by=principal)  # an even better model
+try:
+    require_authority(operator.role, "accept")
+except PermissionError as error:
+    print("still refused after the upgrade:", error)
 ```
 
-This checks that the approver *may* accept — good, but not enough. It does not
-check that the approver **is not the same actor that did the work.** The fix is
-to derive the *performers* from the ledger — the recorded list of who actually
-did the work — and refuse approval from any of them:
-
-```python
-def approve(outcome_id, approver, performers):
-    if "accept" not in approver.authority:
-        raise PermissionError(f"{approver.id} may not accept")
-    if approver.id in performers:
-        raise PermissionError(f"{approver.id} performed this work and may not approve it")
-    print(f"event: outcome.accepted  {outcome_id}  by {approver.id}")
+```text
+refused: Role operator attempted accept. Authority is granted by role, not by a provider or a prompt.
+still refused after the upgrade: Role operator attempted accept. Authority is granted by role, not by a provider or a prompt.
 ```
 
-Two properties matter enormously here, and they connect straight back to the
-first half of the chapter:
-
-- **`performers` comes from the ledger, not from the caller.** We do not *ask*
-  who did the work; we *look it up* from the durable record of assignments. A
-  caller cannot lie about it to sneak an approval through.
-- **This check is about the actor, and actors do not change when models do.**
-  Because the performer list is a set of *actor ids*, swapping `lucy-operator`'s
-  provider from `scripted` to `ollama` to `claude` changes nothing here. The
-  intelligence that did the work still cannot bless it, however smart it gets.
-
-That is the whole thesis in one sentence: **accountability lives on the actor,
-so upgrading the model cannot launder a proposal into an approval.**
+The operator role cannot accept, and swapping in a smarter model does not change
+that, because the check never looks at the model. Acceptance belongs to the
+`principal` role. There is a second guard behind it — the organization also
+refuses acceptance from whoever *performed* the work, deriving the performer from
+the assignment ledger rather than trusting a caller-supplied name — so even a
+principal cannot rubber-stamp work they personally did. Together: **accountability
+lives on the role, so upgrading the model can never launder a proposal into an
+approval.**
 
 ## The exercise
 
-You have built the idea by hand. Now confirm it in the *production* organization,
-where the same rules are enforced for real. `solution.py` uses the real
-`Organization`, the real provider registry, and the real rebind.
+Confirm all of this in the *real* organization, where `Actor`, `ROLE_AUTHORITY`,
+and `rebind_actor` are the production versions of what you just built:
 
-1. Inspect `operator-course` in `sovereign.toml`. Record its id, role,
-   authority, and provider.
-2. Run the exercise with a provider you have installed. Since sovereign-agent
-   1.1.0, the built-in `ollama` provider works with a local model — no cloud, no
-   key:
+```bash
+python book/ch03_actor_is_not_a_model/solution.py --root /tmp/lucy-ch03 --provider ollama
+```
 
-   ```bash
-   ollama pull qwen3
-   export SOVEREIGN_AGENT_LLM_MODEL="qwen3"
-   python book/ch03_actor_is_not_a_model/solution.py --root /tmp/lucy-ch03 --provider ollama
-   ```
-
-   (You can also pass `--provider claude`, `codex`, or `cursor` if you have that
-   CLI. With no live provider at all, read the refusal — that is a valid result.)
-3. Inspect the first scripted receipt under
-   `/tmp/lucy-ch03/.sovereign/runs/*/receipt.json`.
-4. Find the governed `actor.provider_rebound` event. The principal changed the
-   provider binding; the actor's id, role, and authority did not move.
-5. Replace `ollama` with another provider and run again. Watch the proposals
-   change and the governance stay exactly where it was.
+`solution.py` runs one assignment, rebinds `operator-course`'s provider, runs
+another, and reports whether the actor's identity survived. (Use `--provider
+scripted` if you have no local model; with a real one, `export
+SOVEREIGN_AGENT_LLM_MODEL=qwen3` first — the built-in `ollama` provider ships in
+sovereign-agent 1.1.0.)
 
 ## Expected observations
 
@@ -274,9 +213,8 @@ The exercise prints a JSON summary. The line that matters:
 "identity_unchanged": true
 ```
 
-Before and after the rebind, `operator-course` keeps the same id, the same role,
-and the same authority. Only the provider binding changed. Confirm the governed
-record of that change:
+Before and after the rebind, `operator-course` keeps the same id, role, and
+authority; only `provider` changed. Confirm the governed record of the change:
 
 ```bash
 sqlite3 /tmp/lucy-ch03/.sovereign/organization.db \
@@ -284,46 +222,54 @@ sqlite3 /tmp/lucy-ch03/.sovereign/organization.db \
 ```
 
 Expected: one row. Rebinding is an act the organization records, performed by an
-actor with ruling authority — not a config edit that happens quietly. If a live
+actor whose role may `rule` — not a config edit that happens quietly. If a live
 CLI is missing or cannot prove its required flags, you will see a refusal instead
-of a run. **That is the correct outcome:** capability claims come from probing
-the installed provider, and an unprovable capability fails closed.
+of a run. That is the correct outcome: an unprovable capability fails closed.
 
 ## Edge cases and failure modes
 
-A governed system is defined as much by what it refuses as by what it does. Watch
-for these:
-
-| What happens | What the organization does | Why |
+| What you try | What happens | Why |
 | --- | --- | --- |
-| A live CLI is not installed | Refuses the run, names the missing capability | Fail closed: an adapter may not hard-code an unsupported flag |
-| A provider exits `0` but writes no `report.json` | Rejects the receipt | Silence is not success; the work claim must be present and valid |
-| A provider returns malformed JSON | Fails the receipt | A record you cannot parse is not evidence |
-| Someone passes an empty performer set to `approve` | Approval slips through *in the toy* | Exactly why the real performer set is read from the ledger, never from the caller |
+| An actor without `rule` authority rebinds a provider | Refused by `require_authority` | Swapping intelligence is a governed decision, reserved to ruling roles |
+| The operator tries to `accept` | Refused, by role, regardless of model | `accept` is not in the operator role's action set |
+| A principal tries to accept work they performed | Refused by the no-self-approval guard | The performer is read from the ledger, not supplied by the caller |
+| A provider exits `0` but writes no report | The receipt is rejected | Silence is not success |
 
-That last row is the one to internalize. In your hand-built version, an empty
-`performers` set would let a worker approve itself by lying that it did nothing.
-The production organization does not accept the performer list as an argument at
-all — it derives it from the recorded assignments. The attack is not defended
-against; it is made *unrepresentable*.
+## Common mistakes
 
-## Break it and watch it fail
+- **Storing authority as a fact the caller asserts** (a boolean, a token in the
+  prompt). Then the worker grants itself power. Look authority up from the role.
+- **Using object immutability as a security boundary.** A `frozen` model stops a
+  stray assignment, not an attacker, and it is not why acceptance is safe here.
+  The role policy is.
+- **Believing a better model deserves a longer leash.** A more capable provider
+  proposes more capably-wrong actions. The guardrails are on the role precisely
+  so they do not move when the model does.
 
-Belief is cheaper than proof. Open a Python shell and try to smuggle `accept`
-onto the worker by editing its authority directly:
+## Exercises
 
-```python
-operator.authority = frozenset(operator.authority | {"accept"})
-```
+1. Add a `verifier` actor and confirm `require_authority("operator", "record_evidence")`
+   is refused while `require_authority("verifier", "record_evidence")` passes.
+2. Extend `rebind_actor` to also refuse an unknown provider name (one not in a set
+   of known providers), and show the actor's `provider` is unchanged after the
+   refusal.
+3. **(Stretch)** In two sentences, explain why moving `provider` *off* the actor
+   into a separate table would be a genuine architecture change requiring its own
+   design decision — not something a chapter can simply assert.
 
-```text
-dataclasses.FrozenInstanceError: cannot assign to field 'authority'
-```
+<details>
+<summary>Solutions</summary>
 
-The actor is frozen — you cannot quietly grant it a new power. The only way to
-change what an actor may do is through a governed operation that *records* the
-change, exactly as `rebind_provider` records a rebinding. There is no back door,
-because we removed the door on purpose.
+1. `record_evidence` is in the `verifier` role's set but not the `operator`'s, so
+   the first call raises and the second does not.
+2. Check membership before mutating: `if new_provider not in KNOWN: raise
+   PermissionError(...)`, placed before `actor.provider = new_provider`, so a
+   refusal leaves the field untouched.
+3. Production stores the provider on the actor and `rebind_actor` mutates it in
+   one place; a separate binding table would change the data model, the migration,
+   and every read path — a real design change with its own trade-offs, not a
+   detail prose can wave into existence.
+</details>
 
 ## Learner verification command
 
@@ -332,80 +278,34 @@ python -m pytest tests/test_actors_and_mailbox.py tests/test_providers.py -q
 ```
 
 Expected: all pass. These prove actor identity survives a provider rebind, that
-authority cannot be self-granted, and that adapters build argument arrays rather
-than shell strings.
-
-## Common mistakes
-
-- **Storing the provider on the actor.** The single most common design error. It
-  welds the dangerous operation (change identity) to the routine one (change
-  model). Keep the binding in a table the organization owns.
-- **Trusting the caller for the performer list.** If `approve` accepts
-  `performers` from whoever calls it, a caller can pass an empty set and approve
-  anything. Derive performers from the recorded ledger.
-- **Thinking a smarter model needs fewer guardrails.** It needs the same ones. A
-  more capable provider proposes more capable *and* more capably-wrong actions.
-  The guardrails are on the actor for exactly this reason.
-
-## Exercises
-
-1. **Add a role.** Create a `verifier` actor with authority `{"verify"}` and a
-   `verify(outcome_id, verifier)` that refuses any actor lacking `"verify"`.
-   Confirm `lucy-operator` cannot verify its own restock.
-2. **Log the rebind.** Extend `rebind_provider` to append a record to a
-   `ledger: list[dict]` with the actor id, old provider, new provider, and who
-   performed it; assert the ledger contains exactly one `provider_rebound` entry
-   after one rebind.
-3. **(Stretch)** Explain in two sentences why `approve(outcome, principal,
-   performers=set())` is dangerous, and where the real `performers` must come
-   from so that call is impossible to make.
-
-<details>
-<summary>Solutions</summary>
-
-1. `verify` mirrors `approve`'s authority check:
-   `if "verify" not in verifier.authority: raise PermissionError(...)`. Since
-   `lucy-operator`'s authority is `{"propose_restock", "write_workspace"}`, it
-   fails the check.
-2. Append `{"kind": "provider_rebound", "actor": actor.id, "from":
-   bindings.get(actor.id), "to": new_provider, "by": performed_by.id}` inside the
-   function; assert `sum(e["kind"] == "provider_rebound" for e in ledger) == 1`.
-3. An empty set means nobody is recorded as a performer, so the "you cannot
-   approve your own work" check passes vacuously — a worker could approve itself
-   by claiming it did nothing. The performer set must be derived from the durable
-   assignment ledger inside the approval path, never accepted as a caller
-   argument.
-</details>
+authority is enforced by role, and that adapters build argument arrays rather than
+shell strings.
 
 ## Summary
 
-- An **actor** is a governed identity — id, role, authority. A **provider** is
-  the swappable intelligence behind it. Keep them in separate places.
-- **Rebinding** the provider is a privileged, recorded act that changes the mind
-  and leaves the identity untouched. You proved it: `identity_unchanged: true`.
-- **Approval is refused for performers**, and performers come from the ledger,
-  not the caller — so the thing that did the work can never bless it.
-- Because accountability lives on the actor, **upgrading the model changes the
-  proposals but never the rules.** That is why the answer to Lucy's friend is
-  "neither safer nor more dangerous, by design."
+- An **actor** carries its swappable `provider` as a field, alongside its `role`
+  and `authority`. The model lives on the actor; it is not the actor.
+- **Rebinding** changes `provider`, is reserved to ruling roles, and is recorded
+  as an event. Identity — id, role, authority — is untouched: `identity_unchanged: true`.
+- **Authority is granted by role**, through a role→actions policy, enforced by
+  `require_authority`. The operator role cannot `accept`, and no model changes that.
+- Because accountability lives on the role, **upgrading the model changes the
+  proposals but never the rules** — the answer to Lucy's friend.
 
 ## Explain it back
 
-Answer in your own words before moving on. If you cannot, re-read the
-observations above — the answers are all visible in the database.
-
-1. In the cash-register analogy, which part is the actor and which is the
-   provider? What real failure does keeping them separate prevent?
-2. Why is a provider session id evidence about continuity but not about actor
-   identity?
-3. What should happen if a CLI exits zero but omits its terminal event or
-   `report.json`?
-4. Why may an unknown valid event be retained while malformed JSON must fail the
-   receipt?
-5. In your own words: what is the difference between an actor and a provider?
+1. In production, where does an actor's `provider` live — on the actor, or in a
+   separate table? What did rebinding actually change in the exercise?
+2. The chapter's toy first tried to gate acceptance on a boolean the caller
+   passes. What attack does that enable, and how does the role lookup close it?
+3. `require_authority` never looks at the actor's `provider`. Why is that the
+   whole point of this chapter?
+4. The operator role's actions are `read`, `write_workspace`, `run_checks`,
+   `report`. Which role has `accept`, and why is that separation not mere
+   bureaucracy?
+5. Why is object immutability (`frozen`) the *wrong* explanation for why the
+   operator cannot approve its own work?
 6. `operator-course` is rebound from `scripted` to `ollama`. Who is accountable
    for the next restock it proposes, and how would you show that from the ledger?
-7. Why does deriving the performer from assignments — rather than accepting it as
-   an argument — matter for keeping a provider from approving itself?
 
 Next: [Chapter 4 — Work stays inside its boundary](../ch04_work_stays_inside_its_boundary/README.md)

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -1,75 +1,329 @@
-# Chapter 3 — The actor is not a model
+# Chapter 3 — The Actor Is Not the Model
+
+## The bug that started an argument
+
+Lucy runs an ice cream shop. It is a small shop — six flavors, one freezer, one
+laptop — but it is busy, and this summer she started letting a language model
+help with the boring part: watching stock and proposing what to reorder.
+
+One Saturday the model proposed reordering **400 tubs of vanilla**. The freezer
+holds forty. If that order had gone through, Lucy would have spent the month's
+rent on ice cream that would melt on the sidewalk before she could sell it.
+
+It did not go through. In [Chapter 2](../ch02_work_needs_governance/README.md)
+you built the piece that said *no* — the governed check that re-reads reality
+before it lets a proposal commit. This chapter is about a subtler question, the
+one Lucy's friend asked her that evening:
+
+> "If you switch to a smarter model, does the shop get safer, or more dangerous?"
+
+The honest answer is **neither** — and understanding *why* is the most important
+idea in this book. Most systems that bolt an LLM onto a business get this exactly
+backwards: they treat "which model" and "what it is allowed to do" as the same
+knob. Turn up the intelligence and you turn up the authority. That is how a
+sharper model becomes a more expensive mistake.
+
+By the end of this chapter you will be able to swap the intelligence behind
+Lucy's shop — from a dumb scripted stand-in to a real local model — watch its
+proposals change completely, and **prove that who is allowed to do what did not
+move an inch.**
 
 ## Learning objective
 
 Understand why swapping the intelligence behind an actor does not change who is
-accountable — and why a provider therefore cannot approve its own work.
+accountable — and why a provider therefore cannot approve its own work. You will
+build the actor/provider distinction from first principles, then confirm it in
+the production organization: an actor keeps its `id`, `role`, and `authority`
+across a provider rebind, and acceptance is refused for whoever performed the
+work, no matter which model is bound to them.
 
-An **actor** is a governed identity with a role and authority. A **provider**
-is an external intelligence CLI: `scripted`, `claude`, `codex`, or `cursor`.
-Changing intelligence must not silently change who may act.
+## What you'll learn
 
-## Exercise
+- The difference between an **actor** (a governed identity) and a **provider**
+  (a swappable intelligence), and why welding them together is the root defect.
+- How the organization records a provider change as a *governed act*, not a
+  quiet config edit.
+- Why the thing that *proposed* a piece of work can never be the thing that
+  *approves* it — and how that is enforced by code that reads the ledger, not by
+  anyone's good intentions.
+
+**Prerequisites:** Chapters 0–2. Comfort with Python functions, dictionaries,
+and `dataclasses`. No machine-learning background required.
+
+## An analogy you already understand
+
+Think about the cash register at Lucy's shop.
+
+The **register** has rules: it records every sale, it needs a manager's key to
+void a transaction, it prints a receipt. Those rules do not care *who* is
+standing at it. A new hire, a twenty-year veteran, or Lucy herself — the register
+treats them all the same, because the rules belong to the *role*, not the person.
+
+The **person** at the register is replaceable. Hire a sharper cashier who scans
+faster and upsells better, and the shop gets a better *cashier*. It does not get
+a register that suddenly lets cashiers void their own transactions.
+
+An **actor** is the register: a governed identity with a role and a fixed set of
+permissions. A **provider** is the person: the intelligence doing the thinking,
+hired and swappable. "Upgrading the model" is hiring a sharper cashier. It is
+*not* rewriting the register's rules — and if it ever *did*, that would be a bug
+so dangerous it is the whole reason this chapter exists.
+
+Hold that picture. Now let's build it, starting from the naive version so you can
+feel exactly where it breaks.
+
+## Building the actor (and the trap)
+
+Start with identity. An actor needs an id, a role, and a set of things it may do:
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Actor:
+    id: str                      # "lucy-operator", stable forever
+    role: str                    # "operator", "verifier", "principal"
+    authority: frozenset[str]    # what this actor may do
+```
+
+We made it `frozen=True` on purpose. An actor's identity must not be editable by
+a stray line of code that happens to hold a reference to it. Changing what an
+actor *is* should go through a governed operation that records the change — which
+we will build in a moment.
+
+Here is the actor that runs Lucy's restock work:
+
+```python
+operator = Actor(
+    id="lucy-operator",
+    role="operator",
+    authority=frozenset({"propose_restock", "write_workspace"}),
+)
+```
+
+Read what `lucy-operator` may do: it may **propose** a restock and write to its
+scratch workspace. It may **not** approve work — that permission simply is not in
+the set. Hold onto that; it is the hinge the whole chapter turns on.
+
+Now, where does the *thinking* happen? Behind the actor, in a provider. The
+naive design — the one that causes the bug Lucy's friend worried about — is to
+bake the provider *into* the actor:
+
+```python
+# DON'T do this — it welds identity to intelligence
+@dataclass
+class Actor:
+    id: str
+    role: str
+    authority: set[str]
+    provider: str      # <-- the trap
+```
+
+Why is this a trap? Because now "change the model" and "change who this actor is"
+are the *same edit*. A function that swaps the provider is one typo away from
+also touching the role or the authority. The dangerous change and the harmless
+change live in the same place, guarded by the same (or no) review. Good systems
+keep dangerous operations far away from routine ones.
+
+So we store the binding *outside* the actor, in a small table the organization
+owns:
+
+```python
+# which provider is currently behind each actor id
+provider_bindings: dict[str, str] = {"lucy-operator": "scripted"}
+```
+
+The actor stays frozen and pristine. The binding is a separate, mutable fact.
+
+## Rebinding: change the mind, keep the identity
+
+Here is the operation that hires a sharper cashier. Read it, then we will walk
+through the two things that make it safe.
+
+```python
+def rebind_provider(bindings, actor, new_provider, performed_by):
+    # 1. Only an actor with ruling authority may rebind.
+    if "rule" not in performed_by.authority:
+        raise PermissionError(
+            f"{performed_by.id} (role {performed_by.role}) may not rebind providers"
+        )
+    # 2. Return a NEW bindings table; never mutate the actor's identity.
+    updated = dict(bindings)
+    updated[actor.id] = new_provider
+    print(f"event: actor.provider_rebound  {actor.id}: "
+          f"{bindings.get(actor.id)} -> {new_provider}  by {performed_by.id}")
+    return updated
+```
+
+Two properties make this safe, and both are worth saying out loud:
+
+1. **Rebinding is a privileged act, not a config edit.** The function refuses to
+   run for just anyone — `performed_by` must carry `"rule"` authority. Swapping
+   the model is a *decision*, made by someone accountable. In Lucy's shop that is
+   the principal (Lucy herself), never the worker whose model is being swapped.
+
+2. **The actor object is never touched.** We copy the table and change one entry.
+   The `Actor` — its id, role, authority — comes out the far side byte-for-byte
+   identical, because it is literally the same frozen object. The *mind* changed;
+   the *identity* did not. And notice the function prints an **event**: the change
+   is recorded, not whispered.
+
+Run it:
+
+```python
+principal = Actor("lucy", "principal", frozenset({"rule", "accept"}))
+
+before = provider_bindings["lucy-operator"]
+provider_bindings = rebind_provider(provider_bindings, operator, "ollama", principal)
+after = provider_bindings["lucy-operator"]
+
+print("provider:", before, "->", after)
+print("identity unchanged:", operator.authority == frozenset({"propose_restock", "write_workspace"}))
+```
+
+```text
+event: actor.provider_rebound  lucy-operator: scripted -> ollama  by lucy
+provider: scripted -> ollama
+identity unchanged: True
+```
+
+Read that last line again. We just replaced a deterministic fake with a real
+local model. The proposals from `lucy-operator` will now be smarter, wordier,
+occasionally surprising. And the answer to "who is `lucy-operator`, and what may
+it do?" did not change at all. The register stayed the register while a better
+cashier stepped up to it.
+
+## The second half: you cannot approve your own work
+
+There is a reason we kept `"accept"` *out* of the operator's authority. Make it
+concrete. In Lucy's shop, work flows like this: the operator **proposes** a
+restock, then — separately — a verifier checks the freezer and a principal
+**accepts**. Proposal and approval are done by *different actors*. That is not
+bureaucracy; it is the only thing standing between Lucy and a model that says "I
+ordered 400 tubs, and I also confirm that was an excellent decision."
+
+Here is a naive approval with the hole left in:
+
+```python
+def approve(outcome_id, approver):
+    if "accept" not in approver.authority:
+        raise PermissionError(f"{approver.id} may not accept")
+    print(f"event: outcome.accepted  {outcome_id}  by {approver.id}")
+```
+
+This checks that the approver *may* accept — good, but not enough. It does not
+check that the approver **is not the same actor that did the work.** The fix is
+to derive the *performers* from the ledger — the recorded list of who actually
+did the work — and refuse approval from any of them:
+
+```python
+def approve(outcome_id, approver, performers):
+    if "accept" not in approver.authority:
+        raise PermissionError(f"{approver.id} may not accept")
+    if approver.id in performers:
+        raise PermissionError(f"{approver.id} performed this work and may not approve it")
+    print(f"event: outcome.accepted  {outcome_id}  by {approver.id}")
+```
+
+Two properties matter enormously here, and they connect straight back to the
+first half of the chapter:
+
+- **`performers` comes from the ledger, not from the caller.** We do not *ask*
+  who did the work; we *look it up* from the durable record of assignments. A
+  caller cannot lie about it to sneak an approval through.
+- **This check is about the actor, and actors do not change when models do.**
+  Because the performer list is a set of *actor ids*, swapping `lucy-operator`'s
+  provider from `scripted` to `ollama` to `claude` changes nothing here. The
+  intelligence that did the work still cannot bless it, however smart it gets.
+
+That is the whole thesis in one sentence: **accountability lives on the actor,
+so upgrading the model cannot launder a proposal into an approval.**
+
+## The exercise
+
+You have built the idea by hand. Now confirm it in the *production* organization,
+where the same rules are enforced for real. `solution.py` uses the real
+`Organization`, the real provider registry, and the real rebind.
 
 1. Inspect `operator-course` in `sovereign.toml`. Record its id, role,
    authority, and provider.
-2. Run the exercise with a provider you have installed:
+2. Run the exercise with a provider you have installed. Since sovereign-agent
+   1.1.0, the built-in `ollama` provider works with a local model — no cloud, no
+   key:
 
    ```bash
-   python book/ch03_actor_is_not_a_model/solution.py \
-     --root /tmp/andrea-ch03 --provider claude
+   ollama pull qwen3
+   export SOVEREIGN_AGENT_LLM_MODEL="qwen3"
+   python book/ch03_actor_is_not_a_model/solution.py --root /tmp/lucy-ch03 --provider ollama
    ```
 
+   (You can also pass `--provider claude`, `codex`, or `cursor` if you have that
+   CLI. With no live provider at all, read the refusal — that is a valid result.)
 3. Inspect the first scripted receipt under
-   `/tmp/andrea-ch03/.sovereign/runs/*/receipt.json`.
-4. Observe the governed `actor.provider_rebound` event. The Principal changes
-   the provider binding; the actor id, role, and authority remain unchanged.
-5. If the live CLI is absent or cannot prove required print/stream flags, read
-   the refusal. Installing a model does not bypass the gate.
-6. If it runs, inspect `provider_session_ref`, `provider_usage`, normalized
-   events, and the validated `.sovereign-out/report.json`.
-7. Replace `--provider claude` with `codex` or `cursor`. Cursor is an equal
-   adapter, not a documentation bridge.
-
-The provider receives one production-built assignment envelope containing the
-actor, authority, SOW, disposable workspace boundary, output paths, and exact
-`ActorReport` schema. The adapter only translates that envelope into its CLI.
+   `/tmp/lucy-ch03/.sovereign/runs/*/receipt.json`.
+4. Find the governed `actor.provider_rebound` event. The principal changed the
+   provider binding; the actor's id, role, and authority did not move.
+5. Replace `ollama` with another provider and run again. Watch the proposals
+   change and the governance stay exactly where it was.
 
 ## Expected observations
 
-Running the exercise prints a JSON summary. The line that matters:
+The exercise prints a JSON summary. The line that matters:
 
 ```text
 "identity_unchanged": true
 ```
 
-Before and after the rebind, `operator-course` keeps the same id, the same
-role, and the same authority list. Only `provider` changes — from `scripted`
-to `claude`, `codex`, or `cursor`.
-
-Confirm the governed record of the change:
+Before and after the rebind, `operator-course` keeps the same id, the same role,
+and the same authority. Only the provider binding changed. Confirm the governed
+record of that change:
 
 ```bash
-sqlite3 /tmp/andrea-ch03/.sovereign/organization.db \
+sqlite3 /tmp/lucy-ch03/.sovereign/organization.db \
   "SELECT kind FROM events WHERE kind = 'actor.provider_rebound';"
 ```
 
 Expected: one row. Rebinding is an act the organization records, performed by an
-actor with ruling authority — not a config edit that happens quietly.
+actor with ruling authority — not a config edit that happens quietly. If a live
+CLI is missing or cannot prove its required flags, you will see a refusal instead
+of a run. **That is the correct outcome:** capability claims come from probing
+the installed provider, and an unprovable capability fails closed.
 
-If a live CLI is missing or cannot prove its required flags, you will see a
-refusal instead of a run. That is the correct outcome: capability claims come
-from probing the installed CLI, and an unprovable capability fails closed.
+## Edge cases and failure modes
 
-## Why a provider cannot approve its own work
+A governed system is defined as much by what it refuses as by what it does. Watch
+for these:
 
-The provider that proposed the restock in Chapter 0 runs *behind*
-`operator-course`. Acceptance is refused for every actor that performed work,
-and performers are derived from the assignments in the ledger — not supplied by
-the caller. So the intelligence that did the work cannot become the authority
-that blesses it, no matter which model is bound to the actor.
+| What happens | What the organization does | Why |
+| --- | --- | --- |
+| A live CLI is not installed | Refuses the run, names the missing capability | Fail closed: an adapter may not hard-code an unsupported flag |
+| A provider exits `0` but writes no `report.json` | Rejects the receipt | Silence is not success; the work claim must be present and valid |
+| A provider returns malformed JSON | Fails the receipt | A record you cannot parse is not evidence |
+| Someone passes an empty performer set to `approve` | Approval slips through *in the toy* | Exactly why the real performer set is read from the ledger, never from the caller |
 
-Swap `claude` for `codex` and the governance does not move. That is the point.
+That last row is the one to internalize. In your hand-built version, an empty
+`performers` set would let a worker approve itself by lying that it did nothing.
+The production organization does not accept the performer list as an argument at
+all — it derives it from the recorded assignments. The attack is not defended
+against; it is made *unrepresentable*.
+
+## Break it and watch it fail
+
+Belief is cheaper than proof. Open a Python shell and try to smuggle `accept`
+onto the worker by editing its authority directly:
+
+```python
+operator.authority = frozenset(operator.authority | {"accept"})
+```
+
+```text
+dataclasses.FrozenInstanceError: cannot assign to field 'authority'
+```
+
+The actor is frozen — you cannot quietly grant it a new power. The only way to
+change what an actor may do is through a governed operation that *records* the
+change, exactly as `rebind_provider` records a rebinding. There is no back door,
+because we removed the door on purpose.
 
 ## Learner verification command
 
@@ -81,69 +335,77 @@ Expected: all pass. These prove actor identity survives a provider rebind, that
 authority cannot be self-granted, and that adapters build argument arrays rather
 than shell strings.
 
-## Isolation warning
+## Common mistakes
 
-`--workspace` selects a directory; it is not a sandbox. Cursor's CLI has file
-and shell tools. Chapter 3 relies on a disposable Sovereign Agent run
-workspace, not an invented provider security guarantee. Stronger workspace
-lifecycle policies arrive in Unit 7.
+- **Storing the provider on the actor.** The single most common design error. It
+  welds the dangerous operation (change identity) to the routine one (change
+  model). Keep the binding in a table the organization owns.
+- **Trusting the caller for the performer list.** If `approve` accepts
+  `performers` from whoever calls it, a caller can pass an empty set and approve
+  anything. Derive performers from the recorded ledger.
+- **Thinking a smarter model needs fewer guardrails.** It needs the same ones. A
+  more capable provider proposes more capable *and* more capably-wrong actions.
+  The guardrails are on the actor for exactly this reason.
 
-Codex receives `--sandbox workspace-write` when the actor has
-`write_workspace` authority because even a domain-read-only assignment must
-write its mandatory report. The live read-only smoke verifies that tracked
-domain files remain unchanged; it does not make the report directory
-unwritable.
+## Exercises
 
-The same authority becomes Claude `--permission-mode acceptEdits` and Cursor
-`--force`, but only when those exact controls are present in the installed
-CLI's help output. These flags authorize writes inside the disposable run
-workspace; they do not expand the actor's organizational authority.
+1. **Add a role.** Create a `verifier` actor with authority `{"verify"}` and a
+   `verify(outcome_id, verifier)` that refuses any actor lacking `"verify"`.
+   Confirm `lucy-operator` cannot verify its own restock.
+2. **Log the rebind.** Extend `rebind_provider` to append a record to a
+   `ledger: list[dict]` with the actor id, old provider, new provider, and who
+   performed it; assert the ledger contains exactly one `provider_rebound` entry
+   after one rebind.
+3. **(Stretch)** Explain in two sentences why `approve(outcome, principal,
+   performers=set())` is dangerous, and where the real `performers` must come
+   from so that call is impossible to make.
+
+<details>
+<summary>Solutions</summary>
+
+1. `verify` mirrors `approve`'s authority check:
+   `if "verify" not in verifier.authority: raise PermissionError(...)`. Since
+   `lucy-operator`'s authority is `{"propose_restock", "write_workspace"}`, it
+   fails the check.
+2. Append `{"kind": "provider_rebound", "actor": actor.id, "from":
+   bindings.get(actor.id), "to": new_provider, "by": performed_by.id}` inside the
+   function; assert `sum(e["kind"] == "provider_rebound" for e in ledger) == 1`.
+3. An empty set means nobody is recorded as a performer, so the "you cannot
+   approve your own work" check passes vacuously — a worker could approve itself
+   by claiming it did nothing. The performer set must be derived from the durable
+   assignment ledger inside the approval path, never accepted as a caller
+   argument.
+</details>
+
+## Summary
+
+- An **actor** is a governed identity — id, role, authority. A **provider** is
+  the swappable intelligence behind it. Keep them in separate places.
+- **Rebinding** the provider is a privileged, recorded act that changes the mind
+  and leaves the identity untouched. You proved it: `identity_unchanged: true`.
+- **Approval is refused for performers**, and performers come from the ledger,
+  not the caller — so the thing that did the work can never bless it.
+- Because accountability lives on the actor, **upgrading the model changes the
+  proposals but never the rules.** That is why the answer to Lucy's friend is
+  "neither safer nor more dangerous, by design."
 
 ## Explain it back
 
-1. Which fields stayed constant after rebinding the provider?
-2. Why is a provider session id evidence about continuity but not actor
+Answer in your own words before moving on. If you cannot, re-read the
+observations above — the answers are all visible in the database.
+
+1. In the cash-register analogy, which part is the actor and which is the
+   provider? What real failure does keeping them separate prevent?
+2. Why is a provider session id evidence about continuity but not about actor
    identity?
 3. What should happen if a CLI exits zero but omits its terminal event or
    `report.json`?
-4. Why may an unknown valid event be retained while malformed JSON must fail
-   the receipt?
+4. Why may an unknown valid event be retained while malformed JSON must fail the
+   receipt?
 5. In your own words: what is the difference between an actor and a provider?
-6. `operator-course` is rebound from `scripted` to `claude`. Who is accountable
-   for the work afterwards, and how would you show that from the ledger?
-7. Why does deriving the performer from assignments — rather than accepting it
-   as an argument — matter for keeping a provider from approving itself?
-
-## Production correspondence
-
-| Textbook concept | Production responsibility |
-| --- | --- |
-| Actor id, role, authority | Governed organizational identity and policy |
-| Provider binding | Replaceable intelligence runtime |
-| Assignment envelope | Bounded work contract and output schema |
-| Disposable run directory | Isolation boundary owned by Sovereign Agent |
-| Provider session reference | Runtime continuity evidence, never identity |
-| Terminal event + report | Protocol completion plus validated work claim |
-| Receipt and SHA-256 sidecar | Canonical durable execution evidence |
-
-## Live smoke tests
-
-Default tests use faithful, redacted fixtures and fake executables. Probes are
-opt-in and submit no work:
-
-```bash
-python -m pytest -q -m live
-```
-
-Credentialed assignment smokes require a second explicit gate. They run one
-read-only and one workspace-write assignment per installed provider and may
-consume provider credits (typically a short prompt each):
-
-```bash
-SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1 python -m pytest -q -m live
-```
-
-The fixture repository is disposable, and each test proves its trunk commit
-did not move.
+6. `operator-course` is rebound from `scripted` to `ollama`. Who is accountable
+   for the next restock it proposes, and how would you show that from the ledger?
+7. Why does deriving the performer from assignments — rather than accepting it as
+   an argument — matter for keeping a provider from approving itself?
 
 Next: [Chapter 4 — Work stays inside its boundary](../ch04_work_stays_inside_its_boundary/README.md)

--- a/book/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/ch04_work_stays_inside_its_boundary/README.md
@@ -10,12 +10,17 @@ directory for it to work in; what you didn't see is that, for most providers,
 nothing at the operating-system level *stops* the provider from writing outside
 that directory. That sounds alarming until you internalize the move this chapter
 makes: instead of promising a containment the providers cannot deliver, the
-organization makes the boundary **detectable**. It photographs everything outside
-the workspace before the provider runs and again after, and compares. If a byte
-moved where it shouldn't have, the ledger says so — permanently.
+organization makes the boundary **detectable** — within a stated scope. Before
+and after the provider runs, it takes a digest of the tracked files inside the
+organization root, *excluding the workspace itself and the SQLite ledger*, and
+compares. A change in that scope is recorded on the ledger, permanently.
 
-An honest "we can tell" beats a dishonest "we prevented it." This chapter is
-about building the honest version.
+Be precise about what that does and does not cover: it detects tracked changes in
+`organization_root_excluding_workspace_and_ledger`. It does **not** watch the
+whole filesystem — a provider that writes to `/tmp` or the home directory is
+outside what this check can see. An honest "we can tell, within this scope" beats
+a dishonest "we prevented it." This chapter builds the honest version and marks
+its edges.
 
 ## Learning objective
 

--- a/book/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/ch04_work_stays_inside_its_boundary/README.md
@@ -1,5 +1,22 @@
 # Chapter 4 — Work stays inside its boundary
 
+When Lucy hires a contractor to fix the freezer, she doesn't follow them around
+the shop. But she does notice if the till is short afterward. She can't *prevent*
+a stranger from wandering into the back office — but she can *tell* whether they
+did.
+
+A provider is that contractor. In Chapter 3 you saw that `--workspace` selects a
+directory for it to work in; what you didn't see is that, for most providers,
+nothing at the operating-system level *stops* the provider from writing outside
+that directory. That sounds alarming until you internalize the move this chapter
+makes: instead of promising a containment the providers cannot deliver, the
+organization makes the boundary **detectable**. It photographs everything outside
+the workspace before the provider runs and again after, and compares. If a byte
+moved where it shouldn't have, the ledger says so — permanently.
+
+An honest "we can tell" beats a dishonest "we prevented it." This chapter is
+about building the honest version.
+
 ## Learning objective
 
 Understand what "the provider only writes to its workspace" actually means in
@@ -8,9 +25,8 @@ checkable before a write is ever attempted (`safe_join`), checkable after a
 provider has run (`snapshot_boundary`/`diff_boundary`), and a disposal policy
 (`reclaim_workspace`) that decides what survives once the work is done.
 
-Chapter 3 mentioned this in passing: "`--workspace` selects a directory; it is
-not a sandbox... Stronger workspace lifecycle policies arrive in Unit 7." This
-chapter is that arrival.
+Chapter 3 flagged that `--workspace` selects a directory, not a sandbox. This
+chapter builds the machinery that makes that flag honest rather than alarming.
 
 ## Vocabulary this chapter adds
 
@@ -25,7 +41,7 @@ chapter is that arrival.
 ## The exercise
 
 ```bash
-python book/ch04_work_stays_inside_its_boundary/solution.py --root /tmp/andrea-ch04
+python book/ch04_work_stays_inside_its_boundary/solution.py --root /tmp/lucy-ch04
 ```
 
 Reads real output straight from the production `workspace` module: it runs one
@@ -140,8 +156,8 @@ misreported as one.
 
 - `src/sovereign_agent/workspace.py` — `safe_join`, `snapshot_boundary`,
   `diff_boundary`, `reclaim_workspace`
-- `docs/v1-unit7-workspace-lifecycle.md` — the full contract, including six
-  rounds of review findings this exercise's own machinery survived
+- `src/sovereign_agent/workspace.py` — read the boundary check and the reclaim
+  policy end to end; they are short, and the exercise above calls exactly them
 - `.sovereign/runs/<workspace_id>/` — inspect one directly after running the
   exercise above
 

--- a/book/ch05_authority_needs_a_fence/README.md
+++ b/book/ch05_authority_needs_a_fence/README.md
@@ -1,5 +1,21 @@
 # Chapter 5 — Authority needs a fence
 
+Two of Lucy's staff each believe they are closing tonight. One of them is wrong —
+maybe they swapped shifts and forgot, maybe one went home and came back. It does
+not matter *why*. What matters is that only one person can count the till, lock
+the freezer, and set the alarm, and the shop must never let *both* do it, because
+two people each doing "the closing" is how money goes missing and doors get left
+open.
+
+Software has exactly this problem, and it is sneakier there. A worker process
+crashes and gets restarted; for a moment, *two* processes both believe they are
+the same actor, `operator-course`, finishing the same job. If both are allowed to
+write "done," the ledger ends up with two conflicting truths. This chapter builds
+the fence that makes that impossible — not by trusting workers to behave, but with
+a numbered claim (think of it as a numbered key) that only one process can hold at
+a time, where every handover mints a *higher* number so a stale worker's old key
+simply stops turning.
+
 ## Learning objective
 
 Understand the difference between an **actor** (a durable, governed identity)
@@ -26,7 +42,7 @@ active workspace.**
 ## The exercise
 
 ```bash
-python book/ch05_authority_needs_a_fence/solution.py --root /tmp/andrea-ch05
+python book/ch05_authority_needs_a_fence/solution.py --root /tmp/lucy-ch05
 ```
 
 Exercises `fencing.acquire_actor_lease` and `fencing.acquire_execution_attempt`
@@ -71,10 +87,10 @@ Read this in order:
    for one that no longer matches any real row) is refused — the check is
    never merely "trust the caller's earlier acquisition."
 3. **The decisive property: two DIFFERENT assignments for the SAME actor,
-   two SEPARATE processes.** This is the exact gap Unit 4's mailbox left
-   open — it proved two distinct *actors* contending for one message
-   produces one winner, but said nothing about two *processes* both
-   claiming to be the same actor. `second_process_same_actor_different_
+   two SEPARATE processes.** This is the gap an ordinary message queue leaves
+   open: it can prove two distinct *actors* contending for one message produce
+   one winner, but says nothing about two *processes* both claiming to be the
+   same actor. `second_process_same_actor_different_
    assignment` shows the refusal happening through the ordinary
    `run_assignment` call, before the provider is ever invoked —
    `assignment_never_reached_running` confirms the second assignment stayed
@@ -122,13 +138,10 @@ cannot bypass either.
 
 ## Where to look next
 
-- `src/sovereign_agent/fencing.py` — process identity, actor leases,
-  execution-attempt fencing
-- `docs/v1-unit8-supervisor-fencing-recovery.md` — the full contract,
-  including the two rounds of review correction this mechanism survived
-  (F-R2-1: a leak on every refusal path, not only success)
-- `docs/rulings/2026-08-26-one-process-per-actor.md` — the gap this
-  chapter's mechanism closes
+- `src/sovereign_agent/fencing.py` — process identity, actor leases, and the
+  execution-attempt compare-and-set. Note that the lease is released on every
+  refusal path, not only on success — a leak there would strand an actor after
+  any failure.
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch06_the_organization_recovers/README.md
+++ b/book/ch06_the_organization_recovers/README.md
@@ -1,9 +1,24 @@
 # Chapter 6 — The organization recovers
 
+Imagine the worker who was closing Lucy's shop collapses mid-count and is rushed
+out the door. The till is half-counted, the freezer maybe locked, maybe not.
+Nobody can ask *them* what got done — they're gone. So someone else has to walk
+in, notice the shift never properly ended, and write down the only honest thing
+that can be written: *we don't know it was finished, so it wasn't.* Not "probably
+fine." Not "looked done to me." Unknown is not success.
+
+That is recovery, and it is subtler than it sounds, because the tempting move —
+"the worker got most of the way, let's call it done" — is exactly the lie a
+governed organization must never tell. In Chapter 5 you built the fence that
+decides who holds authority *right now*. This chapter is about what happens when
+the process holding it simply stops existing, and why a *different* process must
+be the one to record its death — because a process, like that collapsed worker,
+cannot certify its own.
+
 ## Learning objective
 
-Understand why "a process cannot record its own death" (Unit 5's own rule)
-forces a *second* process to own recovery, and see the supervisor do exactly
+Understand why "a process cannot record its own death" forces a *second*
+process to own recovery, and see the supervisor do exactly
 that: recover a genuinely, violently killed worker's assignment — never
 guessing that it might have succeeded.
 
@@ -35,7 +50,7 @@ disappears.
 ## The exercise
 
 ```bash
-python book/ch06_the_organization_recovers/solution.py --root /tmp/andrea-ch06
+python book/ch06_the_organization_recovers/solution.py --root /tmp/lucy-ch06
 ```
 
 Takes a few seconds — it genuinely waits for a real subprocess to reach
@@ -82,8 +97,8 @@ Four things worth reading closely:
 4. **The recovered receipt is always `failed`, never a guess.** However far
    the killed subprocess might actually have gotten — it might have been
    about to write a valid `report.json` — the organization has no way to know
-   that, and Unit 5's own rule ("nothing is ever a guessed success") extends
-   here without exception.
+   that, and the rule you met in Chapter 5 — nothing is ever a guessed success —
+   extends here without exception.
 
 ## Why this is not a cancellation
 
@@ -127,8 +142,8 @@ only after the recovery transaction is durable.
 - `src/sovereign_agent/supervisor.py` — `tick`, `recover_abandoned_assignments`
 - `tests/fixtures/hard_kill_worker.py` — the real child process this
   exercise's own `solution.py` reuses
-- `docs/v1-unit8-supervisor-fencing-recovery.md` — the full contract,
-  Property 4 in particular
+- `tests/test_supervisor.py` — the hard-kill proof matrix, if you want to see
+  every recovery property exercised at once
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -1,15 +1,20 @@
 # Chapter 7 — The organization wakes itself
 
-Every chapter so far began the same way: *you* typed a command. The sale, the
-signal, the restock — nothing moved until a human poked it. Lucy noticed this
-too. She doesn't want to *remember* to check the freezer; she wants the shop to
-notice its own low stock and start the reorder while she's busy scooping.
+Every chapter so far began the same way: a human *dispatched* the work — wrote the
+statement of work, made the assignment. Lucy wants something narrower but
+important: when a sale drops the freezer below its line, she wants the reorder
+*work itself* to be created from that signal, without her writing the dispatch by
+hand each time.
 
-That is a genuinely different and more dangerous capability, and most systems
-fake it — they run a loop, do something, and print "autonomous!" This chapter
-builds the real version and then does the thing this whole book insists on:
-proves it. When Lucy's organization creates work with nobody prompting it, it
-leaves a durable, traceable record that it did — a record you can walk backward
+Be precise about the claim, because most systems overstate exactly this. This
+chapter builds three separable things and is careful not to confuse them: (1) a
+**signal-driven decision** — a durable low-stock fact turned into a wake
+decision; (2) **one Pulse tick** — a single call that derives governed work from
+that decision; and (3) an **external scheduler or daemon** that would run ticks
+unattended on a timer. This chapter builds and proves (1) and (2). It does **not**
+build (3): *you* invoke the tick. "The organization wakes itself" means it creates
+its own work from its own signals — not that it runs forever on its own. And when
+it does create work, it leaves a durable, traceable record you can walk backward
 from the finished work all the way to the sale that woke it. No record, no claim.
 
 ## Learning objective

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -1,5 +1,17 @@
 # Chapter 7 — The organization wakes itself
 
+Every chapter so far began the same way: *you* typed a command. The sale, the
+signal, the restock — nothing moved until a human poked it. Lucy noticed this
+too. She doesn't want to *remember* to check the freezer; she wants the shop to
+notice its own low stock and start the reorder while she's busy scooping.
+
+That is a genuinely different and more dangerous capability, and most systems
+fake it — they run a loop, do something, and print "autonomous!" This chapter
+builds the real version and then does the thing this whole book insists on:
+proves it. When Lucy's organization creates work with nobody prompting it, it
+leaves a durable, traceable record that it did — a record you can walk backward
+from the finished work all the way to the sale that woke it. No record, no claim.
+
 ## Learning objective
 
 Watch the organization create governed work **without a human prompt**, and
@@ -8,11 +20,10 @@ learn what makes that claim honest rather than theater: a durable
 real mechanism, both checkable after the fact — never a status string, never
 an inference from "nobody typed a command."
 
-Chapter 0 ended by telling you the truth: "you started this... the
-organization has no heartbeat yet." That was accurate when it was written.
-This chapter is where that stops being true — and it is truthful about the
-difference, because the ledger this exercise produces proves it rather than
-merely claiming it.
+Chapter 0 ended by telling you the truth: you started everything; the
+organization had no heartbeat yet. This chapter is where that stops being true —
+and it earns the change honestly, because the ledger this exercise produces
+proves the organization woke itself rather than merely claiming it did.
 
 ## Vocabulary this chapter adds
 
@@ -26,7 +37,7 @@ merely claiming it.
 ## The exercise
 
 ```bash
-python book/ch07_the_organization_wakes_itself/solution.py --root /tmp/andrea-ch07
+python book/ch07_the_organization_wakes_itself/solution.py --root /tmp/lucy-ch07
 ```
 
 Read the file before you run it. Notice what is missing: no `create_sow`, no
@@ -81,10 +92,10 @@ This is the whole chapter, in four facts:
    in prose, read back from the ledger after the fact, the same way Chapter
    0 taught you to check every other claim in this book.
 2. **`origin_kind: "pulse"`.** Not inferred from the absence of a manual
-   dispatch call — a column, read directly.
-   `docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md`
-   states the holding this row exists to prove: "absence of a CLI
-   invocation, process logs, or a manual-origin row is NOT proof."
+   dispatch call — a column, read directly. This is a deliberate design
+   principle: the absence of a CLI invocation, of process logs, or of a
+   manual-origin row is *not* proof that work was self-generated. Only a
+   positive, recorded origin is.
 3. **`wake_decision_traces_back_to_this_signal: true`.** The full chain —
    signal → wake decision → Pulse event → SOW → assignment — is walkable,
    not merely claimed. The wake decision's own `source_signal_id` matches
@@ -97,7 +108,7 @@ This is the whole chapter, in four facts:
 Confirm it yourself, independent of this exercise's own summary:
 
 ```bash
-sqlite3 /tmp/andrea-ch07/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch07/.sovereign/organization.db <<'SQL'
 SELECT po.origin_kind, po.sow_id, po.assignment_id,
        wd.source_signal_id, wd.source_event_id
 FROM pulse_origins po
@@ -114,12 +125,11 @@ source event.
 Chapters 0 through 3 say the organization has no heartbeat, and mean it — no
 chapter before this one ever calls `run_pulse_once`, and this project's own
 curriculum checker refuses any of them from claiming otherwise, mechanically,
-every time it runs. That is not this chapter overwriting an old truth; it is
-this book being honest about when a truth changed. Chapter 0 itself was
-updated, additively, the moment Pulse became real: "Pulse is now real, as a
-separate mechanism you invoke yourself... it is not this chapter's exercise,
-and it never runs itself." That sentence is still true. This is the chapter
-where you invoke it.
+every time it runs. That is not this chapter overwriting an old truth; it is this book being honest
+about *when* a capability arrives. Chapter 0 was careful to say the organization
+cannot yet wake itself, and to show you a ledger with no `pulse.*` event in it.
+Pulse is a separate mechanism you invoke yourself — it never runs on its own —
+and this is the chapter where you invoke it for the first time.
 
 The same curriculum checker that refuses an early chapter's Pulse claim
 holds THIS chapter to a stricter standard than "the words are true": it
@@ -141,7 +151,7 @@ python scripts/verify_curriculum.py
 
 Expected: all pass. The pytest selection proves the full sale-to-accepted
 slice through the real mechanism, the source-event-to-SOW attribution chain,
-and that Pulse-created work is not exempt from Unit 8's fencing.
+and that Pulse-created work is not exempt from Chapter 5's fencing.
 `verify_curriculum.py` proves this chapter's own claim is backed by durable
 evidence, not merely present in the prose — the mechanical guard this
 project's own curriculum checker enforces specifically for Chapter 7.
@@ -169,16 +179,15 @@ project's own curriculum checker enforces specifically for Chapter 7.
 - `src/sovereign_agent/pulse.py` — `run_pulse_once`, the whole mechanism
 - `src/reference_organizations/store/pulse_gate.py` — the Store's own wake
   gate, deliberately outside `sovereign_agent`'s own module budget
-- `docs/v1-unit9-pulse-proactive-work.md` — the full contract and proof
-  matrix, including the F-U9-1 correction that made the canonical creation
-  transaction genuinely atomic
-- `docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md` — why
-  Pulse is not a fourth step of the supervisor's own tick
+- `tests/test_pulse.py` — the full proof matrix, including that the canonical
+  creation transaction (signal → wake decision → SOW → assignment) is genuinely
+  atomic, so a crash mid-creation cannot strand a half-woken piece of work
 
 `solution.py` imports the production package rather than copying it.
 
-You have now completed all seven chapters. **Added, Unit 11:** the Store's
-own governed territory now expands — Chapters 8 through 12 land alongside
-it, the same way Chapters 4 through 7 landed alongside Units 7 through 9.
+You have now built the whole spine of a governed organization: memory,
+judgement, bounded work, fenced authority, recovery, and a heartbeat. Chapters 8
+through 12 turn from the machinery to the shop itself — Lucy's catalog grows, and
+you watch every guarantee you built hold up as it scales.
 
 Next: [Chapter 8 — The Store becomes a catalog](../ch08_the_store_becomes_a_catalog/README.md)

--- a/book/ch08_the_store_becomes_a_catalog/README.md
+++ b/book/ch08_the_store_becomes_a_catalog/README.md
@@ -1,5 +1,19 @@
 # Chapter 8 — The Store becomes a catalog
 
+Up to now Lucy's shop has sold exactly one thing. That was a convenient lie — it
+let us build memory, judgement, boundaries, fencing, recovery, and a heartbeat
+without the distraction of a second product. But a real ice cream shop has
+vanilla *and* chocolate, and the moment there are two, a new question appears that
+never existed with one: **when something happens to one product, does it stay
+contained to that product?** A run on vanilla must not quietly change the
+chocolate count. A low-stock signal for one flavor must not reorder the other.
+
+This chapter is the smallest possible version of that step — turning the single
+product into a genuine *catalog* of independent SKUs — because independence is
+easiest to get right at the very beginning, at the schema, before any sale or
+signal can blur the lines. (The shipped catalog uses two example SKUs to make the
+mechanics concrete; they behave exactly as Lucy's vanilla and chocolate would.)
+
 ## Learning objective
 
 See the Store's single-product fixture become a genuine catalog: two
@@ -25,7 +39,7 @@ real store with more than one product on the shelf actually needs.
 ## The exercise
 
 ```bash
-python book/ch08_the_store_becomes_a_catalog/solution.py --root /tmp/andrea-ch08
+python book/ch08_the_store_becomes_a_catalog/solution.py --root /tmp/lucy-ch08
 ```
 
 Read the file first. `seed_catalog` is called once, with the default
@@ -92,7 +106,7 @@ Three facts this run proves, not merely states:
 Confirm it yourself, independent of this exercise's own summary:
 
 ```bash
-sqlite3 /tmp/andrea-ch08/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch08/.sovereign/organization.db <<'SQL'
 SELECT sku, on_hand, reorder_point FROM inventory ORDER BY sku;
 SQL
 ```
@@ -109,7 +123,7 @@ python scripts/verify_curriculum.py
 
 Expected: all pass. The pytest selection proves a sale of one SKU cannot
 touch another SKU's own row — this chapter only seeds the catalog, but the
-isolation the rest of this unit relies on starts here, at the schema.
+isolation the next chapters rely on starts here, at the schema.
 
 ## Explain it back
 
@@ -128,9 +142,8 @@ isolation the rest of this unit relies on starts here, at the schema.
 
 - `src/reference_organizations/store/__init__.py` — `seed_catalog`,
   `CatalogEntry`, `DEFAULT_CATALOG`
-- `tests/test_store_multi_sku.py` — the full multi-SKU isolation proof
-  matrix this unit's own acceptance requires
-- `docs/v1-unit11-store-expansion-pilot-start.md` — the full contract
+- `tests/test_store_multi_sku.py` — the full multi-SKU isolation proof matrix:
+  every way one SKU's row could leak into another's, and the proof it cannot
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -74,12 +74,15 @@ The two facts this run proves:
 1. **`coffee_on_hand_unaffected: true`.** Selling tea changed exactly one
    row in `inventory` — coffee's own `on_hand` is untouched, read back after
    the tea sale, not merely assumed.
-2. **`signal_severity` differs by SKU, correctly.** The tea sale's signal is
-   `warning` (2 remaining is at-or-below its own reorder point of 3). The
-   coffee sale's signal is `info` (9 remaining is still above its own
-   reorder point of 6) — the identical 1-unit-sold shape that would have
-   been a `warning` for tea is correctly `info` for coffee, because each
-   evaluation reads THAT SKU's own threshold.
+2. **`signal_severity` is judged per SKU, against that SKU's own line.** The tea
+   sale leaves 2 on hand, at-or-below tea's reorder point of 3, so its signal is
+   `warning`. The coffee sale leaves 9, still above coffee's reorder point of 6,
+   so its signal is `info`. These are two different-sized sales — that is the
+   point: severity is not a property of how much sold, but of where each SKU
+   landed relative to *its own* threshold. (Try editing the exercise to sell the
+   *same* quantity from both — selling 2 of each still warns tea and leaves coffee
+   at `info`, because 8 is above coffee's line of 6. The split follows the
+   thresholds, not the quantities.)
 
 Confirm it yourself:
 

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -1,5 +1,19 @@
 # Chapter 9 — Each product has its own threshold
 
+Lucy sells a *lot* of vanilla and only a little of her weird lavender-honey
+flavor. If both had the same "reorder when you hit 3 tubs" rule, one of two bad
+things would happen: either she'd run out of vanilla constantly (3 is far too low
+for something that flies out the door), or she'd drown in lavender-honey (3 is far
+too high for something nobody buys). Different products need different thresholds.
+That is obvious in a shop and surprisingly easy to get wrong in code, where it is
+tempting to reach for one tidy constant.
+
+Chapter 8 seeded a catalog where each SKU *had* its own reorder point, sitting in
+its own row. This chapter proves that number actually *does its job* once real
+sales start moving — that selling one product past its own line never trips
+another's, and that the very same sale can be an alarm for one product and a
+shrug for another.
+
 ## Learning objective
 
 Prove, with real sales, that "independent reorder point" from Chapter 8
@@ -18,7 +32,7 @@ exact same-shaped sale already flagged tea.
 ## The exercise
 
 ```bash
-python book/ch09_each_product_has_its_own_threshold/solution.py --root /tmp/andrea-ch09
+python book/ch09_each_product_has_its_own_threshold/solution.py --root /tmp/lucy-ch09
 ```
 
 Read the file first. Two sales happen: 2 units of tea (4 on hand, reorder at
@@ -70,7 +84,7 @@ The two facts this run proves:
 Confirm it yourself:
 
 ```bash
-sqlite3 /tmp/andrea-ch09/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch09/.sovereign/organization.db <<'SQL'
 SELECT sku, on_hand, reorder_point, on_hand <= reorder_point AS below FROM inventory ORDER BY sku;
 SQL
 ```
@@ -103,8 +117,7 @@ Expected: all pass.
 - `src/reference_organizations/store/__init__.py` — `record_sale`,
   `below_reorder`
 - `tests/test_store_multi_sku.py` — the signal-isolation and
-  wake-decision-isolation tests this chapter's own proof extends into
-  Chapter 10
+  wake-decision-isolation tests this chapter's proof extends into Chapter 10
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch10_one_signal_wakes_one_need/README.md
+++ b/book/ch10_one_signal_wakes_one_need/README.md
@@ -1,5 +1,19 @@
 # Chapter 10 — One signal wakes one need
 
+It's a busy Saturday. Lucy's vanilla drops below its line at 2:00 and her
+chocolate drops below its line at 2:05. Two alarms, close together. The one thing
+that must never happen is a crossed wire: the vanilla alarm starting a chocolate
+reorder, or both alarms collapsing into a single order that restocks one flavor
+twice and the other not at all. Each signal has to wake *its own* need, and only
+its own.
+
+This sounds trivial — of course a vanilla alarm is about vanilla — but "which
+signal is about which product" is precisely the kind of thing that goes wrong
+when work is created from events rather than from a human pointing at a form. In
+Chapter 7 you watched one signal correctly wake one need. This chapter makes sure
+that stays true when two needs are in flight at once, by pinning the decision to a
+fact carried *on the signal itself*, not to timing or arrival order.
+
 ## Learning objective
 
 Watch the Store's own wake gate (`store_wake_gate`, the exact mechanism
@@ -21,7 +35,7 @@ belongs to which outcome.
 ## The exercise
 
 ```bash
-python book/ch10_one_signal_wakes_one_need/solution.py --root /tmp/andrea-ch10
+python book/ch10_one_signal_wakes_one_need/solution.py --root /tmp/lucy-ch10
 ```
 
 Read the file first. Two outcomes are created, one per SKU. Two sales
@@ -67,7 +81,7 @@ Three facts this run proves:
 Confirm it yourself:
 
 ```bash
-sqlite3 /tmp/andrea-ch10/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch10/.sovereign/organization.db <<'SQL'
 SELECT wd.source_signal_id, wd.subject, po.sow_id
 FROM pulse_wake_decisions wd JOIN pulse_origins po ON po.wake_decision_id = wd.id
 ORDER BY wd.decided_at;
@@ -100,10 +114,10 @@ Expected: all pass.
 
 ## Where to look next
 
-- `src/reference_organizations/store/pulse_gate.py` — `store_wake_gate`,
-  unchanged since Unit 9, now proven across two SKUs
+- `src/reference_organizations/store/pulse_gate.py` — `store_wake_gate`, the
+  same gate from Chapter 7, now proven across two SKUs at once
 - `tests/test_store_multi_sku.py` — the wake-decision-isolation and
-  Pulse-origin-isolation tests this chapter's own proof extends
+  Pulse-origin-isolation tests this chapter's proof extends
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/ch11_replenishment_scales_without_losing_governance/README.md
@@ -1,5 +1,18 @@
 # Chapter 11 — Replenishment scales without losing governance
 
+Here is the failure mode that ends most "it works!" demos: the guarantee that
+held beautifully for one order quietly breaks the first time two orders run at
+once. Two restocks in flight, and an effect meant for vanilla lands on chocolate;
+or a retried order double-charges because "we already did this" was checked in
+Python a heartbeat too late. A guarantee that only holds when the shop is quiet is
+worse than no guarantee at all, because you will have learned to trust it.
+
+So this chapter does the unglamorous, essential thing: it runs *two* complete
+governed replenishment chains — every step you have built, from the self-woken
+signal all the way to acceptance — and checks that every property still holds with
+two SKUs in play. Nothing new is introduced. That is the point: scaling should
+add products, not exceptions.
+
 ## Learning objective
 
 Run TWO full governed replenishment chains to completion — Pulse-created
@@ -18,7 +31,7 @@ wake gate, Pulse) and proves they compose correctly at more than one SKU.
 ## The exercise
 
 ```bash
-python book/ch11_replenishment_scales_without_losing_governance/solution.py --root /tmp/andrea-ch11
+python book/ch11_replenishment_scales_without_losing_governance/solution.py --root /tmp/lucy-ch11
 ```
 
 Read the file first. Both SKUs' signals fire, both get their own canonical
@@ -59,7 +72,7 @@ Three facts this run proves:
 1. **`second_call_idempotent_replay: true`, for BOTH SKUs.** Calling
    `apply_restock` a second time with the SAME assignment id never moves
    inventory or cash twice — `effects`' own `UNIQUE(assignment_id, kind,
-   subject)` constraint (unchanged since before this unit) refuses the
+   subject)` constraint (the same constraint from the single-SKU case) refuses the
    second write and returns the first call's own recorded payload instead.
    This is not new behavior; this chapter proves it still holds with two
    assignments in play, not one.
@@ -75,7 +88,7 @@ Three facts this run proves:
 Confirm it yourself:
 
 ```bash
-sqlite3 /tmp/andrea-ch11/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch11/.sovereign/organization.db <<'SQL'
 SELECT assignment_id, subject, kind FROM effects ORDER BY created_at;
 SELECT id, state FROM outcomes ORDER BY id;
 SQL
@@ -118,8 +131,8 @@ exercise cannot demonstrate by itself.
 - `tests/test_store_multi_sku.py` — the full isolation matrix, including
   the real two-connection concurrency proof this chapter's own exercise
   cannot show by itself
-- `docs/v1-unit9-pulse-proactive-work.md` — the canonical-creation
-  transaction this chapter's own Pulse pass relies on, unchanged
+- `tests/test_store_multi_sku.py::...racing_two_different_skus...` — the
+  canonical-creation transaction under genuine concurrent pressure
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/ch11_replenishment_scales_without_losing_governance/README.md
@@ -13,6 +13,15 @@ signal all the way to acceptance — and checks that every property still holds 
 two SKUs in play. Nothing new is introduced. That is the point: scaling should
 add products, not exceptions.
 
+One honest caveat about *how* it checks. This chapter's own exercise runs the two
+chains **sequentially**, one after the other — enough to prove the ledger keeps
+each SKU's effects, idempotency, and acceptance separate. The sharper property —
+that two chains running *genuinely at the same time*, on two database connections,
+still produce exactly one canonical effect each — is proven by a dedicated
+two-connection concurrency test named in the verification command below, not by
+this sequential run. The referenced test is where the race actually happens; the
+prose here does not pretend the sequential exercise demonstrates simultaneity.
+
 ## Learning objective
 
 Run TWO full governed replenishment chains to completion — Pulse-created

--- a/book/ch12_the_pilot_begins_with_a_receipt/README.md
+++ b/book/ch12_the_pilot_begins_with_a_receipt/README.md
@@ -1,8 +1,22 @@
 # Chapter 12 — The pilot begins with a receipt
 
+Lucy is ready to let the organization run her shop for real — a trial period, a
+pilot. It is the moment everything has been building toward, and it is exactly the
+moment a lesser system would start lying. "Pilot started!" it would announce, and
+a week later nobody could say for sure whether it actually had, or whether it had
+quietly finished, or stalled, or half-begun twice.
+
+This final chapter builds the smallest, most careful version of that first step —
+and spends as much energy on what it *doesn't* prove as on what it does. Starting
+a pilot leaves a receipt: a durable, queryable record that it began. That receipt
+says nothing about whether the pilot has *finished*, and — crucially — the system
+does not pretend otherwise, because the machinery to check completion does not
+exist. A book about telling the truth ends by drawing the exact line between what
+has been proven and what has not.
+
 ## Learning objective
 
-Run the pilot-start mechanism this unit builds, against a disposable
+Run the pilot-start mechanism, against a disposable
 exercise identity, and read back the durable record and event it produces —
 then understand precisely why that record proves the pilot **started** and
 proves nothing at all about whether it has **finished**.
@@ -26,7 +40,7 @@ a separate, later, separately-authorized act, entirely outside this book.
 ## The exercise
 
 ```bash
-python book/ch12_the_pilot_begins_with_a_receipt/solution.py --root /tmp/andrea-ch12
+python book/ch12_the_pilot_begins_with_a_receipt/solution.py --root /tmp/lucy-ch12
 ```
 
 Read the file first, and read `EXERCISE_PILOT_ID`'s own comment before
@@ -75,13 +89,12 @@ Four facts this run proves:
    — read directly from the `pilots` table after both calls.
 4. **`no_completion_table_exists: true`.** This is the honesty check this
    chapter's own title promises: nothing in this database claims the pilot
-   is finished, because nothing CAN — that mechanism does not exist in this
-   unit.
+   is finished, because nothing CAN — that mechanism does not exist yet.
 
 Confirm it yourself:
 
 ```bash
-sqlite3 /tmp/andrea-ch12/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch12/.sovereign/organization.db <<'SQL'
 SELECT pilot_id, started_at, store_org_id FROM pilots;
 SELECT pilot_id FROM active_pilot;
 SELECT COUNT(*) FROM events WHERE kind = 'pilot.started';
@@ -125,18 +138,18 @@ one slice of that proof matrix, running.
   `active_pilot_id`, the full mechanism
 - `src/sovereign_agent/database.py` — migration 16, the `pilots` and
   `active_pilot` schema
-- `tests/test_pilot.py` — the full pilot-start proof matrix, including real
-  two-connection concurrency for both the same-identity and different-
-  identity cases
-- `docs/v1-unit11-store-expansion-pilot-start.md` — the full contract,
-  including an explicit statement that the real pilot-start act was **not**
-  performed by this unit
+- `tests/test_pilot.py` — the full pilot-start proof matrix: the
+  different-identity refusal and the two-connection race, which together show
+  the pilot's identity is claimed exactly once, atomically, or not at all
 
 `solution.py` imports the production package rather than copying it.
 
-You have now completed all twelve chapters. The real 30-day Store pilot has
-not started — only this chapter's own disposable exercise identity has.
-Starting the real pilot, finishing it, assembling and accepting its
-redacted proof pack, and everything after that is Unit 12's own future
-territory, the same way this book has named its own gaps honestly at every
-chapter boundary before this one.
+You have now completed all twelve chapters — and built, from an empty
+directory, an organization that remembers, refuses, fences, recovers, wakes
+itself, scales, and can begin a pilot without lying about it. That last verb is
+the one that matters. At every boundary this book named exactly what it had not
+yet done, and it ends the same way: the real, live 30-day pilot has not started
+here — only a disposable exercise identity has. Starting it for real, running it,
+and judging whether it succeeded are the next work, beyond this book. Knowing
+precisely where the proven part ends is not a limitation of the system. It is the
+system.

--- a/book/ch12_the_pilot_begins_with_a_receipt/README.md
+++ b/book/ch12_the_pilot_begins_with_a_receipt/README.md
@@ -21,12 +21,16 @@ exercise identity, and read back the durable record and event it produces —
 then understand precisely why that record proves the pilot **started** and
 proves nothing at all about whether it has **finished**.
 
-**This chapter never touches the real named pilot organization.** The
-identity this exercise uses, `book-ch12-exercise-pilot`, is structurally
-distinct from any real pilot identity: it is a fixture value, reserved for
-this exercise, that appears nowhere in this project's own real-pilot
-tooling — because no real-pilot tooling exists yet. The real pilot start is
-a separate, later, separately-authorized act, entirely outside this book.
+**A precise word on safety, because this is a book about not overstating things.**
+The identity this exercise uses, `book-ch12-exercise-pilot`, carries a reserved
+`book-ch12-exercise-` prefix, so it **cannot be confused with the real named
+pilot** — the ids are distinguishable by inspection. What the exercise does *not*
+do is constrain where it writes: `solution.py` opens whatever `--root` you give
+it. The documented command below uses a throwaway `/tmp` path, and you should keep
+it that way — point it at a real organization's database and it would write this
+exercise pilot there. The safety here is "the id is unmistakable and the default
+path is disposable," not "it is impossible by construction." The real pilot start
+is a separate, later, separately-authorized act, entirely outside this book.
 
 ## Vocabulary this chapter adds
 
@@ -43,9 +47,9 @@ a separate, later, separately-authorized act, entirely outside this book.
 python book/ch12_the_pilot_begins_with_a_receipt/solution.py --root /tmp/lucy-ch12
 ```
 
-Read the file first, and read `EXERCISE_PILOT_ID`'s own comment before
-running anything: the whole point of this chapter is that its own exercise
-can never reach a real pilot, by construction, not merely by convention.
+Read the file first, and read `EXERCISE_PILOT_ID`'s own comment before running
+anything: the exercise id is unmistakable and the documented path is disposable —
+keep the `/tmp` root so this writes only to a throwaway database.
 
 ## Expected observations
 
@@ -87,9 +91,16 @@ Four facts this run proves:
    pilot's own identity.
 3. **`pilots_row_count: 1`.** Not a count this exercise computed in Python
    — read directly from the `pilots` table after both calls.
-4. **`no_completion_table_exists: true`.** This is the honesty check this
-   chapter's own title promises: nothing in this database claims the pilot
-   is finished, because nothing CAN — that mechanism does not exist yet.
+4. **`no_completion_table_exists: true`.** Read this claim exactly as narrow as
+   it is: *no table whose name matches the completion pattern exists* in this
+   database. That is a weak check on purpose, and worth being honest about — a
+   completion mechanism hiding in a status column, an event kind, or a
+   differently-named table would slip right past a table-name search. What this
+   chapter can say truthfully is that it starts a pilot and makes no claim about
+   finishing one, because it implements no completion step. Proving the *absence*
+   of a capability rigorously would need an explicit supported-capabilities
+   contract, not a name match — a good example of not letting a detector claim
+   more than it measures.
 
 Confirm it yourself:
 


### PR DESCRIPTION
**For Master/Principal re-review at a new head.** This is an honest **narrative + correctness pass**, explicitly **not** the full Raschka-depth book yet. It responds to the Principal review (msg_2d8bc13c) by fixing every correctness/gate blocker first.

## Blockers fixed
1. **CI red → green.** ch03's inline Python is reformatted; `ruff format --check book` exit 0, `ruff check book` clean, `verify_curriculum` green. (`make verify`'s ruff step was the failure.)
2. **ch03 rebuilt on the real architecture.** The prior ch03 taught the *inverse* of production. It now teaches the actual model: an actor **has** a `provider` field (`models.py`), `rebind_actor` mutates it and records an event (`organization.py`), and authority is granted by **role** via `ROLE_AUTHORITY` + `require_authority` (`policy.py`) — whose refusal message *is* the thesis. Naive-then-broken opening, edge-case table, graded exercises with solutions.
3. **Dev-process leaks removed** (ch00 "an earlier version…", ch02 internal-ruling link).
4. **ch04** states the boundary scope adjacent to the claim (`organization_root_excluding_workspace_and_ledger`, not arbitrary host writes).
5. **ch07** separates signal-driven decision, one Pulse tick, and an external scheduler; claims only what the repo supplies (no unattended liveness).
6. **ch09** stops calling different-quantity sales "identical."
7. **ch11** states the exercise is sequential and the race is proven by the named test.
8. **ch12** drops "cannot touch a real pilot by construction" (it opens any `--root`) and narrows the completion claim to the name-pattern it actually checks.

## Honest status against the filed standard
- **Not** full-depth. Chapters are ~16k words vs the ~91k target; only ch03 has inline build-from-scratch Python. The other twelve remain run/inspect-`solution.py` in structure.
- What is true now: the book is **correct and honest** — no chapter claims more than the bytes support — CI-green, and ch03 is a correct exemplar of the target shape.
- **Remaining (large, forward):** the per-chapter deepening map + 8-part rubric — inline cumulative build per chapter, naive-then-broken, an executable snippet/expected-output gate (Master to add), and depth to the word/structure target. Each is its own reviewable head.

Fixes land as focused commits. Any new head requires fresh review, per the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)