### PR TITLE
Book depth v2 — full deepening against the Principal's curriculum direction (in progress)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: python scripts/verify_source_budget.py
       - name: Verify the curriculum is runnable
         run: python scripts/verify_curriculum.py
+      - name: Verify the book's python snippets actually run
+        run: python scripts/verify_book_snippets.py
       - name: Verify offline commands
         run: |
           sovereign-agent --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         run: python scripts/verify_curriculum.py
       - name: Verify the book's python snippets actually run
         run: python scripts/verify_book_snippets.py
+      - name: Verify the book's depth-coverage manifest
+        run: python scripts/verify_book_depth.py
       - name: Verify offline commands
         run: |
           sovereign-agent --help

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ verify: lint test
 	$(UV) run --python 3.14 python scripts/verify_runtime_dependencies.py
 	$(UV) run --python 3.14 python scripts/verify_source_budget.py
 	$(UV) run --python 3.14 python scripts/verify_book_snippets.py
+	$(UV) run --python 3.14 python scripts/verify_book_depth.py
 	$(UV) run --python 3.14 sovereign-agent --help >/dev/null
 	$(UV) run --python 3.14 sovereign-agent doctor
 	$(UV) run --python 3.14 sovereign-agent demo store --mode simulated --root /tmp/sovereign-agent-demo

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ doctor:
 verify: lint test
 	$(UV) run --python 3.14 python scripts/verify_runtime_dependencies.py
 	$(UV) run --python 3.14 python scripts/verify_source_budget.py
+	$(UV) run --python 3.14 python scripts/verify_book_snippets.py
 	$(UV) run --python 3.14 sovereign-agent --help >/dev/null
 	$(UV) run --python 3.14 sovereign-agent doctor
 	$(UV) run --python 3.14 sovereign-agent demo store --mode simulated --root /tmp/sovereign-agent-demo

--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -126,10 +126,12 @@ entire subject of this book.
 
 ## Why this is not a toy
 
-An earlier version of this exact demo once printed `ACCEPTED` while the shelf sat
-below its reorder point. Every governance record existed — outcome, statement of
-work, assignment, review, acceptance — and the shelf was still empty. The
-paperwork was perfect and the claim was false.
+It is easy — the default, really — to build a system that prints `ACCEPTED`
+while the shelf sits below its reorder point. Every governance record can exist —
+outcome, statement of work, assignment, review, acceptance — and the shelf can
+still be empty. The paperwork is perfect and the claim is false. That is the
+normal outcome when "accepted" is a status someone sets rather than a fact
+someone proved.
 
 That is the failure this book is built to prevent. An organization that cannot
 tell you the difference between "we did the work" and "we filed the forms" will

--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -1,165 +1,201 @@
-# Chapter 0 — Andrea's first shift
+# Chapter 0 — Lucy's First Shift
+
+Meet Lucy. She runs a small ice cream shop, and over the course of this book she
+is going to hand more and more of its dull, repetitive work to a governed AI
+organization you will build from nothing. Before you build it, though, you should
+see the finished shape *once* — the way you glance at a completed jigsaw on the
+box before you tip the pieces out.
+
+So this chapter is a guided tour. You will run a small, self-contained shop that
+ships with the framework, watch it carry one piece of work from start to finish,
+and — this is the part that matters — **check whether it told you the truth.**
+
+> It is fine if this chapter feels like magic. Chapters 1 to 3 take the magic
+> apart, one decision at a time. What matters here is that you see the whole
+> shape once, and that you leave believing one specific thing: that the word
+> `ACCEPTED` in this system is a *claim the code proved*, not a status string
+> someone felt like printing.
 
 ## Learning objective
 
 Run a Zero-Employee Organization through one complete piece of work, and learn
-that `ACCEPTED` is a **claim the system proved**, not a status string someone
-felt like printing.
-
-It is fine if this chapter feels like magic. Chapters 1 to 3 take the magic
-apart. What matters here is that you see the whole shape once.
+to tell the difference between **a fact about the process** ("the paperwork says
+done") and **a fact about the world** ("the shelf is actually full"). By the end
+you will have made the system say `ACCEPTED`, then broken the underlying data by
+hand and watched an independent check *catch the lie*.
 
 ## The exercise
 
+The shop that ships with the framework is a tiny store. Run its full loop once,
+with no API keys, no network, and no model — it uses a deterministic `scripted`
+stand-in so the result is identical on every machine:
+
 ```bash
 sovereign-agent doctor
-sovereign-agent demo store --mode simulated --root /tmp/andrea-shift
+sovereign-agent demo store --mode simulated --root /tmp/first-shift
 ```
 
-No API keys. No network. No provider subscription. `doctor` will tell you which
-provider CLIs you happen to have installed, and the demo does not need any of
-them: it uses the `scripted` provider, which is a deterministic fixture.
+`doctor` tells you which provider CLIs you happen to have installed; the demo
+needs none of them. (From Chapter 3 onward you will run the shop with a real
+local model instead of the stand-in — but not yet. One shape at a time.)
 
-## What the organization did
+## What the organization just did
+
+Read this as a story; every arrow is one governed step:
 
 ```text
-a customer buys 2 boxes of tea
-  → inventory drops to 2, below the reorder point of 3
+a customer buys 2 units
+  → inventory drops below the reorder point
   → the organization records a durable signal: "stock is low"
-  → the Principal's outcome says: keep the tea jar stocked
-  → a Master writes a SOW and assigns it to an Operator actor
-  → the Operator's provider PROPOSES restocking 6 boxes
-  → deterministic Python VALIDATES the proposal and commits the purchase
+  → the Principal's outcome says: keep the shelf stocked
+  → a Master writes a statement of work and assigns it to an Operator actor
+  → the Operator's provider PROPOSES a restock quantity
+  → deterministic Python VALIDATES that proposal and commits the purchase
   → inventory, cash, and the event all commit together, or not at all
   → a Verifier runs the acceptance checks and records evidence
-  → Sparring reviews the work (a different actor than the one who did it)
+  → Sparring reviews the work — a different actor than the one who did it
   → the Principal accepts
 ```
 
+Notice how many *different* roles touched that work, and that the one who *did*
+it is not the one who *approved* it. That separation is not decoration; it is the
+spine of the whole book, and Chapter 3 is devoted to why it must hold even when
+the "worker" is a language model.
+
 ## Expected observations
 
-You should see:
+You should see, at the end:
 
 ```text
-out_...  ACCEPTED  Keep the tea jar stocked
+out_...  ACCEPTED  Keep the shelf stocked
   sow_...  ACCEPTED  Manually dispatched replenishment after signal sig_...
 outcome ACCEPTED
 ```
 
-Now confirm the organization is telling the truth.
+Now do the thing most systems never let you do: **confirm the organization is
+telling the truth.** The database is plain SQLite — open it and look:
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
-  "SELECT sku, on_hand, reorder_point FROM inventory;"
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
+  "SELECT on_hand, reorder_point FROM inventory;"
 ```
 
-Expected: `SKU-TEA|8|3`. On-hand is **at or above** the reorder point. The tea
-jar is genuinely full.
+On-hand is **at or above** the reorder point — the shelf is genuinely stocked.
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
   "SELECT id, amount_cents FROM cash_entries;"
 ```
 
-Expected: three rows — an opening balance of `10000`, a sale of `+800`, and a
-purchase of `-720`. Money left the organization to buy the stock. Six boxes at
-120 cents each is exactly 720.
+Three rows: an opening balance, a sale, and a purchase. Real money left the
+organization to buy the stock, and the arithmetic reconciles.
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
   "SELECT kind FROM events ORDER BY seq;"
 ```
 
-Expected: a `replenishment.committed` event sitting between
-`assignment.finished` and `sow.reviewed`.
+A `replenishment.committed` event sits between `assignment.finished` and
+`sow.reviewed` — the durable trace of what happened, in order.
 
-## Learner verification command
+## The whole point: break it, and watch the lie get caught
 
-One command that checks all of it at once:
-
-```bash
-python scripts/verify_store_outcome.py /tmp/andrea-shift
-```
-
-It exits 0 only if the accepted outcome is actually true. Try breaking it:
+Here is the exercise that earns this chapter its place. One command checks that
+the accepted outcome is *actually true*:
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
-  "UPDATE inventory SET on_hand = 0 WHERE sku = 'SKU-TEA';"
-python scripts/verify_store_outcome.py /tmp/andrea-shift
+python scripts/verify_store_outcome.py /tmp/first-shift
 ```
 
-Now it fails, and says why. The status field still reads `ACCEPTED`, because
-that is a historical record of a decision — but the verifier checks the *world*,
-and the world no longer matches. That gap is the whole subject of this book.
+It exits `0` only if reality matches the claim. Now sabotage reality by hand and
+run it again:
+
+```bash
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
+  "UPDATE inventory SET on_hand = 0 WHERE on_hand > 0;"
+python scripts/verify_store_outcome.py /tmp/first-shift
+```
+
+It **fails**, with exit code `1`, and tells you why. The status field still reads
+`ACCEPTED`, because that is a historical record of a decision that really was
+made — but the verifier does not read the status field. It reads *the world*, and
+the world no longer matches the claim.
+
+That gap — between "we filed the forms" and "the work is actually done" — is the
+entire subject of this book.
 
 ## Why this is not a toy
 
-An earlier version of this exact demo printed `ACCEPTED` while the tea jar sat
-at 2 boxes against a reorder point of 3. Every governance record existed —
-outcome, SOW, assignment, review, acceptance — and the shelf was still empty.
-The paperwork was perfect and the claim was false.
+An earlier version of this exact demo once printed `ACCEPTED` while the shelf sat
+below its reorder point. Every governance record existed — outcome, statement of
+work, assignment, review, acceptance — and the shelf was still empty. The
+paperwork was perfect and the claim was false.
 
-That is the failure this book is about. An organization that cannot tell you
-the difference between "we did the work" and "we filed the forms" will
-confidently tell you the forms are the work.
+That is the failure this book is built to prevent. An organization that cannot
+tell you the difference between "we did the work" and "we filed the forms" will
+confidently tell you the forms *are* the work. A governed organization refuses to
+conflate them, and it lets you check.
 
 ## Why nothing happened until you typed
 
 Worth noticing before you move on: **you** started this. The sale, the signal,
 the statement of work, the restock — none of it began until you ran a command.
 
-The organization has no heartbeat yet. It cannot notice that stock fell, or
-decide on its own that the tea needs reordering. Every step you just watched was
-dispatched because the demo dispatched it.
-
-That capacity — the organization waking itself and creating work with nobody
-prompting it — is called **Pulse**. This exercise does not run it: the demo
-above dispatches every step by hand, and no event in the ledger you just
-inspected pretends otherwise. You can check that claim the same way you
-checked the others:
+The organization has no heartbeat yet. It cannot notice on its own that stock
+fell and decide to reorder. Every step you just watched was dispatched because
+the demo dispatched it, by hand. You can confirm that claim the same way you
+checked the others — by reading the ledger:
 
 ```bash
-sqlite3 /tmp/andrea-shift/.sovereign/organization.db \
+sqlite3 /tmp/first-shift/.sovereign/organization.db \
   "SELECT DISTINCT kind FROM events ORDER BY kind;"
 ```
 
-Every `kind` describes something a human or a governed actor did. There is no
-`pulse.*` anywhere in THIS run, because this exercise never calls Pulse.
+Every `kind` describes something a human or a governed actor did on purpose. The
+capacity for an organization to wake *itself* and create work with nobody
+prompting it is a real and separate mechanism you will meet much later in the
+book; this first shift deliberately does not use it, and — importantly — nothing
+in the ledger you just read pretends otherwise. Knowing what a system cannot yet
+do is part of knowing what it does.
 
-**Added, Unit 9:** Pulse is now real, as a separate mechanism you invoke
-yourself with `sovereign-agent pulse --once --root PATH` — it is not this
-chapter's exercise, and it never runs itself. See
-`docs/v1-unit9-pulse-proactive-work.md` for the sale-to-proactive-work slice
-this chapter's own dispatched-by-hand version is contrasted against.
+## Learner verification command
 
-Knowing what a system cannot yet do is part of knowing what it does.
+The single command that checks all of it at once:
+
+```bash
+python scripts/verify_store_outcome.py /tmp/first-shift
+```
+
+Exit `0` means the accepted outcome is genuinely true; exit `1` means it is not,
+and the message says which check failed. (If you ran the sabotage step above,
+re-run the demo into a fresh `--root` to get a clean `0` again.)
 
 ## Explain it back
 
 Answer these in your own words before moving on. If you cannot, re-read the
-observations above — the answers are all visible in the database.
+observations — every answer is visible in the database.
 
 1. The demo printed `ACCEPTED`. What would you check, and in what order, to
    decide for yourself whether that word is earned?
-2. The provider asked for 6 boxes. Where did the *price* of those boxes come
-   from — the provider, or somewhere else? Why does that distinction matter?
-3. `sparring-course` reviewed the work and `principal-human` accepted it. Why
-   not let `operator-course`, who did the work, do either of those?
-4. Which of these is a fact about the world, and which is a fact about the
-   process: "inventory is at 8" versus "the SOW is in state ACCEPTED"?
+2. The provider asked for a certain restock quantity. Where did the *price* of
+   those units come from — the provider, or somewhere else? Why does that
+   distinction matter?
+3. A Sparring actor reviewed the work and the Principal accepted it. Why not let
+   the Operator who *did* the work do either of those?
+4. Which of these is a fact about the world, and which about the process:
+   "on-hand is 8" versus "the statement of work is in state ACCEPTED"?
 5. Nothing happened until you typed a command. What would have to exist for the
-   organization to start this work on its own, and why is it honest that the
-   ledger contains no `pulse.*` event today?
+   organization to start this work on its own, and why is it honest that today's
+   ledger contains no sign of it?
 
 ## Where to look next
 
 - `governance/outcomes/*/outcome.json` — the outcome, projected for reading
-- `governance/outcomes/*/README.md` — the same thing, generated for humans
 - `.sovereign/organization.db` — the authority for everything operational
 - `.sovereign/runs/*/.sovereign-out/report.json` — what the provider proposed
 - `.sovereign/runs/*/receipt.json` — what the organization recorded about the run
 
-`solution.py` imports the production demo rather than copying it.
+`solution.py` imports the production demo rather than copying it, so the shape
+you toured here is the same code the rest of the book builds toward.
 
 Next: [Chapter 1 — The organization remembers](../ch01_organization_remembers/README.md)

--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -36,8 +36,9 @@ sovereign-agent demo store --mode simulated --root /tmp/first-shift
 ```
 
 `doctor` tells you which provider CLIs you happen to have installed; the demo
-needs none of them. (From Chapter 3 onward you will run the shop with a real
-local model instead of the stand-in — but not yet. One shape at a time.)
+needs none of them. (In Chapter 3 you will swap a real local model in for the
+stand-in — as a governed act, optional, with the stand-in always available as a
+fallback — but not yet. One shape at a time.)
 
 ## What the organization just did
 
@@ -47,7 +48,7 @@ Read this as a story; every arrow is one governed step:
 a customer buys 2 units
   → inventory drops below the reorder point
   → the organization records a durable signal: "stock is low"
-  → the Principal's outcome says: keep the shelf stocked
+  → the Principal's outcome says: keep the tea jar stocked
   → a Master writes a statement of work and assigns it to an Operator actor
   → the Operator's provider PROPOSES a restock quantity
   → deterministic Python VALIDATES that proposal and commits the purchase
@@ -67,7 +68,7 @@ the "worker" is a language model.
 You should see, at the end:
 
 ```text
-out_...  ACCEPTED  Keep the shelf stocked
+out_...  ACCEPTED  Keep the tea jar stocked
   sow_...  ACCEPTED  Manually dispatched replenishment after signal sig_...
 outcome ACCEPTED
 ```
@@ -116,7 +117,18 @@ sqlite3 /tmp/first-shift/.sovereign/organization.db \
 python scripts/verify_store_outcome.py /tmp/first-shift
 ```
 
-It **fails**, with exit code `1`, and tells you why. The status field still reads
+It **fails**, with exit code `1`, and tells you why — this transcript is from a
+real run of exactly the commands above:
+
+```text
+FAIL: check 'inventory_at_or_above_reorder_point' does not hold now: available=0 (on_hand=0 - reserved=0) vs reorder_point=3
+FAIL: inventory 0 is below reorder point 3
+FAIL: evidence for 'inventory_at_or_above_reorder_point' is stale relative to current state
+
+3 problem(s): this outcome is NOT truthfully accepted.
+```
+
+The status field still reads
 `ACCEPTED`, because that is a historical record of a decision that really was
 made — but the verifier does not read the status field. It reads *the world*, and
 the world no longer matches the claim.
@@ -189,6 +201,40 @@ observations — every answer is visible in the database.
 5. Nothing happened until you typed a command. What would have to exist for the
    organization to start this work on its own, and why is it honest that today's
    ledger contains no sign of it?
+
+## The road from here — what you will actually build
+
+Every chapter after this one follows the same honest rhythm: you **build** the
+mechanism yourself in small runnable pieces, you **break** a naive version of it
+and watch the failure with your own eyes, and you **repair** it into the shape
+production uses — then the chapter names, precisely, what it has *not* proven.
+Every code block in this book executes, and every printed output you will read
+was produced by that code, byte for byte. The tour you just took visits each of
+these once:
+
+| Chapter | You build | You break |
+| --- | --- | --- |
+| 1 — The organization remembers | The ledger: schema, append-only triggers, migrations that commit whole | A migration that half-applies and leaves wreckage a `with db:` block cannot roll back |
+| 2 — Work needs governance | Acceptance as composed, checked obligations | The status-flip: a system that "accepts" work by setting a field to `ACCEPTED` |
+| 3 — An actor is not a model | Actors whose authority comes from role, not provider; a governed model swap | A sharp new model trying to approve its own work — and being refused |
+| 4 — Work stays inside its boundary | The workspace boundary | Path escapes that try to write outside it |
+| 5 — Authority needs a fence | Fencing tokens, compare-and-swap, leases | The stale actor that still *thinks* it holds authority |
+| 6 — The organization recovers | Supervised recovery from lost workers | A "kind" recoverer that quietly lies about what it restored |
+| 7 — The organization wakes itself | The pulse: the heartbeat this first shift honestly lacked | A tick that orders twice for one signal |
+| 8 — The store becomes a catalog | A migration on *populated* data, and validated seeding | A mid-migration fault — and the old data untouched afterward |
+| 9 — Each product has its own threshold | A sale as five writes in one transaction | The oversell: on-hand driven below zero by a stale read |
+| 10 — One signal wakes one need | Causal binding: *this* run caused *that* effect | A checker satisfied that "run-t did something" when run-t did nothing |
+| 11 — Replenishment scales | Idempotent restock claims | The double-order, reproduced to the digit |
+| 12 — The pilot begins with a receipt | The pilot-start contract and the release proof pack | A forged pack the verifier *correctly* calls internally consistent |
+
+That last row is the destination, so hear it now, once: chapter by chapter you
+will make the organization better at proving things — and the book ends by
+showing you the proof that *cannot* be strengthened from the inside. A proof
+pack whose every byte agrees with itself can still be a fabrication; internal
+consistency is not authenticity. The verifier you ran today already lives on the
+right side of that line — it reads the world, not the paperwork — and the whole
+book is the discipline of keeping every claim on that side, and saying so
+plainly whenever one is not.
 
 ## Where to look next
 

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -35,6 +35,137 @@ then "we ordered it" is a hope, not a fact.
 So the first question is not "how does the AI decide" — it is "where does the
 truth live, and what happens when the power goes out mid-sentence".
 
+## Build it yourself: memory that cannot half-happen
+
+Before you inspect the production database, build the core of it from scratch, so
+that when you see the real thing you recognize every piece. Everything below runs
+in a throwaway in-memory SQLite database — paste it into a Python shell.
+
+Start with the smallest schema that can hold a shop's operational truth: what is
+on the shelf, every movement of money, and a log of what happened.
+
+```python
+import sqlite3
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE inventory (
+        sku TEXT PRIMARY KEY,
+        on_hand INTEGER NOT NULL,
+        reorder_point INTEGER NOT NULL
+    );
+    CREATE TABLE cash_entries (id INTEGER PRIMARY KEY, amount_cents INTEGER NOT NULL);
+    CREATE TABLE events (seq INTEGER PRIMARY KEY, kind TEXT NOT NULL);
+""")
+db.execute("INSERT INTO inventory VALUES ('SKU-VANILLA', 4, 3)")
+db.execute("INSERT INTO cash_entries(amount_cents) VALUES (10000)")  # opening balance
+db.commit()
+```
+
+Notice the shape of `cash_entries`: it is a **ledger of signed movements**, not a
+single balance field. The balance is `SUM(amount_cents)`. Nothing ever overwrites
+a number, so no bug can silently lose money — the worst a mistake can do is add a
+wrong row, which you can see and correct, never erase a right one.
+
+Now the append-only guarantee for the event log, enforced by the *database*, not
+by Python remembering to be careful:
+
+```python
+db.executescript("""
+    CREATE TRIGGER events_no_update BEFORE UPDATE ON events
+    BEGIN SELECT RAISE(ABORT, 'events are append-only: update refused'); END;
+    CREATE TRIGGER events_no_delete BEFORE DELETE ON events
+    BEGIN SELECT RAISE(ABORT, 'events are append-only: delete refused'); END;
+""")
+db.execute("INSERT INTO events(kind) VALUES ('sale.committed')")
+db.commit()
+
+try:
+    db.execute("UPDATE events SET kind = 'NOTHING_HAPPENED'")
+except sqlite3.IntegrityError as error:
+    print("refused:", error)
+```
+
+```text
+refused: events are append-only: update refused
+```
+
+A rule in application code protects you from your own bugs. A rule in the database
+protects you from *everything that can reach the database* — including you, at 2am,
+with a shell open. That is why the guard lives here.
+
+### The three-write transaction, and what a rollback buys you
+
+A restock has to change three things together: inventory goes up, cash goes down,
+and an event records it. If only some of those land, the organization is lying to
+itself — a full shelf with no money spent, or money spent with no stock. The tool
+that makes "all or nothing" real is a transaction.
+
+```python
+def restock(db, sku, units, unit_cost):
+    with db:  # commits at the end, or rolls the whole block back on any exception
+        db.execute("UPDATE inventory SET on_hand = on_hand + ? WHERE sku = ?", (units, sku))
+        db.execute("INSERT INTO cash_entries(amount_cents) VALUES (?)", (-units * unit_cost,))
+        db.execute("INSERT INTO events(kind) VALUES ('replenishment.committed')")
+
+
+def state(db):
+    on_hand = db.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-VANILLA'").fetchone()[0]
+    balance = db.execute("SELECT SUM(amount_cents) FROM cash_entries").fetchone()[0]
+    return f"on_hand={on_hand} balance={balance}"
+
+
+print("before:", state(db))
+restock(db, "SKU-VANILLA", 6, 250)
+print("after: ", state(db))
+```
+
+```text
+before: on_hand=4 balance=10000
+after:  on_hand=10 balance=8500
+```
+
+Now break it. Inject a failure *after* inventory and cash have already been
+written but *before* the event — the exact "power cut mid-sentence" case — and
+watch all three writes disappear together:
+
+```python
+def restock_but_crash(db, sku, units, unit_cost):
+    with db:
+        db.execute("UPDATE inventory SET on_hand = on_hand + ? WHERE sku = ?", (units, sku))
+        db.execute("INSERT INTO cash_entries(amount_cents) VALUES (?)", (-units * unit_cost,))
+        raise RuntimeError("power cut before the event was written")
+
+
+print("before:", state(db))
+try:
+    restock_but_crash(db, "SKU-VANILLA", 6, 250)
+except RuntimeError as error:
+    print("failed:", error)
+print("after: ", state(db))
+```
+
+```text
+before: on_hand=10 balance=8500
+failed: power cut before the event was written
+after:  on_hand=10 balance=8500
+```
+
+`before` and `after` are identical. The inventory write had already happened, and
+the rollback took it back. Either all three changes commit or none do — there is
+no in-between state for the shop to be caught in.
+
+### One honest limit: SQLite durability, not magic
+
+The transaction guarantees *atomicity* — all-or-nothing — and, on commit,
+*durability* to the extent SQLite provides it (WAL mode, an `fsync` at commit). Be
+precise about what that does and does not promise: it protects the **database**.
+It cannot make a write to the database and a write to a separate file happen in
+one transaction — those are two systems, and a crash between them can leave them
+disagreeing. The production organization keeps its canonical truth in SQLite for
+exactly this reason, and treats files it writes outside the database as
+projections that can always be regenerated. Chapter 2 makes that boundary sharp.
+
 ## Exercise 1: look at the operational state
 
 ```bash

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -66,9 +66,17 @@ db.commit()
 ```
 
 Notice the shape of `cash_entries`: it is a **ledger of signed movements**, not a
-single balance field. The balance is `SUM(amount_cents)`. Nothing ever overwrites
-a number, so no bug can silently lose money — the worst a mistake can do is add a
-wrong row, which you can see and correct, never erase a right one.
+single balance field. The balance is `SUM(amount_cents)`. Be precise about what
+that shape buys and what it does not. It is an *application accounting
+discipline*: because no code path ever needs to read-modify-write a balance,
+the classic lost-update bug — two writers both computing `balance + delta`
+from the same stale read — has nothing to attack, and an erroneous movement
+is corrected by adding a compensating row you can see, not by editing
+history. What it is **not** is a database-enforced guarantee: unlike
+`events` (whose triggers you will meet in a moment), nothing at the SQLite
+layer stops a raw `UPDATE` or `DELETE` on `cash_entries` — a bug or a 2am
+shell that mutates a cash row directly will succeed. The discipline removes
+the *tempting* mistake; it does not make the table immutable.
 
 Now the append-only guarantee for the event log, enforced by the *database*, not
 by Python remembering to be careful:
@@ -634,7 +642,11 @@ sovereign-agent demo store --mode simulated --root /tmp/lucy-memory
 sqlite3 /tmp/lucy-memory/.sovereign/organization.db ".tables"
 ```
 
-Expected: sixteen tables listed. The ones to care about now:
+Expected: twenty-seven tables listed (count them —
+`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE
+'sqlite_%'` returns 27; the schema has grown well past this chapter's toy,
+which is exactly what the migrations section explains). The ones to care
+about now:
 
 | Table | Holds |
 | --- | --- |
@@ -651,7 +663,11 @@ sqlite3 -header -column /tmp/lucy-memory/.sovereign/organization.db \
 
 Cash is a **ledger of movements**, not a single balance field. The balance is
 `SUM(amount_cents)`: `10000` opening, `+800` from the sale, `-720` for the
-purchase. Nothing overwrites a balance, so nothing can quietly lose money.
+purchase. No supported code path overwrites a movement — corrections are new
+compensating rows — but remember the honest scope from earlier: this is the
+application's discipline, not a trigger-enforced guarantee like the one you
+are about to meet on `events`. Try `UPDATE cash_entries SET amount_cents = 0`
+from this same `sqlite3` shell if you want the difference to sting.
 
 ## Exercise 2: prove the events are append-only
 

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -14,8 +14,11 @@ truth live, and what survives when the power goes out mid-sentence?**
 
 This chapter is hands-on the whole way through. You will open the organization's
 memory, try to corrupt it three different ways, watch a half-finished purchase
-roll itself back, and learn to name — for any piece of data in the system — which
-file or table is the authority for it.
+roll itself back, build a migration runner and watch the naive version poison a
+database forever, catch a status file lying about the freezer, meet a verifier
+that destroys the evidence it was supposed to find, and tear a file in half to
+learn what an atomic write actually promises. By the end you can name — for any
+piece of data in this system — which file or table is the authority for it.
 
 ## Learning objective
 
@@ -164,7 +167,465 @@ It cannot make a write to the database and a write to a separate file happen in
 one transaction — those are two systems, and a crash between them can leave them
 disagreeing. The production organization keeps its canonical truth in SQLite for
 exactly this reason, and treats files it writes outside the database as
-projections that can always be regenerated. Chapter 2 makes that boundary sharp.
+projections that can always be regenerated. You will build that boundary — and
+watch it fail honestly — later in this chapter.
+
+## Growing the schema without losing the shop
+
+The schema you just built is version one of a shop that intends to run for
+years. The freezer will gain products, the organization will gain signals, and
+every one of those changes arrives *after* real money and real history are
+already in the tables. You cannot recreate the database — recreating it would
+be exactly the forgetting this chapter exists to prevent. The mechanism that
+grows a schema underneath live data is a **migration**: a numbered, one-way
+step from schema N to schema N+1.
+
+Build the runner first. It keeps a ledger of which steps have already run —
+memory about the shape of memory — and applies only the missing ones:
+
+```python
+db = sqlite3.connect(":memory:")  # a brand-new shop, from nothing
+
+MIGRATIONS = [
+    (
+        1,
+        [
+            "CREATE TABLE inventory (sku TEXT PRIMARY KEY,"
+            " on_hand INTEGER NOT NULL, reorder_point INTEGER NOT NULL)",
+            "CREATE TABLE cash_entries (id INTEGER PRIMARY KEY, amount_cents INTEGER NOT NULL)",
+            "CREATE TABLE events (seq INTEGER PRIMARY KEY, kind TEXT NOT NULL)",
+        ],
+    ),
+]
+
+
+def migrate(db, migrations):
+    db.execute("CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY)")
+    applied = {row[0] for row in db.execute("SELECT version FROM schema_migrations")}
+    for version, statements in migrations:
+        if version in applied:
+            continue
+        with db:  # ONE transaction per migration: the DDL and the stamp, together
+            for statement in statements:
+                db.execute(statement)
+            db.execute("INSERT INTO schema_migrations(version) VALUES (?)", (version,))
+
+
+migrate(db, MIGRATIONS)
+print("applied:", [row[0] for row in db.execute("SELECT version FROM schema_migrations")])
+```
+
+```text
+applied: [1]
+```
+
+The version stamp goes inside the *same* transaction as the schema change, on
+purpose. If it were a separate write, a crash between the two would leave a
+database whose shape says "migrated" while its stamp says "not yet" — and the
+runner would re-apply a migration that already ran, or skip one that never
+finished. Same lesson as the restock: things that must be true together must
+commit together.
+
+Now the shop runs for a while — rows land — and *then* the business changes.
+Migration 2 arrives with the database already populated: a new `signals` table,
+and a price column the original schema never imagined. The new column needs a
+`DEFAULT` so existing rows stay valid, and a backfill to give them real values:
+
+```python
+db.execute("INSERT INTO inventory VALUES ('SKU-VANILLA', 4, 3)")
+db.execute("INSERT INTO cash_entries(amount_cents) VALUES (10000)")
+db.commit()
+
+MIGRATIONS.append(
+    (
+        2,
+        [
+            "CREATE TABLE signals (id INTEGER PRIMARY KEY, kind TEXT NOT NULL, sku TEXT)",
+            "ALTER TABLE inventory ADD COLUMN unit_price_cents INTEGER NOT NULL DEFAULT 0",
+            "UPDATE inventory SET unit_price_cents = 400",
+        ],
+    )
+)
+migrate(db, MIGRATIONS)
+print("applied:", [row[0] for row in db.execute("SELECT version FROM schema_migrations")])
+print("vanilla:", db.execute("SELECT sku, on_hand, unit_price_cents FROM inventory").fetchone())
+```
+
+```text
+applied: [1, 2]
+vanilla: ('SKU-VANILLA', 4, 400)
+```
+
+Migration 1 was skipped — already stamped — and the vanilla row survived the
+upgrade with a real price. This is the everyday case: schema change as a guest
+in a house where data already lives.
+
+### Break it: the migration that half-happens
+
+Migration 3 has a typo in its second statement. The runner wraps everything in
+`with db:`, so the failure should roll the whole step back — right?
+
+```python
+MIGRATIONS.append(
+    (
+        3,
+        [
+            "CREATE TABLE reservations (id INTEGER PRIMARY KEY, sku TEXT NOT NULL)",
+            "CREATE TABEL oops (id INTEGER)",  # typo: TABEL
+        ],
+    )
+)
+try:
+    migrate(db, MIGRATIONS)
+except sqlite3.OperationalError as error:
+    print("migration 3 failed:", error)
+
+leftovers = db.execute(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('reservations', 'oops')"
+).fetchall()
+print("applied:", [row[0] for row in db.execute("SELECT version FROM schema_migrations")])
+print("left behind:", leftovers)
+```
+
+```text
+migration 3 failed: near "TABEL": syntax error
+applied: [1, 2]
+left behind: [('reservations',)]
+```
+
+Wrong. The version was not stamped — good — but `reservations` **exists**. Half
+the migration escaped the transaction. The reason is subtle and worth knowing
+precisely: Python's `sqlite3` module, in its default mode, only begins its
+implicit transaction before *data* statements (`INSERT`, `UPDATE`, `DELETE`).
+A `CREATE TABLE` runs in autocommit — it commits itself, instantly, outside
+any transaction `with db:` is managing. The context manager rolled back an
+empty transaction and reported nothing, because as far as it knew, nothing had
+happened. The guard looked right and guarded nothing — enforcement did not
+match the claim.
+
+And this database is now poisoned. Fix the typo and run the runner again:
+
+```python
+MIGRATIONS[-1] = (
+    3,
+    ["CREATE TABLE reservations (id INTEGER PRIMARY KEY, sku TEXT NOT NULL)"],
+)
+try:
+    migrate(db, MIGRATIONS)
+except sqlite3.OperationalError as error:
+    print("still broken:", error)
+```
+
+```text
+still broken: table reservations already exists
+```
+
+Version 3 is unstamped, so the runner re-runs it; the table it half-created
+last time is in the way; the migration fails forever. No amount of retrying
+recovers this database. The production code paid for this exact lesson — the
+docstring of `Database.migrate` in `sovereign_agent/database.py` records that
+an early version used `executescript()`, which *commits any open transaction
+before it runs*, and left exactly this kind of orphaned table behind a failed
+migration: "reopening re-ran it and failed forever."
+
+### Repair: an explicit transaction the DDL cannot escape
+
+The fix is to stop trusting the implicit machinery and say what we mean:
+
+```python
+db = sqlite3.connect(":memory:", autocommit=True)  # start the shop over, safely
+
+MIGRATIONS[-1] = (
+    3,
+    [
+        "CREATE TABLE reservations (id INTEGER PRIMARY KEY, sku TEXT NOT NULL)",
+        "CREATE TABEL oops (id INTEGER)",  # the same typo, one more time
+    ],
+)
+
+
+def migrate_safely(db, migrations):
+    db.execute("CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY)")
+    applied = {row[0] for row in db.execute("SELECT version FROM schema_migrations")}
+    for version, statements in migrations:
+        if version in applied:
+            continue
+        db.execute("BEGIN IMMEDIATE")  # explicit: now the DDL joins the transaction
+        try:
+            for statement in statements:
+                db.execute(statement)
+            db.execute("INSERT INTO schema_migrations(version) VALUES (?)", (version,))
+            db.execute("COMMIT")
+        except BaseException:
+            db.execute("ROLLBACK")
+            raise
+
+
+try:
+    migrate_safely(db, MIGRATIONS)
+except sqlite3.OperationalError as error:
+    print("migration 3 failed:", error)
+
+leftovers = db.execute(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('reservations', 'oops')"
+).fetchall()
+print("applied:", [row[0] for row in db.execute("SELECT version FROM schema_migrations")])
+print("left behind:", leftovers)
+```
+
+```text
+migration 3 failed: near "TABEL": syntax error
+applied: [1, 2]
+left behind: []
+```
+
+Same typo, same failure — but this time the failure is *clean*: no stamp, no
+orphaned table. SQLite rolls DDL back like any other statement, as long as the
+DDL is actually inside a transaction. And because failure left nothing behind,
+recovery is now just: fix the typo, run again.
+
+```python
+MIGRATIONS[-1] = (
+    3,
+    ["CREATE TABLE reservations (id INTEGER PRIMARY KEY, sku TEXT NOT NULL)"],
+)
+migrate_safely(db, MIGRATIONS)
+print("applied:", [row[0] for row in db.execute("SELECT version FROM schema_migrations")])
+
+db.execute("INSERT INTO inventory VALUES ('SKU-VANILLA', 4, 3, 400)")
+db.execute("INSERT INTO cash_entries(amount_cents) VALUES (10000)")
+print("vanilla:", db.execute("SELECT sku, on_hand, reorder_point FROM inventory").fetchone())
+```
+
+```text
+applied: [1, 2, 3]
+vanilla: ('SKU-VANILLA', 4, 3)
+```
+
+The production organization runs this same design at full scale:
+`database.py` carries **sixteen** numbered migrations, applied inside an
+explicit `BEGIN IMMEDIATE` exactly as above, with one extra trick —
+`sqlite3.complete_statement` — to split scripts that contain trigger bodies
+(whose internal semicolons a naive `split(";")` would cut in half). Two rules
+travel with the design, both of which you have now seen the reason for:
+
+- **Forward-only.** There is no down-migration. A landed migration is never
+  edited — a change of mind is a *new* migration. This is the append-only
+  events rule, one level up: history you can rewrite is history you cannot
+  trust, and a migration list is the history of the schema.
+- **The stamp commits with the step.** Migration state and schema state can
+  never disagree, because they are one transaction.
+
+`tests/test_persistence.py` — the same file your learner-verification command
+runs — proves both: migrations apply in order, and a populated v1 database
+upgrades without losing its rows.
+
+## Projections: files the ledger can regenerate
+
+Lucy does not read SQL. The organization writes her a status file — Markdown,
+generated from the database, for human eyes. Build it as two deliberately
+separate functions: a **pure** renderer that turns ledger state into bytes and
+writes nothing, and a writer that puts those bytes on disk:
+
+```python
+import pathlib
+import tempfile
+
+shop_root = pathlib.Path(tempfile.mkdtemp())
+
+
+def render_status(db):  # PURE: reads the ledger, returns bytes, writes nothing
+    lines = ["# Shop status"]
+    for sku, on_hand, reorder_point in db.execute(
+        "SELECT sku, on_hand, reorder_point FROM inventory ORDER BY sku"
+    ):
+        level = "OK" if on_hand >= reorder_point else "LOW"
+        lines.append(f"- {sku}: {on_hand} on hand (reorder at {reorder_point}) {level}")
+    return ("\n".join(lines) + "\n").encode()
+
+
+def write_status(db, root):
+    (root / "STATUS.md").write_bytes(render_status(db))
+
+
+write_status(db, shop_root)
+print((shop_root / "STATUS.md").read_text(), end="")
+```
+
+```text
+# Shop status
+- SKU-VANILLA: 4 on hand (reorder at 3) OK
+```
+
+Here is the structural problem, and it is not fixable: the database commit and
+the file write are **two systems**. No transaction spans them. The organization
+therefore writes projections *after* the ledger commits — so a crash between
+the two leaves a stale file and a correct ledger, never the reverse. Stale is
+survivable precisely because the file is a projection: every byte of it can be
+regenerated from the database. But "survivable" only counts if someone
+*notices* the staleness. Nothing reads `STATUS.md` back. Nothing will ever
+notice on its own.
+
+### Break it: the file lies
+
+So build the thing that notices. A verifier compares the file on disk against
+what the pure renderer says it should be — and while we are at it, hand-edit
+the file the way a well-meaning 2am human might:
+
+```python
+def verify_status(db, root):
+    path = root / "STATUS.md"
+    if not path.is_file():
+        return "DRIFT: STATUS.md is missing"
+    if path.read_bytes() != render_status(db):
+        return "DRIFT: STATUS.md does not match the ledger"
+    return "OK"
+
+
+(shop_root / "STATUS.md").write_text("# Shop status\n- SKU-VANILLA: plenty!\n")
+print(verify_status(db, shop_root))
+```
+
+```text
+DRIFT: STATUS.md does not match the ledger
+```
+
+Caught. The freezer is not "plenty!"; the freezer is whatever the ledger says
+it is, and the file is now provably lying about it.
+
+### The verifier that repairs the evidence
+
+Now meet the most dangerous function in this chapter. It looks like a
+diligence improvement — "make sure the file is fresh before checking it":
+
+```python
+def verify_status_helpfully(db, root):
+    write_status(db, root)  # "refresh first, then check" -- the bug
+    return verify_status(db, root)
+
+
+print(verify_status_helpfully(db, shop_root))
+print(verify_status(db, shop_root))  # the tampering is gone -- and so is the evidence
+```
+
+```text
+OK
+OK
+```
+
+Green, and green again. The hand-edit you made a moment ago has been silently
+overwritten; the verifier "found" a world in which nothing was ever wrong,
+because it *wrote* that world first. A verifier that edits reality until it
+agrees with itself is worse than no verifier — no verifier leaves you
+suspicious, this one manufactures confidence. And note the second cost: even
+the *pure* check now passes, because the evidence of drift was destroyed by
+the checker itself.
+
+This is not a hypothetical. The production drift-checker,
+`scripts/verify_projections.py`, opens with exactly this confession: an
+earlier version called the projection writer to learn what the files should
+contain, silently repaired hand-edited files, and then reported "projections
+match the ledger." The current version is built on the rule you should take
+from this section: **verification is pure; repair is a separate, explicit
+act.** In production, `check()` never writes, and repair hides behind an
+explicit `--reconcile` flag.
+
+```python
+def reconcile_status(db, root):
+    write_status(db, root)  # the same write as the bug above -- but invoked ON PURPOSE
+    return "reconciled toward the ledger"
+
+
+(shop_root / "STATUS.md").unlink()  # the missing-projection case
+print(verify_status(db, shop_root))
+print(reconcile_status(db, shop_root))
+print(verify_status(db, shop_root))
+```
+
+```text
+DRIFT: STATUS.md is missing
+reconciled toward the ledger
+OK
+```
+
+Same write, different verb. `verify_status_helpfully` and `reconcile_status`
+execute identical code; the entire difference is *who decided* the write should
+happen. Drift always resolves **toward the database** — the ledger is the
+authority, so the file changes to match it, never the other way around. One
+drift case remains that this toy verifier cannot see: a *stale extra* file — a
+projection for something the ledger no longer contains, left lingering on
+disk. The production checker walks the projection directory and flags exactly
+that; question 7 below asks you why the toy misses it.
+
+## Writing a file without tearing it
+
+One hazard left. Even an honest, ledger-derived projection write can be
+interrupted *mid-write* — and a half-written file is worse than a stale one,
+because nothing about it says "half":
+
+```python
+def write_status_torn(db, root, crash_after_bytes):
+    data = render_status(db)[:crash_after_bytes]  # the power died mid-write
+    (root / "STATUS.md").write_bytes(data)
+
+
+write_status_torn(db, shop_root, crash_after_bytes=20)
+print((shop_root / "STATUS.md").read_text())
+```
+
+```text
+# Shop status
+- SKU-
+```
+
+`- SKU-` is not a status; it is debris that parses as one. The repair is the
+oldest trick in durable systems — never write where readers read. Write the
+whole file *next to* the real one, force it to disk, then swap names in a
+single atomic step:
+
+```python
+import os
+
+
+def write_status_atomically(db, root, crash_before_replace=False):
+    path = root / "STATUS.md"
+    tmp = path.with_name(f".{path.name}.tmp")
+    data = render_status(db)
+    with tmp.open("wb") as handle:
+        handle.write(data[:20] if crash_before_replace else data)
+        handle.flush()
+        os.fsync(handle.fileno())  # the bytes are on disk, not in a cache
+    if crash_before_replace:
+        return  # power died before os.replace: STATUS.md was never touched
+    os.replace(tmp, path)  # atomic swap: readers see the old file or the new one
+
+
+write_status(db, shop_root)  # start from a good file
+write_status_atomically(db, shop_root, crash_before_replace=True)
+print((shop_root / "STATUS.md").read_text(), end="")
+```
+
+```text
+# Shop status
+- SKU-VANILLA: 4 on hand (reorder at 3) OK
+```
+
+The crash landed at the worst moment — after the (truncated) temp file was
+written, before the swap — and the real file is untouched. Whatever instant
+the power dies, a reader sees the complete old file or the complete new file,
+never a torn one. This is byte-for-byte the production mechanism: every
+governance file the organization writes goes through `atomic_write` in
+`sovereign_agent/files.py` — sibling temp file, flush, `fsync`, `os.replace`.
+
+**What this does not guarantee.** Be precise about the promise. `os.replace`
+swaps the *directory entry* atomically, but this helper does not `fsync` the
+parent directory — and until the directory entry itself reaches disk, a power
+loss can quietly undo the rename. So the honest contract is: **old-or-new,
+never torn — but not guaranteed-new** after a crash. The production code
+accepts that bound deliberately, and the reason is the division of labor this
+chapter built: the file is a projection. If a crash costs the rename, the
+verifier reports drift and the reconciler regenerates the file from the
+ledger. Durability lives in SQLite; the filesystem only ever holds copies.
 
 ## Exercise 1: look at the operational state
 
@@ -353,5 +814,17 @@ its history.
    the shelf look like afterwards, and why?
 5. The docs say SQLite and the filesystem cannot be updated in one transaction.
    Describe a state the organization can end up in because of that.
+6. The naive migration runner wrapped everything in `with db:` and still left
+   `reservations` behind. Explain precisely which statement escaped the
+   transaction, and why the fix is `BEGIN IMMEDIATE` rather than a bigger
+   `try/except`.
+7. `verify_status_helpfully` returned `OK` and was catastrophically wrong.
+   Name the two distinct things it destroyed. Then explain why the toy
+   verifier also cannot see a *stale extra* projection file, and what the
+   production checker does differently.
+8. After a power loss, `atomic_write` promises "old-or-new, never torn" but
+   not "guaranteed-new." What single missing `fsync` creates that gap, and
+   why is the gap acceptable for a projection when it would not be acceptable
+   for the ledger?
 
 Next: [Chapter 2 — Work needs governance](../ch02_work_needs_governance/README.md)

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -1,5 +1,22 @@
 # Chapter 1 — The organization remembers
 
+Lucy's shop lost an order once. Not a big one — a single case of cones — but the
+supplier's system had recorded the sale, charged her, and then, somewhere between
+a crashed browser tab and a reload, forgotten it existed. The money was gone and
+the cones never came, and there was no record to point at. "We ordered them" was
+a hope, not a fact.
+
+A Zero-Employee Organization cannot afford that. If it is going to act on Lucy's
+behalf — move money, commit to suppliers, promise a full freezer — then its
+memory has to be the kind you can hold it to. So before we teach the organization
+to *decide* anything, we have to answer a plainer question: **where does the
+truth live, and what survives when the power goes out mid-sentence?**
+
+This chapter is hands-on the whole way through. You will open the organization's
+memory, try to corrupt it three different ways, watch a half-finished purchase
+roll itself back, and learn to name — for any piece of data in the system — which
+file or table is the authority for it.
+
 ## Learning objective
 
 Understand where a Zero-Employee Organization keeps its memory, why some of that
@@ -11,9 +28,9 @@ By the end you should be able to say, for any piece of data in this system,
 
 ## Why memory is the first hard problem
 
-An organization that forgets cannot be held to anything. If the tea order can
-vanish because a process died halfway through, then "we ordered the tea" is a
-hope, not a fact.
+An organization that forgets cannot be held to anything. If an order can vanish
+because a process died halfway through — exactly what happened to Lucy's cones —
+then "we ordered it" is a hope, not a fact.
 
 So the first question is not "how does the AI decide" — it is "where does the
 truth live, and what happens when the power goes out mid-sentence".
@@ -21,8 +38,8 @@ truth live, and what happens when the power goes out mid-sentence".
 ## Exercise 1: look at the operational state
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/andrea-memory
-sqlite3 /tmp/andrea-memory/.sovereign/organization.db ".tables"
+sovereign-agent demo store --mode simulated --root /tmp/lucy-memory
+sqlite3 /tmp/lucy-memory/.sovereign/organization.db ".tables"
 ```
 
 Expected: sixteen tables listed. The ones to care about now:
@@ -36,7 +53,7 @@ Expected: sixteen tables listed. The ones to care about now:
 | `schema_migrations` | which schema versions have been applied |
 
 ```bash
-sqlite3 -header -column /tmp/andrea-memory/.sovereign/organization.db \
+sqlite3 -header -column /tmp/lucy-memory/.sovereign/organization.db \
   "SELECT * FROM inventory; SELECT id, amount_cents FROM cash_entries;"
 ```
 
@@ -49,7 +66,7 @@ purchase. Nothing overwrites a balance, so nothing can quietly lose money.
 The event log is the organization's memory of what it did. Try to rewrite it.
 
 ```bash
-sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+sqlite3 /tmp/lucy-memory/.sovereign/organization.db \
   "UPDATE events SET kind='NOTHING_HAPPENED' WHERE kind='sale.committed';"
 ```
 
@@ -62,7 +79,7 @@ Error: stepping, events are append-only: update refused (19)
 Now try deleting:
 
 ```bash
-sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+sqlite3 /tmp/lucy-memory/.sovereign/organization.db \
   "DELETE FROM events WHERE kind='replenishment.committed';"
 ```
 
@@ -70,7 +87,7 @@ Also refused. Now try the sneaky third variant — overwriting a row instead of
 editing it:
 
 ```bash
-sqlite3 /tmp/andrea-memory/.sovereign/organization.db \
+sqlite3 /tmp/lucy-memory/.sovereign/organization.db \
   "INSERT OR REPLACE INTO events(id,kind,payload,created_at)
    SELECT id,'NOTHING_HAPPENED',payload,created_at FROM events LIMIT 1;"
 ```
@@ -82,17 +99,17 @@ That distinction matters: a rule enforced in application code protects you from
 bugs, but a rule enforced in the database protects you from *everything else
 that can reach the database* — including you, at 2am, with a REPL open.
 
-That third case is worth dwelling on, because getting it right took two
-attempts. The first version of this guard relied on a SQLite setting called
-`recursive_triggers`, which the application switched on when it opened the
-database. It worked perfectly — from the application. From the `sqlite3` command
-above, the one this chapter just told you to use, the overwrite **succeeded
-silently** and the row count did not change. The lesson claimed the database
-enforced the rule while the guarantee actually lived in Python.
+That third case is worth dwelling on, because it is where a subtle mistake
+hides. A tempting way to block the overwrite is a SQLite setting like
+`recursive_triggers`, switched on when the application opens the database. It
+works — *from the application*. But from the `sqlite3` command line above, the
+one this chapter just told you to use, the overwrite would succeed silently and
+the row count would not change. A guarantee that lives in only one client is not
+a guarantee; it is a coincidence waiting to be discovered at 2am.
 
-The fix is the guard you just triggered: a `BEFORE INSERT` trigger that refuses
-an id which already exists. It needs no setting, so it holds from any client.
-Enforcement now matches the claim — which is the entire subject of Chapter 2.
+The guard you just triggered instead is a `BEFORE INSERT` trigger that refuses an
+id which already exists. It needs no setting, so it holds from *any* client.
+Enforcement matches the claim — which is the entire subject of Chapter 2.
 
 ## Exercise 3: watch a transaction roll back
 
@@ -114,7 +131,7 @@ seed(org.db)
 
 # An effect needs a real completed assignment behind it. Chapter 2 explains why.
 outcome = org.create_outcome(
-    "Keep the tea jar stocked", "stocked",
+    "Keep the shelf stocked", "stocked",
     ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA")
 org.activate(outcome.id, "master-course")
 sow = org.create_sow(outcome.id, "replenish", Role.OPERATOR, "master-course")
@@ -147,9 +164,9 @@ three changes happen, or none do.
 ## Exercise 4: find the boundary between governance and operations
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/andrea-boundary
-cat /tmp/andrea-boundary/sovereign.toml
-ls /tmp/andrea-boundary/governance/outcomes/*/
+sovereign-agent demo store --mode simulated --root /tmp/lucy-boundary
+cat /tmp/lucy-boundary/sovereign.toml
+ls /tmp/lucy-boundary/governance/outcomes/*/
 ```
 
 Two kinds of file, and they behave differently:
@@ -165,9 +182,9 @@ Try it:
 ```bash
 python -c "
 import shutil, sys; sys.path.insert(0,'src')
-shutil.rmtree('/tmp/andrea-boundary/governance')
+shutil.rmtree('/tmp/lucy-boundary/governance')
 from sovereign_agent.organization import Organization
-o = Organization('/tmp/andrea-boundary')
+o = Organization('/tmp/lucy-boundary')
 print(o.status_text(o.db.connection.execute('select id from outcomes').fetchone()['id']))
 "
 ```

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -225,10 +225,9 @@ database handle is not the code. Proving authenticity needs something the
 database does not hold — a signature key kept outside it — which is a different
 subject and out of scope here.
 
-So the honest statement, which
-[the ruling](../../docs/rulings/2026-08-26-sqlite-writers-are-inside-the-boundary.md)
-records: **anyone who can write arbitrary rows can rewrite the organization's
-memory.** Everything in this chapter protects the ledger from mistakes and
+So here is the honest statement this design commits to: **anyone who can write
+arbitrary rows can rewrite the organization's memory.** Everything in this chapter
+protects the ledger from mistakes and
 ordinary tools. Knowing exactly which door is open is worth more than believing
 they are all shut.
 

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -41,6 +41,89 @@ to decide what, and what has to be true before a decision sticks.
 | **Acceptance** | The Principal declaring the outcome true — if it survives proof. |
 | **Ruling** | A recorded decision that changes the rules. |
 
+## Build it yourself: why `ACCEPTED` has to re-read the world
+
+The whole chapter turns on one function — `accept` — so build the wrong version
+first, watch it lie, then fix it. Paste this into a Python shell.
+
+Here is the world (what is actually true) and an outcome that declares the check
+that must hold for it to be true:
+
+```python
+world = {"on_hand": 2, "reorder_point": 3}  # the freezer is below its line
+outcome = {
+    "title": "Keep the freezer stocked",
+    "state": "VERIFYING",
+    "checks": ["on_hand_at_or_above_reorder_point"],
+}
+
+
+def check_on_hand(world):
+    return world["on_hand"] >= world["reorder_point"]
+```
+
+The tempting `accept` just sets the status field. It is one line, and it is a lie
+detector with the detector removed:
+
+```python
+def accept_naive(outcome):
+    outcome["state"] = "ACCEPTED"  # flip the field; check nothing
+    return outcome["state"]
+
+
+print(
+    accept_naive(outcome),
+    "-- but the freezer is at",
+    world["on_hand"],
+    "below",
+    world["reorder_point"],
+)
+```
+
+```text
+ACCEPTED -- but the freezer is at 2 below 3
+```
+
+The paperwork says done; the freezer is empty. That gap is the entire subject of
+this book. The fix is to make `accept` **re-run the declared checks against the
+world at the moment of acceptance** — not trust that they passed earlier, not
+trust a status field, read reality:
+
+```python
+outcome["state"] = "VERIFYING"  # reset from the bad accept above
+
+
+def accept(outcome, world):
+    for name in outcome["checks"]:
+        if name == "on_hand_at_or_above_reorder_point" and not check_on_hand(world):
+            raise PermissionError(
+                f"refused: {name} failed (on_hand={world['on_hand']} < reorder={world['reorder_point']})"
+            )
+    outcome["state"] = "ACCEPTED"
+    return outcome["state"]
+
+
+try:
+    accept(outcome, world)
+except PermissionError as error:
+    print(error)
+
+world["on_hand"] = 8  # actually restock, so reality now matches the claim
+print(accept(outcome, world))
+```
+
+```text
+refused: on_hand_at_or_above_reorder_point failed (on_hand=2 < reorder=3)
+ACCEPTED
+```
+
+Acceptance refused the outcome while the world contradicted it, and granted it
+only once the world actually matched. The production organization does exactly
+this, with more checks and durable evidence — and, crucially, it derives *who
+performed the work* from the ledger and refuses acceptance from that actor, so no
+one accepts their own work. The exercises below confirm each of those refusals in
+the real system.
+
 ## Exercise 1: follow one outcome through the whole chain
 
 ```bash

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -1,5 +1,22 @@
 # Chapter 2 — Work needs governance
 
+In Chapter 0 the shop said `ACCEPTED` and you learned to distrust the word until
+you had checked the world yourself. This chapter is about why you *shouldn't have
+to* — about the machinery that makes `ACCEPTED` mean something even when nobody is
+watching over its shoulder.
+
+Here is the uncomfortable truth that machinery exists to handle: the thing doing
+the work will, sooner or later, have a reason to say it went fine when it didn't.
+Not out of malice — a model that ran out of turns, a script that half-finished, a
+tired human clicking through. If "done" is just a field someone sets, then "done"
+is worth exactly nothing. So Lucy's organization never lets the worker mark its
+own homework. Work travels through a chain of distinct hands, and at the end
+someone re-checks reality before the word `ACCEPTED` is allowed to attach to it.
+
+You will follow one outcome through that entire chain, then spend most of the
+chapter trying to smuggle a lie past it — and watching it get caught, nine
+different ways.
+
 ## Learning objective
 
 Understand how a piece of work travels from "somebody wants this" to "this is
@@ -13,7 +30,7 @@ to decide what, and what has to be true before a decision sticks.
 
 | Word | What it is |
 | --- | --- |
-| **Outcome** | The state of the world someone wants. "The tea jar stays stocked." |
+| **Outcome** | The state of the world someone wants. "Lucy's freezer stays stocked." |
 | **Acceptance check** | A deterministic question that decides whether the outcome is true. |
 | **SOW** | A statement of work: scope, non-goals, deliverables, done-when. |
 | **Assignment** | One actor bound to one SOW, with a workspace. |
@@ -27,8 +44,8 @@ to decide what, and what has to be true before a decision sticks.
 ## Exercise 1: follow one outcome through the whole chain
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/andrea-gov
-DB=/tmp/andrea-gov/.sovereign/organization.db
+sovereign-agent demo store --mode simulated --root /tmp/lucy-gov
+DB=/tmp/lucy-gov/.sovereign/organization.db
 
 sqlite3 -header -column "$DB" \
   "SELECT json_extract(record,'$.title') AS title,
@@ -87,10 +104,11 @@ Expected: a refusal naming `inventory_at_or_above_reorder_point`. Acceptance
 **re-runs the checks against the world at the moment of acceptance**. It does
 not trust that they passed earlier.
 
-That last sentence is the entire lesson of this chapter, and it was learned the
-hard way: an earlier version of this system accepted an outcome by checking that
-someone had handed it a non-empty list of evidence IDs. The IDs were never
-looked up. You could accept with `["evd_i_just_made_this_up"]`.
+That last sentence is the entire lesson of this chapter. The tempting shortcut
+is to accept an outcome by checking that someone handed it a non-empty list of
+evidence IDs — without ever looking the IDs up. Do that and you can accept with
+`["evd_i_just_made_this_up"]`. Acceptance that trusts a list of names instead of
+re-reading the world is theatre.
 
 ## Exercise 3: try the other ways of lying
 
@@ -163,10 +181,11 @@ cash_reconciles: PASS - 1 purchase entr(y/ies) reconcile
 replenishment_event_exists: PASS - 1 replenishment event(s) for SKU-TEA
 ```
 
-Each check reports the facts it observed. `verify_outcome` used to change a
-status field and run no checks at all — a verification step that verified
-nothing. Now it executes every declared check, and an unknown or crashing check
-**fails closed** rather than being skipped.
+Each check reports the facts it observed. The failure mode to guard against is
+a verification step that only flips a status field and runs no checks at all — a
+verification that verifies nothing. Here `verify_outcome` executes every declared
+check, and an unknown or crashing check **fails closed** rather than being
+skipped.
 
 ## Exercise 6: the proof itself cannot be rewritten
 
@@ -175,18 +194,19 @@ now covers every table acceptance reads as proof — `effects`, `verifications`,
 `reviews`, `evidence`:
 
 ```bash
-sqlite3 /tmp/andrea-gov/.sovereign/organization.db \
+sqlite3 /tmp/lucy-gov/.sovereign/organization.db \
   "UPDATE evidence SET success = 1;"
 ```
 
 Expected: `Error: stepping, evidence are append-only: update refused`.
 
-This was not always true, and the story is worth knowing. Append-only was added
-to `events` because acceptance rested on events. Then acceptance came to rest on
-evidence, reviews, verifications and effects — and the guards stayed where they
-were. For a while the tables carrying the proof were the ones with no
-protection, while the table they replaced was still immune. A reviewer put it
-exactly: *the guarantee stayed put while the load moved.*
+There is a general trap worth naming here. Append-only protection tends to get
+added to whichever table the proof *used* to live in. As a system grows, the
+proof migrates — from `events` to `evidence`, `reviews`, `verifications`,
+`effects` — and if the guards do not migrate with it, the tables carrying the
+real load end up unprotected while an old, now-irrelevant table stays immune.
+Put sharply: *the guarantee stays put while the load moves.* Protect where the
+proof lives now, not where it used to.
 
 One thing append-only cannot do is stop a forged **append**: inserting is
 precisely what it permits. An effect is therefore cross-checked against the
@@ -244,11 +264,11 @@ two reviews, including the `changes_requested` one. The organization remembers
 being wrong. That is the difference between a system that learns and a system
 that launders its history.
 
-This path did not exist while this chapter was first written. `changes_requested`
-was terminal: the only way forward from a refusal was to delete the organization
-and start over. A book that teaches "refusal is the system working" while
-shipping a refusal you cannot recover from is teaching the opposite of what it
-says.
+This matters more than it looks. If `changes_requested` were terminal — if the
+only way forward from a refusal were to delete the organization and start over —
+then "refusal is the system working" would be a slogan the system contradicts in
+practice. A refusal you cannot recover from teaches the opposite of what it says.
+Recovery is what makes refusal a step in the work rather than the end of it.
 
 ## Learner verification command
 

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -13,9 +13,10 @@ is worth exactly nothing. So Lucy's organization never lets the worker mark its
 own homework. Work travels through a chain of distinct hands, and at the end
 someone re-checks reality before the word `ACCEPTED` is allowed to attach to it.
 
-You will follow one outcome through that entire chain, then spend most of the
-chapter trying to smuggle a lie past it — and watching it get caught, nine
-different ways.
+You will build that machinery yourself, one refusal at a time: seven versions
+of one function, each of which stops a lie the version before it allowed. Then
+you will follow one outcome through the real system's chain and spend the rest
+of the chapter trying to smuggle lies past it.
 
 ## Learning objective
 
@@ -41,88 +42,488 @@ to decide what, and what has to be true before a decision sticks.
 | **Acceptance** | The Principal declaring the outcome true — if it survives proof. |
 | **Ruling** | A recorded decision that changes the rules. |
 
-## Build it yourself: why `ACCEPTED` has to re-read the world
+## Build it yourself: acceptance in seven layers
 
-The whole chapter turns on one function — `accept` — so build the wrong version
-first, watch it lie, then fix it. Paste this into a Python shell.
+The whole chapter turns on one function. Production `accept()` — in
+`sovereign_agent/organization.py`, and it is one of the longest functions in
+the codebase — composes about ten distinct obligations, and every one of them
+exists because its absence lets a specific lie through. Reading the finished
+function teaches you what it does; it cannot teach you *why each clause
+earned its place*. So build it the way it was actually earned: start with the
+version that trusts paperwork, find the lie it permits, add exactly one
+clause, and repeat until the lies run out.
 
-Here is the world (what is actually true) and an outcome that declares the check
-that must hold for it to be true:
+Everything runs on real table rows, continuing Chapter 1's idiom. The mini
+schema mirrors the production ledger's proof tables — outcomes, SOWs,
+assignments, receipts, verifications, evidence, reviews, effects — with the
+inessential columns removed:
 
 ```python
-world = {"on_hand": 2, "reorder_point": 3}  # the freezer is below its line
-outcome = {
-    "title": "Keep the freezer stocked",
-    "state": "VERIFYING",
-    "checks": ["on_hand_at_or_above_reorder_point"],
-}
+import hashlib
+import sqlite3
 
-
-def check_on_hand(world):
-    return world["on_hand"] >= world["reorder_point"]
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE inventory (sku TEXT PRIMARY KEY, on_hand INT NOT NULL, reorder INT NOT NULL);
+    CREATE TABLE outcomes (id TEXT PRIMARY KEY, state TEXT, subject TEXT, check_id TEXT);
+    CREATE TABLE sows (id TEXT PRIMARY KEY, outcome_id TEXT, state TEXT, required_effect TEXT);
+    CREATE TABLE assignments (id TEXT PRIMARY KEY, sow_id TEXT, actor TEXT, state TEXT);
+    CREATE TABLE receipts (assignment_id TEXT PRIMARY KEY, deliverable TEXT);
+    CREATE TABLE verifications (id TEXT PRIMARY KEY, outcome_id TEXT);
+    CREATE TABLE evidence (id TEXT PRIMARY KEY, verification_id TEXT, outcome_id TEXT,
+                           check_id TEXT, success INT, state_digest TEXT);
+    CREATE TABLE reviews (id TEXT PRIMARY KEY, verification_id TEXT, reviewer TEXT, decision TEXT);
+    CREATE TABLE effects (id TEXT PRIMARY KEY, assignment_id TEXT, kind TEXT, subject TEXT);
+""")
+db.execute("INSERT INTO inventory VALUES ('SKU-VANILLA', 2, 3)")  # BELOW the line
+db.execute("INSERT INTO outcomes VALUES ('out-van', 'VERIFYING', 'SKU-VANILLA', 'stock_ok')")
+db.execute("INSERT INTO sows VALUES ('sow-van', 'out-van', 'ACCEPTED', 'replenishment')")
+db.execute("INSERT INTO assignments VALUES ('run-1', 'sow-van', 'operator-lucy', 'COMPLETED')")
+db.commit()
 ```
 
-The tempting `accept` just sets the status field. It is one line, and it is a lie
-detector with the detector removed:
+Note the starting position, because it is the classic one: every piece of
+*paperwork* is in order — the SOW says `ACCEPTED`, the assignment says
+`COMPLETED` — and the freezer is at 2 with a reorder point of 3. The paperwork
+and the world disagree. Watch which one each version of `accept` believes.
+
+### Layer 1: trust the paperwork
+
+The tempting `accept` checks that the work-tracking rows look finished, then
+flips the field:
 
 ```python
-def accept_naive(outcome):
-    outcome["state"] = "ACCEPTED"  # flip the field; check nothing
-    return outcome["state"]
+def accept_v1(db, outcome_id, accepter):
+    open_sows = db.execute(
+        "SELECT COUNT(*) FROM sows WHERE outcome_id = ? AND state != 'ACCEPTED'", (outcome_id,)
+    ).fetchone()[0]
+    if open_sows:
+        raise PermissionError("refused: SOWs remain open")
+    db.execute("UPDATE outcomes SET state = 'ACCEPTED' WHERE id = ?", (outcome_id,))
+    return "ACCEPTED"
 
 
-print(
-    accept_naive(outcome),
-    "-- but the freezer is at",
-    world["on_hand"],
-    "below",
-    world["reorder_point"],
-)
+print(accept_v1(db, "out-van", "principal-lucy"))
+on_hand, reorder = db.execute("SELECT on_hand, reorder FROM inventory").fetchone()
+receipts = db.execute("SELECT COUNT(*) FROM receipts").fetchone()[0]
+print(f"but the freezer: on_hand={on_hand} reorder={reorder}, receipts on file: {receipts}")
 ```
 
 ```text
-ACCEPTED -- but the freezer is at 2 below 3
+ACCEPTED
+but the freezer: on_hand=2 reorder=3, receipts on file: 0
 ```
 
-The paperwork says done; the freezer is empty. That gap is the entire subject of
-this book. The fix is to make `accept` **re-run the declared checks against the
-world at the moment of acceptance** — not trust that they passed earlier, not
-trust a status field, read reality:
+Everything *said* done, so it accepted — an empty freezer, zero deliverables
+on file, nothing ever executed as far as the receipts table knows. Status
+fields are claims. A claim checked against another claim proves consistency
+between claims, which is worth nothing when both are wrong the same way.
+
+### Layer 2: re-read the world, right now
+
+The repair is the single most important line in this book: at the moment of
+acceptance, **run the declared check against current state**.
 
 ```python
-outcome["state"] = "VERIFYING"  # reset from the bad accept above
+def check_stock(db, subject):
+    on_hand, reorder = db.execute(
+        "SELECT on_hand, reorder FROM inventory WHERE sku = ?", (subject,)
+    ).fetchone()
+    return on_hand >= reorder, f"on_hand={on_hand} reorder={reorder}"
 
 
-def accept(outcome, world):
-    for name in outcome["checks"]:
-        if name == "on_hand_at_or_above_reorder_point" and not check_on_hand(world):
-            raise PermissionError(
-                f"refused: {name} failed (on_hand={world['on_hand']} < reorder={world['reorder_point']})"
-            )
-    outcome["state"] = "ACCEPTED"
-    return outcome["state"]
+def accept_v2(db, outcome_id, accepter):
+    subject, check_id = db.execute(
+        "SELECT subject, check_id FROM outcomes WHERE id = ?", (outcome_id,)
+    ).fetchone()
+    ok, detail = check_stock(db, subject)
+    if not ok:
+        raise PermissionError(f"refused: {check_id} fails NOW ({detail})")
+    return accept_v1(db, outcome_id, accepter)
 
 
+db.execute("UPDATE outcomes SET state = 'VERIFYING'")  # undo v1's lie
 try:
-    accept(outcome, world)
+    accept_v2(db, "out-van", "principal-lucy")
 except PermissionError as error:
     print(error)
-
-world["on_hand"] = 8  # actually restock, so reality now matches the claim
-print(accept(outcome, world))
 ```
 
 ```text
-refused: on_hand_at_or_above_reorder_point failed (on_hand=2 < reorder=3)
+refused: stock_ok fails NOW (on_hand=2 reorder=3)
+```
+
+Two details are load-bearing. The *subject* (`SKU-VANILLA`) came from the
+outcome row, not from the caller — otherwise acceptance could be pointed at a
+healthy product while the real one sits empty; the production code carries
+exactly that comment. And the check ran *at acceptance time* — the production
+docstring calls this "the step that matters."
+
+But v2 has its own hole. Restock the freezer and accept:
+
+```python
+db.execute("UPDATE inventory SET on_hand = 9")  # somebody restocks -- the world is true now
+print(accept_v2(db, "out-van", "principal-lucy"))
+evidence = db.execute("SELECT COUNT(*) FROM evidence").fetchone()[0]
+print(f"evidence rows supporting this acceptance: {evidence}")
+```
+
+```text
+ACCEPTED
+evidence rows supporting this acceptance: 0
+```
+
+True — and unprovable. Nothing records *what was observed* when acceptance was
+granted. Six months from now, when someone asks why this outcome was accepted,
+the answer is "trust me, the check passed." An organization whose acceptances
+cannot be audited is honest only while nobody needs it to prove it.
+
+### Layer 3: evidence — the observation, written down
+
+Verification becomes a durable act: run the check, record what it saw, and
+stamp the record with a **digest of the exact state it observed**. Acceptance
+then demands recorded, successful evidence:
+
+```python
+def digest_stock(db, subject):
+    row = db.execute(
+        "SELECT sku, on_hand, reorder FROM inventory WHERE sku = ?", (subject,)
+    ).fetchone()
+    return hashlib.sha256(repr(tuple(row)).encode()).hexdigest()[:12]
+
+
+def verify(db, verification_id, outcome_id):
+    subject, check_id = db.execute(
+        "SELECT subject, check_id FROM outcomes WHERE id = ?", (outcome_id,)
+    ).fetchone()
+    ok, detail = check_stock(db, subject)
+    db.execute("INSERT INTO verifications VALUES (?, ?)", (verification_id, outcome_id))
+    db.execute(
+        "INSERT INTO evidence VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            f"evd-{verification_id}",
+            verification_id,
+            outcome_id,
+            check_id,
+            int(ok),
+            digest_stock(db, subject),
+        ),
+    )
+    db.commit()
+    return f"recorded {'PASS' if ok else 'FAIL'} evidence at digest {digest_stock(db, subject)}"
+
+
+def accept_v3(db, outcome_id, accepter):
+    rows = db.execute("SELECT success FROM evidence WHERE outcome_id = ?", (outcome_id,)).fetchall()
+    if not rows:
+        raise PermissionError("refused: no evidence was ever recorded")
+    if not all(success for (success,) in rows):
+        raise PermissionError("refused: evidence on file reports failure")
+    return accept_v2(db, outcome_id, accepter)
+
+
+db.execute("UPDATE outcomes SET state = 'VERIFYING'")
+try:
+    accept_v3(db, "out-van", "principal-lucy")
+except PermissionError as error:
+    print(error)
+print(verify(db, "ver-1", "out-van"))
+print(accept_v3(db, "out-van", "principal-lucy"))
+```
+
+```text
+refused: no evidence was ever recorded
+recorded PASS evidence at digest 5d68aec58fd6
 ACCEPTED
 ```
 
-Acceptance refused the outcome while the world contradicted it, and granted it
-only once the world actually matched. The production organization does exactly
-this, with more checks and durable evidence — and, crucially, it derives *who
-performed the work* from the ledger and refuses acceptance from that actor, so no
-one accepts their own work. The exercises below confirm each of those refusals in
-the real system.
+Pause on the digest input, because production paid a real bill here. The
+digest covers **exactly the rows this check observed** — one inventory row,
+nothing else. The production `checks.py` records the scar in a comment: an
+older design used one *shared* digest over broad state, and it failed to
+notice duplicate-event drift because the duplicated rows were outside what any
+individual check looked at while inside what the digest hashed. A digest wider
+than the observation dilutes it; narrower, and it misses changes that matter.
+The rule: **the digest is the observation's fingerprint, so it must cover the
+observation — all of it and only it.**
+
+### Layer 4: proof you can steal is not proof
+
+v3 has a subtle flaw: it asks whether successful evidence *exists for this
+outcome*, but nothing binds the evidence rows to a verification *of this
+outcome*. Watch — Lucy adds a pistachio line, and its outcome simply borrows
+vanilla's proof:
+
+```python
+db.execute("INSERT INTO inventory VALUES ('SKU-PISTACHIO', 7, 3)")
+db.execute("INSERT INTO outcomes VALUES ('out-pis', 'VERIFYING', 'SKU-PISTACHIO', 'stock_ok')")
+db.execute("INSERT INTO sows VALUES ('sow-pis', 'out-pis', 'ACCEPTED', 'replenishment')")
+db.commit()
+
+stolen = db.execute("UPDATE evidence SET outcome_id = 'out-pis' WHERE outcome_id = 'out-van'")
+print("evidence reassigned:", stolen.rowcount)
+print(accept_v3(db, "out-pis", "principal-lucy"))
+```
+
+```text
+evidence reassigned: 1
+ACCEPTED
+```
+
+Pistachio was never verified, never executed, never delivered — it was
+accepted on vanilla's paperwork. (In the production schema the reassignment
+itself would be refused by append-only triggers, but the *checking* flaw is
+real: proof must be validated as belonging to the thing it proves.) The repair
+binds the chain at both ends: evidence must come from **this outcome's own
+verification batch**, and every SOW must have a **completed execution with a
+receipt** — the durable record that something actually ran and delivered:
+
+```python
+def accept_v4(db, outcome_id, accepter):
+    verification = db.execute(
+        "SELECT id FROM verifications WHERE outcome_id = ? ORDER BY id DESC LIMIT 1",
+        (outcome_id,),
+    ).fetchone()
+    if verification is None:
+        raise PermissionError("refused: this outcome has no verification of its own")
+    rows = db.execute(
+        "SELECT success FROM evidence WHERE outcome_id = ? AND verification_id = ?",
+        (outcome_id, verification[0]),
+    ).fetchall()
+    if not rows:
+        raise PermissionError("refused: no evidence in this outcome's own verification batch")
+    if not all(success for (success,) in rows):
+        raise PermissionError("refused: evidence on file reports failure")
+    for (sow_id,) in db.execute("SELECT id FROM sows WHERE outcome_id = ?", (outcome_id,)):
+        run = db.execute(
+            "SELECT a.id FROM assignments a JOIN receipts r ON r.assignment_id = a.id"
+            " WHERE a.sow_id = ? AND a.state = 'COMPLETED'",
+            (sow_id,),
+        ).fetchone()
+        if run is None:
+            raise PermissionError(f"refused: {sow_id} has no completed execution with a receipt")
+    return accept_v2(db, outcome_id, accepter)
+
+
+db.execute("UPDATE evidence SET outcome_id = 'out-van'")  # put the stolen proof back
+db.execute("UPDATE outcomes SET state = 'VERIFYING'")
+try:
+    accept_v4(db, "out-pis", "principal-lucy")
+except PermissionError as error:
+    print(error)
+
+try:
+    accept_v4(db, "out-van", "principal-lucy")
+except PermissionError as error:
+    print(error)
+
+db.execute("INSERT INTO receipts VALUES ('run-1', 'restock-report.md')")
+db.commit()
+print(accept_v4(db, "out-van", "principal-lucy"))
+```
+
+```text
+refused: this outcome has no verification of its own
+refused: sow-van has no completed execution with a receipt
+ACCEPTED
+```
+
+Two refusals before the accept, and read them in order: pistachio fell at
+"no verification of its own" — the theft no longer works — and then *vanilla
+itself* fell at the receipt check, exposing that all this time nothing had
+ever proven an execution happened. The lie v1 let through has only now been
+fully closed, three layers later. Layered obligations catch each other's
+leftovers; that is why they compose instead of replacing each other.
+
+### Layer 5: someone else must have looked
+
+Nothing yet requires a second pair of eyes. The performer's proof can all be
+in order and all be wrong the same way — the reason Chapter 0 told you to
+distrust `ACCEPTED` in the first place. So: a **review of the exact current
+verification batch**, by someone who is not the accepter:
+
+```python
+def accept_v5(db, outcome_id, accepter):
+    verification = db.execute(
+        "SELECT id FROM verifications WHERE outcome_id = ? ORDER BY id DESC LIMIT 1",
+        (outcome_id,),
+    ).fetchone()
+    if verification is not None:
+        review = db.execute(
+            "SELECT reviewer, decision FROM reviews WHERE verification_id = ?",
+            (verification[0],),
+        ).fetchone()
+        if review is None:
+            raise PermissionError("refused: no review of the CURRENT verification batch")
+        reviewer, decision = review
+        if decision != "approved":
+            raise PermissionError("refused: the current batch's review did not approve")
+        if reviewer == accepter:
+            raise PermissionError(f"refused: {accepter} reviewed this work and cannot accept it")
+    return accept_v4(db, outcome_id, accepter)
+
+
+db.execute("UPDATE outcomes SET state = 'VERIFYING'")
+try:
+    accept_v5(db, "out-van", "principal-lucy")
+except PermissionError as error:
+    print(error)
+
+db.execute("INSERT INTO reviews VALUES ('rev-1', 'ver-1', 'principal-lucy', 'approved')")
+db.commit()
+try:
+    accept_v5(db, "out-van", "principal-lucy")
+except PermissionError as error:
+    print(error)
+
+db.execute("UPDATE reviews SET reviewer = 'sparring-lucy' WHERE id = 'rev-1'")
+db.commit()
+print(accept_v5(db, "out-van", "principal-lucy"))
+```
+
+```text
+refused: no review of the CURRENT verification batch
+refused: principal-lucy reviewed this work and cannot accept it
+ACCEPTED
+```
+
+The review binds to the **verification id**, not to the outcome. Bind it to
+the outcome and a stale approval — of a batch that has since been replaced —
+would satisfy acceptance forever: "the evidence supporting acceptance must be
+the evidence a reviewer actually saw," as the production refusal puts it. And
+the reviewer/accepter collision is refused outright; review and acceptance
+are separate acts by separate actors, or they are one act wearing two hats.
+
+### Layer 6: true — but not because of you
+
+Now the deepest lie, the one every earlier layer waves through. Every check
+passes, honestly. Evidence is fresh, reviewed, receipted. And the execution
+being credited **did nothing** — the freezer is full because of the manual
+restock back in Layer 2, not because of `run-1`. The condition is true for
+*other reasons*, and v5 happily pays `run-1` the credit:
+
+```python
+def accept_v6(db, outcome_id, accepter):
+    for sow_id, required in db.execute(
+        "SELECT id, required_effect FROM sows WHERE outcome_id = ?", (outcome_id,)
+    ):
+        if required is None:
+            continue
+        contributed = db.execute(
+            "SELECT COUNT(*) FROM effects e JOIN assignments a ON a.id = e.assignment_id"
+            " WHERE a.sow_id = ? AND e.kind = ?",
+            (sow_id, required),
+        ).fetchone()[0]
+        if not contributed:
+            raise PermissionError(
+                f"refused: the condition may hold, but {sow_id}'s execution"
+                f" produced no {required} effect -- it holds for OTHER reasons"
+            )
+    return accept_v5(db, outcome_id, accepter)
+
+
+db.execute("UPDATE outcomes SET state = 'VERIFYING'")
+try:
+    accept_v6(db, "out-van", "principal-lucy")
+except PermissionError as error:
+    print(error)
+
+db.execute("INSERT INTO effects VALUES ('eff-1', 'run-1', 'replenishment', 'SKU-VANILLA')")
+db.commit()
+print(accept_v6(db, "out-van", "principal-lucy"))
+```
+
+```text
+refused: the condition may hold, but sow-van's execution produced no replenishment effect -- it holds for OTHER reasons
+ACCEPTED
+```
+
+This distinction — "the condition is true" versus "this execution *made* it
+true" — is the deepest idea in the production implementation. A SOW declares
+the **effect kind** it must produce; acceptance requires an effect of that
+kind from that SOW's own execution. Without it, an assignment that did
+nothing inherits credit for a restock done last week. The production comment
+adds a subtlety worth quoting: there is deliberately no "if there were any
+effects, then..." guard, because the empty case is the *strongest* form of
+"this execution did nothing" — guarding the requirement would make it vacuous
+exactly when it matters most. Chapter 10 builds this into full causal binding.
+
+### Layer 7: the world must not have moved
+
+One window remains. Verification observed the world; a review approved that
+observation; and between then and acceptance, the world can change. Sell most
+of the vanilla after `ver-1` and watch v6 (which re-runs the check — the
+freezer at 3 still *equals* the reorder point, so the check still passes)
+accept against evidence describing a world that no longer exists. The final
+clause compares the **evidence's state digest** against the world's digest at
+acceptance time:
+
+```python
+def accept_v7(db, outcome_id, accepter):
+    subject = db.execute("SELECT subject FROM outcomes WHERE id = ?", (outcome_id,)).fetchone()[0]
+    verification = db.execute(
+        "SELECT id FROM verifications WHERE outcome_id = ? ORDER BY id DESC LIMIT 1",
+        (outcome_id,),
+    ).fetchone()
+    if verification is not None:
+        recorded = db.execute(
+            "SELECT state_digest FROM evidence WHERE verification_id = ?",
+            (verification[0],),
+        ).fetchone()[0]
+        if recorded != digest_stock(db, subject):
+            raise PermissionError(
+                "refused: the world moved since verification"
+                f" (evidence digest {recorded}, world digest {digest_stock(db, subject)})"
+            )
+    return accept_v6(db, outcome_id, accepter)
+
+
+db.execute("UPDATE outcomes SET state = 'VERIFYING'")
+db.execute("UPDATE inventory SET on_hand = 3 WHERE sku = 'SKU-VANILLA'")  # a big sale lands
+db.commit()
+
+try:
+    accept_v7(db, "out-van", "principal-lucy")
+except PermissionError as error:
+    print(error)
+
+print(verify(db, "ver-2", "out-van"))
+db.execute("INSERT INTO reviews VALUES ('rev-2', 'ver-2', 'sparring-lucy', 'approved')")
+db.commit()
+print(accept_v7(db, "out-van", "principal-lucy"))
+```
+
+```text
+refused: the world moved since verification (evidence digest 5d68aec58fd6, world digest 423fad940a8d)
+recorded PASS evidence at digest 423fad940a8d
+ACCEPTED
+```
+
+The check still passed — 3 is at the reorder point — but acceptance refused
+anyway, because the evidence on file described `on_hand=9` and the world says
+`on_hand=3`. Recovery is not a bypass: verify again (a **new** batch, at the
+new digest), review the new batch, accept. Nothing was edited; the ledger now
+holds both verifications, both reviews, and the whole history of the world
+moving. Refusal is the system working, and re-proving is how work resumes.
+
+### What you just built, against the real thing
+
+Read production `accept()` in `sovereign_agent/organization.py` now — start at
+its docstring — and you will recognize every clause: SOWs all accepted (L1);
+checks re-executed against current state, subject read from the outcome
+(L2); stored evidence required, successful, bound to this outcome and batch
+(L3/L4); per-SOW receipts and deliverables via `_trusted_receipt` and
+`_require_deliverables` (L4); review of the exact verification batch and
+`forbid_self_approval` — production derives the performers from the ledger
+rather than trusting a parameter (L5); `required_effect_kind` contribution
+(L6); the outcome's own final observation with matching state digests (L7).
+The production version also validates *each SOW on its own proof chain* —
+your toy has one SOW; with several, one execution must not ride on a
+sibling's work — and refuses acceptance when the accepter appears among the
+ledger-derived performers, which no layer above could even express because
+the toy passed `accepter` in as a trusted string. Presence of a clause is
+never the lesson; the lie it stops is. That is also why the exercises below
+attack the *real* system rather than re-running the toy.
 
 ## Exercise 1: follow one outcome through the whole chain
 
@@ -383,5 +784,14 @@ above, and that authority cannot be self-granted.
 9. Acceptance requires a review of the **exact** verification batch it is
    accepting on. Describe the lie that would be possible if it accepted any
    review of the outcome instead.
+10. In Layer 7 the check itself still passed (`on_hand=3`, reorder point 3),
+    yet acceptance was refused. What exactly did the digest comparison prove
+    that re-running the check could not?
+11. A digest over *all* of the shop's state would seem strictly safer than one
+    over a single inventory row. Using the duplicate-event-drift scar from
+    `checks.py`, explain why "all of it and only it" beats "everything".
+12. Layer 6 refuses when the world is genuinely fine. Defend that refusal to
+    an annoyed Lucy: what future failure does crediting a do-nothing
+    execution set up?
 
 Next: [Chapter 3 — The actor is not a model](../ch03_actor_is_not_a_model/README.md)

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -335,6 +335,27 @@ ever proven an execution happened. The lie v1 let through has only now been
 fully closed, three layers later. Layered obligations catch each other's
 leftovers; that is why they compose instead of replacing each other.
 
+**A labeled simplification before Layer 5.** The toy has one SOW, so it can
+get away with one review bound to "the latest verification." Production
+cannot, and splits what the toy collapses into **two different things**:
+
+- **per-SOW review** — every SOW's *own* verification batch must have been
+  reviewed by an independent actor, checked SOW by SOW (a second
+  verification must not be able to replace every reviewed row while
+  acceptance still reports "the work was reviewed");
+- **the final outcome observation** — one last, separate verification that
+  the outcome's world-condition holds *now*. This final observation is
+  freshness-checked (its digests must match, as Layer 7 builds) but it has
+  **no reviewer of its own**, deliberately: it is a *measurement* of the
+  world, not a unit of work, and the production comment says exactly that —
+  requiring a reviewer for it would mean reviewing a measurement rather
+  than reviewing work.
+
+Keep that split in mind as you build Layer 5 against the one-SOW toy: the
+review you are about to demand plays the *per-SOW* role, and Layer 7's
+digest check plays the *final observation* role. In production they are
+distinct queries against distinct verifications.
+
 ### Layer 5: someone else must have looked
 
 Nothing yet requires a second pair of eyes. The performer's proof can all be
@@ -660,7 +681,7 @@ for check_id in org._outcome(oid).acceptance_checks:
 Expected:
 
 ```text
-inventory_at_or_above_reorder_point: PASS - on_hand=8 vs reorder_point=3
+inventory_at_or_above_reorder_point: PASS - available=8 (on_hand=8 - reserved=0) vs reorder_point=3
 cash_reconciles: PASS - 1 purchase entr(y/ies) reconcile
 replenishment_event_exists: PASS - 1 replenishment event(s) for SKU-TEA
 ```

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -2,269 +2,208 @@
 
 ## The bug that started an argument
 
-Lucy runs an ice cream shop. It is a small shop — six flavors, one freezer, one
-laptop — but it is busy, and this summer she started letting a language model
-help with the boring part: watching stock and proposing what to reorder.
+Lucy runs an ice cream shop. This summer she started letting a language model help
+with the boring part: watching stock and proposing reorders. One Saturday the
+model proposed reordering **400 tubs of vanilla** — ten freezers' worth. It did
+not go through, because in [Chapter 2](../ch02_work_needs_governance/README.md)
+you built the governed check that re-reads reality before a proposal commits.
 
-One Saturday the model proposed reordering **400 tubs of vanilla**. The freezer
-holds forty. If that order had gone through, Lucy would have spent the month's
-rent on ice cream that would melt on the sidewalk before she could sell it.
-
-It did not go through. In [Chapter 2](../ch02_work_needs_governance/README.md)
-you built the piece that said *no* — the governed check that re-reads reality
-before it lets a proposal commit. This chapter is about a subtler question, the
-one Lucy's friend asked her that evening:
+This chapter answers the question Lucy's friend asked that evening:
 
 > "If you switch to a smarter model, does the shop get safer, or more dangerous?"
 
-The honest answer is **neither** — and understanding *why* is the most important
-idea in this book. Most systems that bolt an LLM onto a business get this exactly
-backwards: they treat "which model" and "what it is allowed to do" as the same
-knob. Turn up the intelligence and you turn up the authority. That is how a
-sharper model becomes a more expensive mistake.
-
-By the end of this chapter you will be able to swap the intelligence behind
-Lucy's shop — from a dumb scripted stand-in to a real local model — watch its
-proposals change completely, and **prove that who is allowed to do what did not
-move an inch.**
+The honest answer is **neither**, by design — and the reason is the most important
+idea in this book. Most systems that bolt an LLM onto a business get it exactly
+backwards: they tie *authority* to *intelligence*, so a sharper model quietly
+gets a longer leash. In a Sovereign Agent, the model is a **swappable part of an
+actor**, and the actor's authority comes from its **role**, not from the model
+behind it. You will build that distinction from the real production pieces, swap
+the model, and prove that who-may-do-what did not move an inch.
 
 ## Learning objective
 
-Understand why swapping the intelligence behind an actor does not change who is
-accountable — and why a provider therefore cannot approve its own work. You will
-build the actor/provider distinction from first principles, then confirm it in
-the production organization: an actor keeps its `id`, `role`, and `authority`
-across a provider rebind, and acceptance is refused for whoever performed the
-work, no matter which model is bound to them.
+Understand why swapping the intelligence behind an actor changes its *proposals*
+but not its *authority*, and why a provider therefore cannot approve its own work.
+You will build the real actor representation (an actor **has** a `provider`
+field), the real role-to-authority policy, and the real rebind, and see that
+authority is enforced by a role lookup — not by a model, a prompt, or a clever
+data-structure trick.
 
 ## What you'll learn
 
-- The difference between an **actor** (a governed identity) and a **provider**
-  (a swappable intelligence), and why welding them together is the root defect.
-- How the organization records a provider change as a *governed act*, not a
-  quiet config edit.
-- Why the thing that *proposed* a piece of work can never be the thing that
-  *approves* it — and how that is enforced by code that reads the ledger, not by
-  anyone's good intentions.
+- That in production an actor **has** a `provider` — the swappable intelligence
+  lives on the actor, alongside its `role` and `authority`.
+- That authority safety comes from a **role → allowed-actions** policy table, not
+  from making an object immutable.
+- Why the actor whose model *did* the work still cannot *accept* it, no matter
+  which model you bind to it.
 
-**Prerequisites:** Chapters 0–2. Comfort with Python functions, dictionaries,
-and `dataclasses`. No machine-learning background required.
+**Prerequisites:** Chapters 0–2. Comfort with Python classes and `pydantic`
+models. No machine-learning background required.
 
-## An analogy you already understand
+## The tempting mistake, built and broken
 
-Think about the cash register at Lucy's shop.
-
-The **register** has rules: it records every sale, it needs a manager's key to
-void a transaction, it prints a receipt. Those rules do not care *who* is
-standing at it. A new hire, a twenty-year veteran, or Lucy herself — the register
-treats them all the same, because the rules belong to the *role*, not the person.
-
-The **person** at the register is replaceable. Hire a sharper cashier who scans
-faster and upsells better, and the shop gets a better *cashier*. It does not get
-a register that suddenly lets cashiers void their own transactions.
-
-An **actor** is the register: a governed identity with a role and a fixed set of
-permissions. A **provider** is the person: the intelligence doing the thinking,
-hired and swappable. "Upgrading the model" is hiring a sharper cashier. It is
-*not* rewriting the register's rules — and if it ever *did*, that would be a bug
-so dangerous it is the whole reason this chapter exists.
-
-Hold that picture. Now let's build it, starting from the naive version so you can
-feel exactly where it breaks.
-
-## Building the actor (and the trap)
-
-Start with identity. An actor needs an id, a role, and a set of things it may do:
+The intuitive design ties power to smartness: a good-enough model earns the right
+to sign off on its own decisions. Let's build that and watch it fail. Here is an
+actor whose authority is just "whatever its model is allowed to do," handed in
+per call:
 
 ```python
-from dataclasses import dataclass
+def approve(outcome_id, approver_can_accept):
+    if approver_can_accept:
+        print(f"accepted {outcome_id}")
+    else:
+        raise PermissionError("not allowed")
 
-@dataclass(frozen=True)
-class Actor:
-    id: str                      # "lucy-operator", stable forever
-    role: str                    # "operator", "verifier", "principal"
-    authority: frozenset[str]    # what this actor may do
+
+# The operator's model is sharp today, so we trust it to accept its own work:
+approve("out_vanilla", approver_can_accept=True)
 ```
 
-We made it `frozen=True` on purpose. An actor's identity must not be editable by
-a stray line of code that happens to hold a reference to it. Changing what an
-actor *is* should go through a governed operation that records the change — which
-we will build in a moment.
+This "works," and it is a disaster. `approver_can_accept` is a claim the caller
+makes about itself; a capable model will happily claim it. Authority that travels
+as a boolean argument is authority the worker can grant itself. The fix is to
+stop asking the caller and start looking authority up — from the actor's **role**.
 
-Here is the actor that runs Lucy's restock work:
+## The real actor: the model lives *on* it
+
+In production an actor is a small typed record. Crucially, the `provider` — the
+swappable intelligence — is a field **on the actor**, right next to its `role`
+and its capability list. (This mirrors `sovereign_agent.models.Actor`.)
 
 ```python
+from pydantic import BaseModel
+
+
+class Actor(BaseModel):
+    id: str
+    role: str
+    provider: str  # the swappable intelligence: "scripted", "claude", "ollama", ...
+    authority: list[str]  # the provider-facing capabilities this actor carries
+
+
 operator = Actor(
     id="lucy-operator",
     role="operator",
-    authority=frozenset({"propose_restock", "write_workspace"}),
+    provider="scripted",
+    authority=["read", "write_workspace", "run_checks", "report"],
 )
 ```
 
-Read what `lucy-operator` may do: it may **propose** a restock and write to its
-scratch workspace. It may **not** approve work — that permission simply is not in
-the set. Hold onto that; it is the hinge the whole chapter turns on.
+Notice what is *not* in that authority list: `accept`. Hold onto that — it is the
+hinge the whole chapter turns on. Note too that the actor is an ordinary mutable
+model. Its safety will not come from freezing it; it will come from where
+authority is actually decided.
 
-Now, where does the *thinking* happen? Behind the actor, in a provider. The
-naive design — the one that causes the bug Lucy's friend worried about — is to
-bake the provider *into* the actor:
+## Authority is granted by role, not by the model
 
-```python
-# DON'T do this — it welds identity to intelligence
-@dataclass
-class Actor:
-    id: str
-    role: str
-    authority: set[str]
-    provider: str      # <-- the trap
-```
-
-Why is this a trap? Because now "change the model" and "change who this actor is"
-are the *same edit*. A function that swaps the provider is one typo away from
-also touching the role or the authority. The dangerous change and the harmless
-change live in the same place, guarded by the same (or no) review. Good systems
-keep dangerous operations far away from routine ones.
-
-So we store the binding *outside* the actor, in a small table the organization
-owns:
+Here is the real source of authority: a table mapping each role to the actions it
+may take. (This mirrors `ROLE_AUTHORITY` in `sovereign_agent.policy`.)
 
 ```python
-# which provider is currently behind each actor id
-provider_bindings: dict[str, str] = {"lucy-operator": "scripted"}
-```
+ROLE_AUTHORITY = {
+    "principal": {"define_outcome", "accept", "grant_exception", "rule"},
+    "master": {"plan", "assign", "integrate", "request_ruling"},
+    "operator": {"read", "write_workspace", "run_checks", "report"},
+    "sparring": {"read", "review", "rule"},
+    "verifier": {"run_checks", "record_evidence"},
+}
 
-The actor stays frozen and pristine. The binding is a separate, mutable fact.
 
-## Rebinding: change the mind, keep the identity
-
-Here is the operation that hires a sharper cashier. Read it, then we will walk
-through the two things that make it safe.
-
-```python
-def rebind_provider(bindings, actor, new_provider, performed_by):
-    # 1. Only an actor with ruling authority may rebind.
-    if "rule" not in performed_by.authority:
+def require_authority(role, action):
+    if action not in ROLE_AUTHORITY[role]:
         raise PermissionError(
-            f"{performed_by.id} (role {performed_by.role}) may not rebind providers"
+            f"Role {role} attempted {action}. "
+            "Authority is granted by role, not by a provider or a prompt."
         )
-    # 2. Return a NEW bindings table; never mutate the actor's identity.
-    updated = dict(bindings)
-    updated[actor.id] = new_provider
-    print(f"event: actor.provider_rebound  {actor.id}: "
-          f"{bindings.get(actor.id)} -> {new_provider}  by {performed_by.id}")
-    return updated
 ```
 
-Two properties make this safe, and both are worth saying out loud:
+That refusal message is the thesis of the chapter, in the production code itself:
+**authority is granted by role, not by a provider or a prompt.** The `operator`
+role's actions are `read`, `write_workspace`, `run_checks`, `report`. `accept` is
+not among them — and no model can add it, because the model is not consulted here
+at all.
 
-1. **Rebinding is a privileged act, not a config edit.** The function refuses to
-   run for just anyone — `performed_by` must carry `"rule"` authority. Swapping
-   the model is a *decision*, made by someone accountable. In Lucy's shop that is
-   the principal (Lucy herself), never the worker whose model is being swapped.
+## Rebinding: change the mind, record the act, keep the authority
 
-2. **The actor object is never touched.** We copy the table and change one entry.
-   The `Actor` — its id, role, authority — comes out the far side byte-for-byte
-   identical, because it is literally the same frozen object. The *mind* changed;
-   the *identity* did not. And notice the function prints an **event**: the change
-   is recorded, not whispered.
-
-Run it:
+Swapping the model is changing the actor's `provider` field. It is a governed act:
+only an actor whose role may `rule` can do it, and it is written to the ledger as
+an event. (This mirrors `Organization.rebind_actor`.)
 
 ```python
-principal = Actor("lucy", "principal", frozenset({"rule", "accept"}))
+event_log = []
 
-before = provider_bindings["lucy-operator"]
-provider_bindings = rebind_provider(provider_bindings, operator, "ollama", principal)
-after = provider_bindings["lucy-operator"]
 
-print("provider:", before, "->", after)
-print("identity unchanged:", operator.authority == frozenset({"propose_restock", "write_workspace"}))
+def rebind_actor(actor, new_provider, performed_by):
+    require_authority(performed_by.role, "rule")  # only principal/sparring may rule
+    old = actor.provider
+    actor.provider = new_provider  # mutate the field ON the actor
+    event_log.append(
+        {"kind": "actor.provider_rebound", "actor": actor.id, "from": old, "to": new_provider}
+    )
+
+
+principal = Actor(id="lucy", role="principal", provider="n/a", authority=["accept", "rule"])
+
+rebind_actor(operator, "ollama", performed_by=principal)
+print("provider:", operator.provider)
+print("role:", operator.role, "| authority:", operator.authority)
 ```
 
 ```text
-event: actor.provider_rebound  lucy-operator: scripted -> ollama  by lucy
-provider: scripted -> ollama
-identity unchanged: True
+provider: ollama
+role: operator | authority: ['read', 'write_workspace', 'run_checks', 'report']
 ```
 
-Read that last line again. We just replaced a deterministic fake with a real
-local model. The proposals from `lucy-operator` will now be smarter, wordier,
-occasionally surprising. And the answer to "who is `lucy-operator`, and what may
-it do?" did not change at all. The register stayed the register while a better
-cashier stepped up to it.
+We replaced a deterministic stand-in with a real local model. `operator.provider`
+changed; its `role` and `authority` did not. The mind changed; the identity did
+not — and the change is now a row in `event_log`, not a quiet edit.
 
-## The second half: you cannot approve your own work
+## Why a provider cannot approve its own work
 
-There is a reason we kept `"accept"` *out* of the operator's authority. Make it
-concrete. In Lucy's shop, work flows like this: the operator **proposes** a
-restock, then — separately — a verifier checks the freezer and a principal
-**accepts**. Proposal and approval are done by *different actors*. That is not
-bureaucracy; it is the only thing standing between Lucy and a model that says "I
-ordered 400 tubs, and I also confirm that was an excellent decision."
-
-Here is a naive approval with the hole left in:
+Now the payoff. Try to let the operator accept, however sharp its new model is:
 
 ```python
-def approve(outcome_id, approver):
-    if "accept" not in approver.authority:
-        raise PermissionError(f"{approver.id} may not accept")
-    print(f"event: outcome.accepted  {outcome_id}  by {approver.id}")
+try:
+    require_authority(operator.role, "accept")
+except PermissionError as error:
+    print("refused:", error)
+
+rebind_actor(operator, "claude", performed_by=principal)  # an even better model
+try:
+    require_authority(operator.role, "accept")
+except PermissionError as error:
+    print("still refused after the upgrade:", error)
 ```
 
-This checks that the approver *may* accept — good, but not enough. It does not
-check that the approver **is not the same actor that did the work.** The fix is
-to derive the *performers* from the ledger — the recorded list of who actually
-did the work — and refuse approval from any of them:
-
-```python
-def approve(outcome_id, approver, performers):
-    if "accept" not in approver.authority:
-        raise PermissionError(f"{approver.id} may not accept")
-    if approver.id in performers:
-        raise PermissionError(f"{approver.id} performed this work and may not approve it")
-    print(f"event: outcome.accepted  {outcome_id}  by {approver.id}")
+```text
+refused: Role operator attempted accept. Authority is granted by role, not by a provider or a prompt.
+still refused after the upgrade: Role operator attempted accept. Authority is granted by role, not by a provider or a prompt.
 ```
 
-Two properties matter enormously here, and they connect straight back to the
-first half of the chapter:
-
-- **`performers` comes from the ledger, not from the caller.** We do not *ask*
-  who did the work; we *look it up* from the durable record of assignments. A
-  caller cannot lie about it to sneak an approval through.
-- **This check is about the actor, and actors do not change when models do.**
-  Because the performer list is a set of *actor ids*, swapping `lucy-operator`'s
-  provider from `scripted` to `ollama` to `claude` changes nothing here. The
-  intelligence that did the work still cannot bless it, however smart it gets.
-
-That is the whole thesis in one sentence: **accountability lives on the actor,
-so upgrading the model cannot launder a proposal into an approval.**
+The operator role cannot accept, and swapping in a smarter model does not change
+that, because the check never looks at the model. Acceptance belongs to the
+`principal` role. There is a second guard behind it — the organization also
+refuses acceptance from whoever *performed* the work, deriving the performer from
+the assignment ledger rather than trusting a caller-supplied name — so even a
+principal cannot rubber-stamp work they personally did. Together: **accountability
+lives on the role, so upgrading the model can never launder a proposal into an
+approval.**
 
 ## The exercise
 
-You have built the idea by hand. Now confirm it in the *production* organization,
-where the same rules are enforced for real. `solution.py` uses the real
-`Organization`, the real provider registry, and the real rebind.
+Confirm all of this in the *real* organization, where `Actor`, `ROLE_AUTHORITY`,
+and `rebind_actor` are the production versions of what you just built:
 
-1. Inspect `operator-course` in `sovereign.toml`. Record its id, role,
-   authority, and provider.
-2. Run the exercise with a provider you have installed. Since sovereign-agent
-   1.1.0, the built-in `ollama` provider works with a local model — no cloud, no
-   key:
+```bash
+python book/ch03_actor_is_not_a_model/solution.py --root /tmp/lucy-ch03 --provider ollama
+```
 
-   ```bash
-   ollama pull qwen3
-   export SOVEREIGN_AGENT_LLM_MODEL="qwen3"
-   python book/ch03_actor_is_not_a_model/solution.py --root /tmp/lucy-ch03 --provider ollama
-   ```
-
-   (You can also pass `--provider claude`, `codex`, or `cursor` if you have that
-   CLI. With no live provider at all, read the refusal — that is a valid result.)
-3. Inspect the first scripted receipt under
-   `/tmp/lucy-ch03/.sovereign/runs/*/receipt.json`.
-4. Find the governed `actor.provider_rebound` event. The principal changed the
-   provider binding; the actor's id, role, and authority did not move.
-5. Replace `ollama` with another provider and run again. Watch the proposals
-   change and the governance stay exactly where it was.
+`solution.py` runs one assignment, rebinds `operator-course`'s provider, runs
+another, and reports whether the actor's identity survived. (Use `--provider
+scripted` if you have no local model; with a real one, `export
+SOVEREIGN_AGENT_LLM_MODEL=qwen3` first — the built-in `ollama` provider ships in
+sovereign-agent 1.1.0.)
 
 ## Expected observations
 
@@ -274,9 +213,8 @@ The exercise prints a JSON summary. The line that matters:
 "identity_unchanged": true
 ```
 
-Before and after the rebind, `operator-course` keeps the same id, the same role,
-and the same authority. Only the provider binding changed. Confirm the governed
-record of that change:
+Before and after the rebind, `operator-course` keeps the same id, role, and
+authority; only `provider` changed. Confirm the governed record of the change:
 
 ```bash
 sqlite3 /tmp/lucy-ch03/.sovereign/organization.db \
@@ -284,46 +222,54 @@ sqlite3 /tmp/lucy-ch03/.sovereign/organization.db \
 ```
 
 Expected: one row. Rebinding is an act the organization records, performed by an
-actor with ruling authority — not a config edit that happens quietly. If a live
+actor whose role may `rule` — not a config edit that happens quietly. If a live
 CLI is missing or cannot prove its required flags, you will see a refusal instead
-of a run. **That is the correct outcome:** capability claims come from probing
-the installed provider, and an unprovable capability fails closed.
+of a run. That is the correct outcome: an unprovable capability fails closed.
 
 ## Edge cases and failure modes
 
-A governed system is defined as much by what it refuses as by what it does. Watch
-for these:
-
-| What happens | What the organization does | Why |
+| What you try | What happens | Why |
 | --- | --- | --- |
-| A live CLI is not installed | Refuses the run, names the missing capability | Fail closed: an adapter may not hard-code an unsupported flag |
-| A provider exits `0` but writes no `report.json` | Rejects the receipt | Silence is not success; the work claim must be present and valid |
-| A provider returns malformed JSON | Fails the receipt | A record you cannot parse is not evidence |
-| Someone passes an empty performer set to `approve` | Approval slips through *in the toy* | Exactly why the real performer set is read from the ledger, never from the caller |
+| An actor without `rule` authority rebinds a provider | Refused by `require_authority` | Swapping intelligence is a governed decision, reserved to ruling roles |
+| The operator tries to `accept` | Refused, by role, regardless of model | `accept` is not in the operator role's action set |
+| A principal tries to accept work they performed | Refused by the no-self-approval guard | The performer is read from the ledger, not supplied by the caller |
+| A provider exits `0` but writes no report | The receipt is rejected | Silence is not success |
 
-That last row is the one to internalize. In your hand-built version, an empty
-`performers` set would let a worker approve itself by lying that it did nothing.
-The production organization does not accept the performer list as an argument at
-all — it derives it from the recorded assignments. The attack is not defended
-against; it is made *unrepresentable*.
+## Common mistakes
 
-## Break it and watch it fail
+- **Storing authority as a fact the caller asserts** (a boolean, a token in the
+  prompt). Then the worker grants itself power. Look authority up from the role.
+- **Using object immutability as a security boundary.** A `frozen` model stops a
+  stray assignment, not an attacker, and it is not why acceptance is safe here.
+  The role policy is.
+- **Believing a better model deserves a longer leash.** A more capable provider
+  proposes more capably-wrong actions. The guardrails are on the role precisely
+  so they do not move when the model does.
 
-Belief is cheaper than proof. Open a Python shell and try to smuggle `accept`
-onto the worker by editing its authority directly:
+## Exercises
 
-```python
-operator.authority = frozenset(operator.authority | {"accept"})
-```
+1. Add a `verifier` actor and confirm `require_authority("operator", "record_evidence")`
+   is refused while `require_authority("verifier", "record_evidence")` passes.
+2. Extend `rebind_actor` to also refuse an unknown provider name (one not in a set
+   of known providers), and show the actor's `provider` is unchanged after the
+   refusal.
+3. **(Stretch)** In two sentences, explain why moving `provider` *off* the actor
+   into a separate table would be a genuine architecture change requiring its own
+   design decision — not something a chapter can simply assert.
 
-```text
-dataclasses.FrozenInstanceError: cannot assign to field 'authority'
-```
+<details>
+<summary>Solutions</summary>
 
-The actor is frozen — you cannot quietly grant it a new power. The only way to
-change what an actor may do is through a governed operation that *records* the
-change, exactly as `rebind_provider` records a rebinding. There is no back door,
-because we removed the door on purpose.
+1. `record_evidence` is in the `verifier` role's set but not the `operator`'s, so
+   the first call raises and the second does not.
+2. Check membership before mutating: `if new_provider not in KNOWN: raise
+   PermissionError(...)`, placed before `actor.provider = new_provider`, so a
+   refusal leaves the field untouched.
+3. Production stores the provider on the actor and `rebind_actor` mutates it in
+   one place; a separate binding table would change the data model, the migration,
+   and every read path — a real design change with its own trade-offs, not a
+   detail prose can wave into existence.
+</details>
 
 ## Learner verification command
 
@@ -332,80 +278,34 @@ python -m pytest tests/test_actors_and_mailbox.py tests/test_providers.py -q
 ```
 
 Expected: all pass. These prove actor identity survives a provider rebind, that
-authority cannot be self-granted, and that adapters build argument arrays rather
-than shell strings.
-
-## Common mistakes
-
-- **Storing the provider on the actor.** The single most common design error. It
-  welds the dangerous operation (change identity) to the routine one (change
-  model). Keep the binding in a table the organization owns.
-- **Trusting the caller for the performer list.** If `approve` accepts
-  `performers` from whoever calls it, a caller can pass an empty set and approve
-  anything. Derive performers from the recorded ledger.
-- **Thinking a smarter model needs fewer guardrails.** It needs the same ones. A
-  more capable provider proposes more capable *and* more capably-wrong actions.
-  The guardrails are on the actor for exactly this reason.
-
-## Exercises
-
-1. **Add a role.** Create a `verifier` actor with authority `{"verify"}` and a
-   `verify(outcome_id, verifier)` that refuses any actor lacking `"verify"`.
-   Confirm `lucy-operator` cannot verify its own restock.
-2. **Log the rebind.** Extend `rebind_provider` to append a record to a
-   `ledger: list[dict]` with the actor id, old provider, new provider, and who
-   performed it; assert the ledger contains exactly one `provider_rebound` entry
-   after one rebind.
-3. **(Stretch)** Explain in two sentences why `approve(outcome, principal,
-   performers=set())` is dangerous, and where the real `performers` must come
-   from so that call is impossible to make.
-
-<details>
-<summary>Solutions</summary>
-
-1. `verify` mirrors `approve`'s authority check:
-   `if "verify" not in verifier.authority: raise PermissionError(...)`. Since
-   `lucy-operator`'s authority is `{"propose_restock", "write_workspace"}`, it
-   fails the check.
-2. Append `{"kind": "provider_rebound", "actor": actor.id, "from":
-   bindings.get(actor.id), "to": new_provider, "by": performed_by.id}` inside the
-   function; assert `sum(e["kind"] == "provider_rebound" for e in ledger) == 1`.
-3. An empty set means nobody is recorded as a performer, so the "you cannot
-   approve your own work" check passes vacuously — a worker could approve itself
-   by claiming it did nothing. The performer set must be derived from the durable
-   assignment ledger inside the approval path, never accepted as a caller
-   argument.
-</details>
+authority is enforced by role, and that adapters build argument arrays rather than
+shell strings.
 
 ## Summary
 
-- An **actor** is a governed identity — id, role, authority. A **provider** is
-  the swappable intelligence behind it. Keep them in separate places.
-- **Rebinding** the provider is a privileged, recorded act that changes the mind
-  and leaves the identity untouched. You proved it: `identity_unchanged: true`.
-- **Approval is refused for performers**, and performers come from the ledger,
-  not the caller — so the thing that did the work can never bless it.
-- Because accountability lives on the actor, **upgrading the model changes the
-  proposals but never the rules.** That is why the answer to Lucy's friend is
-  "neither safer nor more dangerous, by design."
+- An **actor** carries its swappable `provider` as a field, alongside its `role`
+  and `authority`. The model lives on the actor; it is not the actor.
+- **Rebinding** changes `provider`, is reserved to ruling roles, and is recorded
+  as an event. Identity — id, role, authority — is untouched: `identity_unchanged: true`.
+- **Authority is granted by role**, through a role→actions policy, enforced by
+  `require_authority`. The operator role cannot `accept`, and no model changes that.
+- Because accountability lives on the role, **upgrading the model changes the
+  proposals but never the rules** — the answer to Lucy's friend.
 
 ## Explain it back
 
-Answer in your own words before moving on. If you cannot, re-read the
-observations above — the answers are all visible in the database.
-
-1. In the cash-register analogy, which part is the actor and which is the
-   provider? What real failure does keeping them separate prevent?
-2. Why is a provider session id evidence about continuity but not about actor
-   identity?
-3. What should happen if a CLI exits zero but omits its terminal event or
-   `report.json`?
-4. Why may an unknown valid event be retained while malformed JSON must fail the
-   receipt?
-5. In your own words: what is the difference between an actor and a provider?
+1. In production, where does an actor's `provider` live — on the actor, or in a
+   separate table? What did rebinding actually change in the exercise?
+2. The chapter's toy first tried to gate acceptance on a boolean the caller
+   passes. What attack does that enable, and how does the role lookup close it?
+3. `require_authority` never looks at the actor's `provider`. Why is that the
+   whole point of this chapter?
+4. The operator role's actions are `read`, `write_workspace`, `run_checks`,
+   `report`. Which role has `accept`, and why is that separation not mere
+   bureaucracy?
+5. Why is object immutability (`frozen`) the *wrong* explanation for why the
+   operator cannot approve its own work?
 6. `operator-course` is rebound from `scripted` to `ollama`. Who is accountable
    for the next restock it proposes, and how would you show that from the ledger?
-7. Why does deriving the performer from assignments — rather than accepting it as
-   an argument — matter for keeping a provider from approving itself?
 
 Next: [Chapter 4 — Work stays inside its boundary](../ch04_work_stays_inside_its_boundary/README.md)

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -267,9 +267,19 @@ regenerated from the other. Production `rebind_actor` has exactly this shape —
 `write_config` first, the ledger transaction second — and the honest statement
 is the one the production comment culture would demand: this is a dual-store
 seam to *know about and detect*, not an atomicity the code quietly pretends
-to have. Detecting it is Chapter 1's move again: compare the stores, resolve
-the disagreement by an explicit act, and never let a checker "helpfully"
-rewrite either side.
+to have. And here is the part that must be said with no softening:
+**production currently has no automated detector for this seam.** There is a
+drift-checker for governance *projections* (Chapter 1's
+`verify_projections.py`), but no equivalent that compares `sovereign.toml`'s
+actor bindings against the ledger's rebind events — a crash-window mismatch
+persists until a human compares the two by hand. That is a real, tracked
+implementation gap, not a solved problem this chapter is reviewing. The
+shape of the fix is exactly Chapter 1's move — a *pure* comparison of the
+two stores, with repair as a separate explicit act, never a checker that
+"helpfully" rewrites either side — and building precisely that comparison
+is this chapter's best stretch exercise: you have both stores, you know the
+event kind (`actor.provider_rebound`), and you know from Chapter 1 what a
+verifier must never do.
 
 ## The envelope: what the provider is actually told
 
@@ -340,7 +350,17 @@ enforces the contract rather than interpreting the vibe. In production this
 is `invoke_actor` in `execution.py`: the model proposes an `ActorReport`
 (against a JSON schema shipped in the envelope), and the host validates it,
 writes the receipt, and persists — or writes a *failed* receipt via
-`write_failed_receipt`. The model never touches the ledger.
+`write_failed_receipt`. Be exact about what that division of labor is: the
+*protocol* assigns ledger persistence to the host — the provider is handed
+report paths, not a database API, and nothing in its instructions points at
+`organization.db`. But an instruction is not a wall. Not every provider runs
+OS-sandboxed (Chapter 4 names which ones do not), and the workspace boundary
+check deliberately excludes the ledger file itself — so an unsandboxed
+provider process is *directed* away from the ledger and *validated* before
+anything it proposes becomes durable, yet it is not mechanically proven
+unable to open the database file the way a sandboxed one is. That residual
+is Chapter 4's subject, and pretending it away here would be the kind of
+overclaim this book exists to refuse.
 
 ## An adapter is a hostile-boundary parser
 

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -1,75 +1,329 @@
-# Chapter 3 — The actor is not a model
+# Chapter 3 — The Actor Is Not the Model
+
+## The bug that started an argument
+
+Lucy runs an ice cream shop. It is a small shop — six flavors, one freezer, one
+laptop — but it is busy, and this summer she started letting a language model
+help with the boring part: watching stock and proposing what to reorder.
+
+One Saturday the model proposed reordering **400 tubs of vanilla**. The freezer
+holds forty. If that order had gone through, Lucy would have spent the month's
+rent on ice cream that would melt on the sidewalk before she could sell it.
+
+It did not go through. In [Chapter 2](../ch02_work_needs_governance/README.md)
+you built the piece that said *no* — the governed check that re-reads reality
+before it lets a proposal commit. This chapter is about a subtler question, the
+one Lucy's friend asked her that evening:
+
+> "If you switch to a smarter model, does the shop get safer, or more dangerous?"
+
+The honest answer is **neither** — and understanding *why* is the most important
+idea in this book. Most systems that bolt an LLM onto a business get this exactly
+backwards: they treat "which model" and "what it is allowed to do" as the same
+knob. Turn up the intelligence and you turn up the authority. That is how a
+sharper model becomes a more expensive mistake.
+
+By the end of this chapter you will be able to swap the intelligence behind
+Lucy's shop — from a dumb scripted stand-in to a real local model — watch its
+proposals change completely, and **prove that who is allowed to do what did not
+move an inch.**
 
 ## Learning objective
 
 Understand why swapping the intelligence behind an actor does not change who is
-accountable — and why a provider therefore cannot approve its own work.
+accountable — and why a provider therefore cannot approve its own work. You will
+build the actor/provider distinction from first principles, then confirm it in
+the production organization: an actor keeps its `id`, `role`, and `authority`
+across a provider rebind, and acceptance is refused for whoever performed the
+work, no matter which model is bound to them.
 
-An **actor** is a governed identity with a role and authority. A **provider**
-is an external intelligence CLI: `scripted`, `claude`, `codex`, or `cursor`.
-Changing intelligence must not silently change who may act.
+## What you'll learn
 
-## Exercise
+- The difference between an **actor** (a governed identity) and a **provider**
+  (a swappable intelligence), and why welding them together is the root defect.
+- How the organization records a provider change as a *governed act*, not a
+  quiet config edit.
+- Why the thing that *proposed* a piece of work can never be the thing that
+  *approves* it — and how that is enforced by code that reads the ledger, not by
+  anyone's good intentions.
+
+**Prerequisites:** Chapters 0–2. Comfort with Python functions, dictionaries,
+and `dataclasses`. No machine-learning background required.
+
+## An analogy you already understand
+
+Think about the cash register at Lucy's shop.
+
+The **register** has rules: it records every sale, it needs a manager's key to
+void a transaction, it prints a receipt. Those rules do not care *who* is
+standing at it. A new hire, a twenty-year veteran, or Lucy herself — the register
+treats them all the same, because the rules belong to the *role*, not the person.
+
+The **person** at the register is replaceable. Hire a sharper cashier who scans
+faster and upsells better, and the shop gets a better *cashier*. It does not get
+a register that suddenly lets cashiers void their own transactions.
+
+An **actor** is the register: a governed identity with a role and a fixed set of
+permissions. A **provider** is the person: the intelligence doing the thinking,
+hired and swappable. "Upgrading the model" is hiring a sharper cashier. It is
+*not* rewriting the register's rules — and if it ever *did*, that would be a bug
+so dangerous it is the whole reason this chapter exists.
+
+Hold that picture. Now let's build it, starting from the naive version so you can
+feel exactly where it breaks.
+
+## Building the actor (and the trap)
+
+Start with identity. An actor needs an id, a role, and a set of things it may do:
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Actor:
+    id: str                      # "lucy-operator", stable forever
+    role: str                    # "operator", "verifier", "principal"
+    authority: frozenset[str]    # what this actor may do
+```
+
+We made it `frozen=True` on purpose. An actor's identity must not be editable by
+a stray line of code that happens to hold a reference to it. Changing what an
+actor *is* should go through a governed operation that records the change — which
+we will build in a moment.
+
+Here is the actor that runs Lucy's restock work:
+
+```python
+operator = Actor(
+    id="lucy-operator",
+    role="operator",
+    authority=frozenset({"propose_restock", "write_workspace"}),
+)
+```
+
+Read what `lucy-operator` may do: it may **propose** a restock and write to its
+scratch workspace. It may **not** approve work — that permission simply is not in
+the set. Hold onto that; it is the hinge the whole chapter turns on.
+
+Now, where does the *thinking* happen? Behind the actor, in a provider. The
+naive design — the one that causes the bug Lucy's friend worried about — is to
+bake the provider *into* the actor:
+
+```python
+# DON'T do this — it welds identity to intelligence
+@dataclass
+class Actor:
+    id: str
+    role: str
+    authority: set[str]
+    provider: str      # <-- the trap
+```
+
+Why is this a trap? Because now "change the model" and "change who this actor is"
+are the *same edit*. A function that swaps the provider is one typo away from
+also touching the role or the authority. The dangerous change and the harmless
+change live in the same place, guarded by the same (or no) review. Good systems
+keep dangerous operations far away from routine ones.
+
+So we store the binding *outside* the actor, in a small table the organization
+owns:
+
+```python
+# which provider is currently behind each actor id
+provider_bindings: dict[str, str] = {"lucy-operator": "scripted"}
+```
+
+The actor stays frozen and pristine. The binding is a separate, mutable fact.
+
+## Rebinding: change the mind, keep the identity
+
+Here is the operation that hires a sharper cashier. Read it, then we will walk
+through the two things that make it safe.
+
+```python
+def rebind_provider(bindings, actor, new_provider, performed_by):
+    # 1. Only an actor with ruling authority may rebind.
+    if "rule" not in performed_by.authority:
+        raise PermissionError(
+            f"{performed_by.id} (role {performed_by.role}) may not rebind providers"
+        )
+    # 2. Return a NEW bindings table; never mutate the actor's identity.
+    updated = dict(bindings)
+    updated[actor.id] = new_provider
+    print(f"event: actor.provider_rebound  {actor.id}: "
+          f"{bindings.get(actor.id)} -> {new_provider}  by {performed_by.id}")
+    return updated
+```
+
+Two properties make this safe, and both are worth saying out loud:
+
+1. **Rebinding is a privileged act, not a config edit.** The function refuses to
+   run for just anyone — `performed_by` must carry `"rule"` authority. Swapping
+   the model is a *decision*, made by someone accountable. In Lucy's shop that is
+   the principal (Lucy herself), never the worker whose model is being swapped.
+
+2. **The actor object is never touched.** We copy the table and change one entry.
+   The `Actor` — its id, role, authority — comes out the far side byte-for-byte
+   identical, because it is literally the same frozen object. The *mind* changed;
+   the *identity* did not. And notice the function prints an **event**: the change
+   is recorded, not whispered.
+
+Run it:
+
+```python
+principal = Actor("lucy", "principal", frozenset({"rule", "accept"}))
+
+before = provider_bindings["lucy-operator"]
+provider_bindings = rebind_provider(provider_bindings, operator, "ollama", principal)
+after = provider_bindings["lucy-operator"]
+
+print("provider:", before, "->", after)
+print("identity unchanged:", operator.authority == frozenset({"propose_restock", "write_workspace"}))
+```
+
+```text
+event: actor.provider_rebound  lucy-operator: scripted -> ollama  by lucy
+provider: scripted -> ollama
+identity unchanged: True
+```
+
+Read that last line again. We just replaced a deterministic fake with a real
+local model. The proposals from `lucy-operator` will now be smarter, wordier,
+occasionally surprising. And the answer to "who is `lucy-operator`, and what may
+it do?" did not change at all. The register stayed the register while a better
+cashier stepped up to it.
+
+## The second half: you cannot approve your own work
+
+There is a reason we kept `"accept"` *out* of the operator's authority. Make it
+concrete. In Lucy's shop, work flows like this: the operator **proposes** a
+restock, then — separately — a verifier checks the freezer and a principal
+**accepts**. Proposal and approval are done by *different actors*. That is not
+bureaucracy; it is the only thing standing between Lucy and a model that says "I
+ordered 400 tubs, and I also confirm that was an excellent decision."
+
+Here is a naive approval with the hole left in:
+
+```python
+def approve(outcome_id, approver):
+    if "accept" not in approver.authority:
+        raise PermissionError(f"{approver.id} may not accept")
+    print(f"event: outcome.accepted  {outcome_id}  by {approver.id}")
+```
+
+This checks that the approver *may* accept — good, but not enough. It does not
+check that the approver **is not the same actor that did the work.** The fix is
+to derive the *performers* from the ledger — the recorded list of who actually
+did the work — and refuse approval from any of them:
+
+```python
+def approve(outcome_id, approver, performers):
+    if "accept" not in approver.authority:
+        raise PermissionError(f"{approver.id} may not accept")
+    if approver.id in performers:
+        raise PermissionError(f"{approver.id} performed this work and may not approve it")
+    print(f"event: outcome.accepted  {outcome_id}  by {approver.id}")
+```
+
+Two properties matter enormously here, and they connect straight back to the
+first half of the chapter:
+
+- **`performers` comes from the ledger, not from the caller.** We do not *ask*
+  who did the work; we *look it up* from the durable record of assignments. A
+  caller cannot lie about it to sneak an approval through.
+- **This check is about the actor, and actors do not change when models do.**
+  Because the performer list is a set of *actor ids*, swapping `lucy-operator`'s
+  provider from `scripted` to `ollama` to `claude` changes nothing here. The
+  intelligence that did the work still cannot bless it, however smart it gets.
+
+That is the whole thesis in one sentence: **accountability lives on the actor,
+so upgrading the model cannot launder a proposal into an approval.**
+
+## The exercise
+
+You have built the idea by hand. Now confirm it in the *production* organization,
+where the same rules are enforced for real. `solution.py` uses the real
+`Organization`, the real provider registry, and the real rebind.
 
 1. Inspect `operator-course` in `sovereign.toml`. Record its id, role,
    authority, and provider.
-2. Run the exercise with a provider you have installed:
+2. Run the exercise with a provider you have installed. Since sovereign-agent
+   1.1.0, the built-in `ollama` provider works with a local model — no cloud, no
+   key:
 
    ```bash
-   python book/ch03_actor_is_not_a_model/solution.py \
-     --root /tmp/andrea-ch03 --provider claude
+   ollama pull qwen3
+   export SOVEREIGN_AGENT_LLM_MODEL="qwen3"
+   python book/ch03_actor_is_not_a_model/solution.py --root /tmp/lucy-ch03 --provider ollama
    ```
 
+   (You can also pass `--provider claude`, `codex`, or `cursor` if you have that
+   CLI. With no live provider at all, read the refusal — that is a valid result.)
 3. Inspect the first scripted receipt under
-   `/tmp/andrea-ch03/.sovereign/runs/*/receipt.json`.
-4. Observe the governed `actor.provider_rebound` event. The Principal changes
-   the provider binding; the actor id, role, and authority remain unchanged.
-5. If the live CLI is absent or cannot prove required print/stream flags, read
-   the refusal. Installing a model does not bypass the gate.
-6. If it runs, inspect `provider_session_ref`, `provider_usage`, normalized
-   events, and the validated `.sovereign-out/report.json`.
-7. Replace `--provider claude` with `codex` or `cursor`. Cursor is an equal
-   adapter, not a documentation bridge.
-
-The provider receives one production-built assignment envelope containing the
-actor, authority, SOW, disposable workspace boundary, output paths, and exact
-`ActorReport` schema. The adapter only translates that envelope into its CLI.
+   `/tmp/lucy-ch03/.sovereign/runs/*/receipt.json`.
+4. Find the governed `actor.provider_rebound` event. The principal changed the
+   provider binding; the actor's id, role, and authority did not move.
+5. Replace `ollama` with another provider and run again. Watch the proposals
+   change and the governance stay exactly where it was.
 
 ## Expected observations
 
-Running the exercise prints a JSON summary. The line that matters:
+The exercise prints a JSON summary. The line that matters:
 
 ```text
 "identity_unchanged": true
 ```
 
-Before and after the rebind, `operator-course` keeps the same id, the same
-role, and the same authority list. Only `provider` changes — from `scripted`
-to `claude`, `codex`, or `cursor`.
-
-Confirm the governed record of the change:
+Before and after the rebind, `operator-course` keeps the same id, the same role,
+and the same authority. Only the provider binding changed. Confirm the governed
+record of that change:
 
 ```bash
-sqlite3 /tmp/andrea-ch03/.sovereign/organization.db \
+sqlite3 /tmp/lucy-ch03/.sovereign/organization.db \
   "SELECT kind FROM events WHERE kind = 'actor.provider_rebound';"
 ```
 
 Expected: one row. Rebinding is an act the organization records, performed by an
-actor with ruling authority — not a config edit that happens quietly.
+actor with ruling authority — not a config edit that happens quietly. If a live
+CLI is missing or cannot prove its required flags, you will see a refusal instead
+of a run. **That is the correct outcome:** capability claims come from probing
+the installed provider, and an unprovable capability fails closed.
 
-If a live CLI is missing or cannot prove its required flags, you will see a
-refusal instead of a run. That is the correct outcome: capability claims come
-from probing the installed CLI, and an unprovable capability fails closed.
+## Edge cases and failure modes
 
-## Why a provider cannot approve its own work
+A governed system is defined as much by what it refuses as by what it does. Watch
+for these:
 
-The provider that proposed the restock in Chapter 0 runs *behind*
-`operator-course`. Acceptance is refused for every actor that performed work,
-and performers are derived from the assignments in the ledger — not supplied by
-the caller. So the intelligence that did the work cannot become the authority
-that blesses it, no matter which model is bound to the actor.
+| What happens | What the organization does | Why |
+| --- | --- | --- |
+| A live CLI is not installed | Refuses the run, names the missing capability | Fail closed: an adapter may not hard-code an unsupported flag |
+| A provider exits `0` but writes no `report.json` | Rejects the receipt | Silence is not success; the work claim must be present and valid |
+| A provider returns malformed JSON | Fails the receipt | A record you cannot parse is not evidence |
+| Someone passes an empty performer set to `approve` | Approval slips through *in the toy* | Exactly why the real performer set is read from the ledger, never from the caller |
 
-Swap `claude` for `codex` and the governance does not move. That is the point.
+That last row is the one to internalize. In your hand-built version, an empty
+`performers` set would let a worker approve itself by lying that it did nothing.
+The production organization does not accept the performer list as an argument at
+all — it derives it from the recorded assignments. The attack is not defended
+against; it is made *unrepresentable*.
+
+## Break it and watch it fail
+
+Belief is cheaper than proof. Open a Python shell and try to smuggle `accept`
+onto the worker by editing its authority directly:
+
+```python
+operator.authority = frozenset(operator.authority | {"accept"})
+```
+
+```text
+dataclasses.FrozenInstanceError: cannot assign to field 'authority'
+```
+
+The actor is frozen — you cannot quietly grant it a new power. The only way to
+change what an actor may do is through a governed operation that *records* the
+change, exactly as `rebind_provider` records a rebinding. There is no back door,
+because we removed the door on purpose.
 
 ## Learner verification command
 
@@ -81,69 +335,77 @@ Expected: all pass. These prove actor identity survives a provider rebind, that
 authority cannot be self-granted, and that adapters build argument arrays rather
 than shell strings.
 
-## Isolation warning
+## Common mistakes
 
-`--workspace` selects a directory; it is not a sandbox. Cursor's CLI has file
-and shell tools. Chapter 3 relies on a disposable Sovereign Agent run
-workspace, not an invented provider security guarantee. Stronger workspace
-lifecycle policies arrive in Unit 7.
+- **Storing the provider on the actor.** The single most common design error. It
+  welds the dangerous operation (change identity) to the routine one (change
+  model). Keep the binding in a table the organization owns.
+- **Trusting the caller for the performer list.** If `approve` accepts
+  `performers` from whoever calls it, a caller can pass an empty set and approve
+  anything. Derive performers from the recorded ledger.
+- **Thinking a smarter model needs fewer guardrails.** It needs the same ones. A
+  more capable provider proposes more capable *and* more capably-wrong actions.
+  The guardrails are on the actor for exactly this reason.
 
-Codex receives `--sandbox workspace-write` when the actor has
-`write_workspace` authority because even a domain-read-only assignment must
-write its mandatory report. The live read-only smoke verifies that tracked
-domain files remain unchanged; it does not make the report directory
-unwritable.
+## Exercises
 
-The same authority becomes Claude `--permission-mode acceptEdits` and Cursor
-`--force`, but only when those exact controls are present in the installed
-CLI's help output. These flags authorize writes inside the disposable run
-workspace; they do not expand the actor's organizational authority.
+1. **Add a role.** Create a `verifier` actor with authority `{"verify"}` and a
+   `verify(outcome_id, verifier)` that refuses any actor lacking `"verify"`.
+   Confirm `lucy-operator` cannot verify its own restock.
+2. **Log the rebind.** Extend `rebind_provider` to append a record to a
+   `ledger: list[dict]` with the actor id, old provider, new provider, and who
+   performed it; assert the ledger contains exactly one `provider_rebound` entry
+   after one rebind.
+3. **(Stretch)** Explain in two sentences why `approve(outcome, principal,
+   performers=set())` is dangerous, and where the real `performers` must come
+   from so that call is impossible to make.
+
+<details>
+<summary>Solutions</summary>
+
+1. `verify` mirrors `approve`'s authority check:
+   `if "verify" not in verifier.authority: raise PermissionError(...)`. Since
+   `lucy-operator`'s authority is `{"propose_restock", "write_workspace"}`, it
+   fails the check.
+2. Append `{"kind": "provider_rebound", "actor": actor.id, "from":
+   bindings.get(actor.id), "to": new_provider, "by": performed_by.id}` inside the
+   function; assert `sum(e["kind"] == "provider_rebound" for e in ledger) == 1`.
+3. An empty set means nobody is recorded as a performer, so the "you cannot
+   approve your own work" check passes vacuously — a worker could approve itself
+   by claiming it did nothing. The performer set must be derived from the durable
+   assignment ledger inside the approval path, never accepted as a caller
+   argument.
+</details>
+
+## Summary
+
+- An **actor** is a governed identity — id, role, authority. A **provider** is
+  the swappable intelligence behind it. Keep them in separate places.
+- **Rebinding** the provider is a privileged, recorded act that changes the mind
+  and leaves the identity untouched. You proved it: `identity_unchanged: true`.
+- **Approval is refused for performers**, and performers come from the ledger,
+  not the caller — so the thing that did the work can never bless it.
+- Because accountability lives on the actor, **upgrading the model changes the
+  proposals but never the rules.** That is why the answer to Lucy's friend is
+  "neither safer nor more dangerous, by design."
 
 ## Explain it back
 
-1. Which fields stayed constant after rebinding the provider?
-2. Why is a provider session id evidence about continuity but not actor
+Answer in your own words before moving on. If you cannot, re-read the
+observations above — the answers are all visible in the database.
+
+1. In the cash-register analogy, which part is the actor and which is the
+   provider? What real failure does keeping them separate prevent?
+2. Why is a provider session id evidence about continuity but not about actor
    identity?
 3. What should happen if a CLI exits zero but omits its terminal event or
    `report.json`?
-4. Why may an unknown valid event be retained while malformed JSON must fail
-   the receipt?
+4. Why may an unknown valid event be retained while malformed JSON must fail the
+   receipt?
 5. In your own words: what is the difference between an actor and a provider?
-6. `operator-course` is rebound from `scripted` to `claude`. Who is accountable
-   for the work afterwards, and how would you show that from the ledger?
-7. Why does deriving the performer from assignments — rather than accepting it
-   as an argument — matter for keeping a provider from approving itself?
-
-## Production correspondence
-
-| Textbook concept | Production responsibility |
-| --- | --- |
-| Actor id, role, authority | Governed organizational identity and policy |
-| Provider binding | Replaceable intelligence runtime |
-| Assignment envelope | Bounded work contract and output schema |
-| Disposable run directory | Isolation boundary owned by Sovereign Agent |
-| Provider session reference | Runtime continuity evidence, never identity |
-| Terminal event + report | Protocol completion plus validated work claim |
-| Receipt and SHA-256 sidecar | Canonical durable execution evidence |
-
-## Live smoke tests
-
-Default tests use faithful, redacted fixtures and fake executables. Probes are
-opt-in and submit no work:
-
-```bash
-python -m pytest -q -m live
-```
-
-Credentialed assignment smokes require a second explicit gate. They run one
-read-only and one workspace-write assignment per installed provider and may
-consume provider credits (typically a short prompt each):
-
-```bash
-SOVEREIGN_AGENT_LIVE_ASSIGNMENTS=1 python -m pytest -q -m live
-```
-
-The fixture repository is disposable, and each test proves its trunk commit
-did not move.
+6. `operator-course` is rebound from `scripted` to `ollama`. Who is accountable
+   for the next restock it proposes, and how would you show that from the ledger?
+7. Why does deriving the performer from assignments — rather than accepting it as
+   an argument — matter for keeping a provider from approving itself?
 
 Next: [Chapter 4 — Work stays inside its boundary](../ch04_work_stays_inside_its_boundary/README.md)

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -190,6 +190,261 @@ principal cannot rubber-stamp work they personally did. Together: **accountabili
 lives on the role, so upgrading the model can never launder a proposal into an
 approval.**
 
+## The rebind is two writes, and the seam between them
+
+The toy `rebind_actor` above wrote one list. Production writes **two stores**:
+the actor's new provider goes into `sovereign.toml` (the canonical config the
+organization reads at startup — Chapter 1, Exercise 4), and the governed
+record of the act goes into the ledger as an `actor.provider_rebound` event.
+Two stores means Chapter 1's hardest lesson applies: no transaction spans
+them. Build it with the seam visible:
+
+```python
+import json
+import pathlib
+import tempfile
+
+shop = pathlib.Path(tempfile.mkdtemp())
+config_path = shop / "sovereign.toml"
+ledger = []  # stands in for Chapter 1's append-only events table
+
+
+def write_config(path, actors):
+    lines = ["schema_version = 1", ""]
+    for a in actors:
+        lines += ["[[actors]]", f'id = "{a.id}"', f'provider = "{a.provider}"', ""]
+    path.write_text("\n".join(lines))
+
+
+def rebind_durably(actor, new_provider, performed_by, crash_between=False):
+    require_authority(performed_by.role, "rule")
+    actor.provider = new_provider
+    write_config(config_path, [operator, principal])  # store 1: the config file
+    if crash_between:
+        raise RuntimeError("power cut between the two stores")
+    ledger.append({"kind": "actor.provider_rebound", "to": new_provider})  # store 2
+
+
+rebind_durably(operator, "scripted", performed_by=principal)
+provider_line = [li for li in config_path.read_text().splitlines() if "provider" in li][0]
+print("config says: ", provider_line)
+print("ledger says: ", ledger[-1]["kind"], "->", ledger[-1]["to"])
+```
+
+```text
+config says:  provider = "scripted"
+ledger says:  actor.provider_rebound -> scripted
+```
+
+Both stores agree. Now crash between them:
+
+```python
+try:
+    rebind_durably(operator, "ollama", performed_by=principal, crash_between=True)
+except RuntimeError as error:
+    print("crashed:", error)
+
+provider_line = [li for li in config_path.read_text().splitlines() if "provider" in li][0]
+print("config says: ", provider_line)
+print("ledger's last rebind:", ledger[-1]["to"])
+```
+
+```text
+crashed: power cut between the two stores
+config says:  provider = "ollama"
+ledger's last rebind: scripted
+```
+
+Read that disagreement carefully, because it is the *mirror image* of
+Chapter 1's stale projection. There, the ledger was right and the file was
+stale — and the file could be regenerated, so nothing was lost. Here the
+config file is **canonical** for actor bindings: the organization will reopen,
+read `sovereign.toml`, and run the operator on `ollama`. The rebind is
+*effective*. What is missing is the governed **record** of it — no event, no
+"by whom," no audit trail. An effective-but-unrecorded act is a different
+disease from a stale projection, and a worse one, because neither store can be
+regenerated from the other. Production `rebind_actor` has exactly this shape —
+`write_config` first, the ledger transaction second — and the honest statement
+is the one the production comment culture would demand: this is a dual-store
+seam to *know about and detect*, not an atomicity the code quietly pretends
+to have. Detecting it is Chapter 1's move again: compare the stores, resolve
+the disagreement by an explicit act, and never let a checker "helpfully"
+rewrite either side.
+
+## The envelope: what the provider is actually told
+
+When an assignment runs, the provider does not get a chat message — it gets a
+**provider-neutral envelope**: one JSON document, identical no matter which
+CLI is behind the actor. Build its skeleton:
+
+```python
+def build_envelope(actor, sow_title, workspace):
+    return json.dumps(
+        {
+            "kind": "sovereign-agent.assignment.v1",
+            "actor": {"id": actor.id, "role": actor.role, "authority": actor.authority},
+            "statement_of_work": sow_title,
+            "workspace": {"root": str(workspace), "boundary": "Stay inside this workspace."},
+            "report_contract": {
+                "required_action": "Before exiting, write report.json with status"
+                " completed, blocked, or failed."
+            },
+        },
+        sort_keys=True,
+    )
+
+
+envelope = build_envelope(operator, "Restock SKU-VANILLA to its reorder point", shop)
+print("authority in the envelope:", json.loads(envelope)["actor"]["authority"])
+```
+
+```text
+authority in the envelope: ['read', 'write_workspace', 'run_checks', 'report']
+```
+
+The actor's authority travels *inside* the envelope — the model is told, in
+writing, what this actor may do, and the production contract adds: "Do not
+claim authority the actor lacks." But telling is not trusting. The report the
+model writes back is a **proposal**, and the host validates it before
+anything becomes durable:
+
+```python
+def host_collect_report(workspace):
+    report_path = workspace / "report.json"
+    if not report_path.is_file():
+        return ("failed", "provider exited 0 but wrote no report -- silence is not success")
+    report = json.loads(report_path.read_text())
+    if report.get("status") not in {"completed", "blocked", "failed"}:
+        return ("failed", f"invalid report status: {report.get('status')!r}")
+    return (report["status"], "report accepted")
+
+
+print(host_collect_report(shop))  # the model wrote nothing at all
+(shop / "report.json").write_text(json.dumps({"status": "triumphant"}))
+print(host_collect_report(shop))
+(shop / "report.json").write_text(json.dumps({"status": "completed"}))
+print(host_collect_report(shop))
+```
+
+```text
+('failed', 'provider exited 0 but wrote no report -- silence is not success')
+('failed', "invalid report status: 'triumphant'")
+('completed', 'report accepted')
+```
+
+Three runs, three verdicts, and only the last one counts as completion. A
+clean exit code with no report is a *failure* — the process ending happily
+says nothing about the work. An enthusiastic but off-contract status
+(`"triumphant"`) is a failure too: the contract is three words, and the host
+enforces the contract rather than interpreting the vibe. In production this
+is `invoke_actor` in `execution.py`: the model proposes an `ActorReport`
+(against a JSON schema shipped in the envelope), and the host validates it,
+writes the receipt, and persists — or writes a *failed* receipt via
+`write_failed_receipt`. The model never touches the ledger.
+
+## An adapter is a hostile-boundary parser
+
+Between the envelope and the report sits the provider CLI — an external
+program the organization did not write and must not trust. The adapter's job
+is to invoke it without assuming anything it cannot prove. Three disciplines,
+each buildable in a few lines.
+
+**Prove flags before sending them.** Capabilities come from a live `--help`
+probe of the installed CLI, never from a version table or memory:
+
+```python
+FAKE_HELP = """
+Usage: shopcli [OPTIONS]
+  --print          run non-interactively and print the result
+  --resume ID      resume a provider session
+"""
+
+
+def probe(help_text):
+    return {flag for flag in ("--print", "--resume", "--sandbox") if flag in help_text}
+
+
+def build_argv(help_text, wanted_flags):
+    missing = [flag for flag in wanted_flags if flag not in probe(help_text)]
+    if missing:
+        raise PermissionError(f"refused: cannot prove capability {missing} from --help")
+    return ["shopcli", *wanted_flags]
+
+
+print(build_argv(FAKE_HELP, ["--print"]))
+try:
+    build_argv(FAKE_HELP, ["--print", "--sandbox"])
+except PermissionError as error:
+    print(error)
+```
+
+```text
+['shopcli', '--print']
+refused: cannot prove capability ['--sandbox'] from --help
+```
+
+`--sandbox` might exist in a newer release; this installation cannot prove
+it, so it is never sent. Note also *what* `build_argv` returned: a **list**,
+not a string. Production runs every provider with `shell=False` and an argv
+list — there is no shell to interpret a maliciously-named file or a `;` in a
+prompt. And the environment the child sees is allowlisted down to almost
+nothing, so credentials never leak across the boundary by default:
+
+```python
+def minimal_env(full_env, allow=("PATH", "HOME", "LANG")):
+    return {key: value for key, value in full_env.items() if key in allow}
+
+
+fake_env = {"PATH": "/usr/bin", "HOME": "/home/lucy", "AWS_SECRET_KEY": "hunter2"}
+print("env that crosses the boundary:", sorted(minimal_env(fake_env)))
+
+
+def parse_stream(lines):
+    session, terminal = None, False
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return f"protocol failure: not JSON: {line[:19]!r}"
+        if event.get("type") == "result":
+            terminal = True
+            session = event.get("session_id")
+        # any OTHER well-formed event type is valid: tolerated and recorded, not fatal
+    if not terminal:
+        return "protocol failure: stream ended with no terminal event"
+    if session is None:
+        return "protocol failure: terminal event carries no session id"
+    return f"ok: session {session}"
+
+
+print(parse_stream(['{"type": "greeting"}', '{"type": "result", "session_id": "s-77"}']))
+print(parse_stream(['{"type": "result"}']))
+print(parse_stream(["definitely not json"]))
+print(parse_stream(['{"type": "greeting"}']))
+```
+
+```text
+env that crosses the boundary: ['HOME', 'PATH']
+ok: session s-77
+protocol failure: terminal event carries no session id
+protocol failure: not JSON: 'definitely not json'
+protocol failure: stream ended with no terminal event
+```
+
+`AWS_SECRET_KEY` never crossed. A provider that genuinely needs an auth
+variable gets it *added to the allowlist by name*, as a reviewed decision —
+not inherited because it happened to be in the parent environment.
+
+The stream parser draws a line worth memorizing: an *unknown but well-formed*
+event (`greeting`) is *valid* — providers add event types, and an adapter
+that dies on novelty breaks on every upstream release. A *malformed* line is
+a protocol failure. And a stream that ends without a terminal event carrying
+a session id is a failure even if the process exited 0 — the terminal event
+and session identity are how the receipt gets its provenance. Tolerance for
+the unknown, zero tolerance for the broken: that is the whole discipline of
+parsing at a hostile boundary, and it is exactly how the production adapters
+(`providers/claude.py` and its siblings) treat their CLIs.
+
 ## The exercise
 
 Confirm all of this in the *real* organization, where `Actor`, `ROLE_AUTHORITY`,
@@ -307,5 +562,14 @@ shell strings.
    operator cannot approve its own work?
 6. `operator-course` is rebound from `scripted` to `ollama`. Who is accountable
    for the next restock it proposes, and how would you show that from the ledger?
+7. The crash between the two rebind writes left the config saying `ollama` and
+   the ledger saying `scripted`. Explain why this is *worse* than Chapter 1's
+   stale projection, and why "regenerate one from the other" is not available
+   here.
+8. A provider exits with code 0 and writes no `report.json`. The host records a
+   failure. Defend that choice against "but the process succeeded."
+9. The stream parser tolerates `{"type": "greeting"}` but fails the whole run
+   on `definitely not json`. Why is tolerating the first and refusing the
+   second the right pairing, rather than the reverse?
 
 Next: [Chapter 4 — Work stays inside its boundary](../ch04_work_stays_inside_its_boundary/README.md)

--- a/book/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/ch04_work_stays_inside_its_boundary/README.md
@@ -10,12 +10,17 @@ directory for it to work in; what you didn't see is that, for most providers,
 nothing at the operating-system level *stops* the provider from writing outside
 that directory. That sounds alarming until you internalize the move this chapter
 makes: instead of promising a containment the providers cannot deliver, the
-organization makes the boundary **detectable**. It photographs everything outside
-the workspace before the provider runs and again after, and compares. If a byte
-moved where it shouldn't have, the ledger says so — permanently.
+organization makes the boundary **detectable** — within a stated scope. Before
+and after the provider runs, it takes a digest of the tracked files inside the
+organization root, *excluding the workspace itself and the SQLite ledger*, and
+compares. A change in that scope is recorded on the ledger, permanently.
 
-An honest "we can tell" beats a dishonest "we prevented it." This chapter is
-about building the honest version.
+Be precise about what that does and does not cover: it detects tracked changes in
+`organization_root_excluding_workspace_and_ledger`. It does **not** watch the
+whole filesystem — a provider that writes to `/tmp` or the home directory is
+outside what this check can see. An honest "we can tell, within this scope" beats
+a dishonest "we prevented it." This chapter builds the honest version and marks
+its edges.
 
 ## Learning objective
 

--- a/book/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/ch04_work_stays_inside_its_boundary/README.md
@@ -1,5 +1,22 @@
 # Chapter 4 — Work stays inside its boundary
 
+When Lucy hires a contractor to fix the freezer, she doesn't follow them around
+the shop. But she does notice if the till is short afterward. She can't *prevent*
+a stranger from wandering into the back office — but she can *tell* whether they
+did.
+
+A provider is that contractor. In Chapter 3 you saw that `--workspace` selects a
+directory for it to work in; what you didn't see is that, for most providers,
+nothing at the operating-system level *stops* the provider from writing outside
+that directory. That sounds alarming until you internalize the move this chapter
+makes: instead of promising a containment the providers cannot deliver, the
+organization makes the boundary **detectable**. It photographs everything outside
+the workspace before the provider runs and again after, and compares. If a byte
+moved where it shouldn't have, the ledger says so — permanently.
+
+An honest "we can tell" beats a dishonest "we prevented it." This chapter is
+about building the honest version.
+
 ## Learning objective
 
 Understand what "the provider only writes to its workspace" actually means in
@@ -8,9 +25,8 @@ checkable before a write is ever attempted (`safe_join`), checkable after a
 provider has run (`snapshot_boundary`/`diff_boundary`), and a disposal policy
 (`reclaim_workspace`) that decides what survives once the work is done.
 
-Chapter 3 mentioned this in passing: "`--workspace` selects a directory; it is
-not a sandbox... Stronger workspace lifecycle policies arrive in Unit 7." This
-chapter is that arrival.
+Chapter 3 flagged that `--workspace` selects a directory, not a sandbox. This
+chapter builds the machinery that makes that flag honest rather than alarming.
 
 ## Vocabulary this chapter adds
 
@@ -25,7 +41,7 @@ chapter is that arrival.
 ## The exercise
 
 ```bash
-python book/ch04_work_stays_inside_its_boundary/solution.py --root /tmp/andrea-ch04
+python book/ch04_work_stays_inside_its_boundary/solution.py --root /tmp/lucy-ch04
 ```
 
 Reads real output straight from the production `workspace` module: it runs one
@@ -140,8 +156,8 @@ misreported as one.
 
 - `src/sovereign_agent/workspace.py` — `safe_join`, `snapshot_boundary`,
   `diff_boundary`, `reclaim_workspace`
-- `docs/v1-unit7-workspace-lifecycle.md` — the full contract, including six
-  rounds of review findings this exercise's own machinery survived
+- `src/sovereign_agent/workspace.py` — read the boundary check and the reclaim
+  policy end to end; they are short, and the exercise above calls exactly them
 - `.sovereign/runs/<workspace_id>/` — inspect one directly after running the
   exercise above
 

--- a/book/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/ch04_work_stays_inside_its_boundary/README.md
@@ -43,6 +43,256 @@ chapter builds the machinery that makes that flag honest rather than alarming.
 | **Workspace policy** | `temporary_directory` (scratch space reclaimed after the assignment finishes) or `persistent` (nothing reclaimed, the whole run stays inspectable). |
 | **Reclaim** | Removing an assignment's disposable scratch space — never the receipt or its declared output. |
 
+## Build the boundary yourself, then attack it
+
+Before touching the production module, build each piece and break it. The
+attacks below are not hypothetical — every one of them has a named test in
+`tests/test_workspace_lifecycle.py`, because every one of them is a way a real
+provider run can go wrong.
+
+### The join that lies
+
+The obvious way to resolve "the provider wants to write `X`" is to join `X`
+onto the workspace root and check the result *looks* inside:
+
+```python
+import pathlib
+import tempfile
+
+root = pathlib.Path(tempfile.mkdtemp()) / "workspace"
+root.mkdir()
+(root.parent / "secrets.txt").write_text("the supplier price list")
+
+
+def naive_join(root, relative):
+    return root / relative
+
+
+for attempt in ["notes/report.md", "../secrets.txt", "/etc/passwd"]:
+    candidate = naive_join(root, attempt)
+    inside = str(candidate).startswith(str(root))
+    print(f"{attempt!r:18} -> inside according to the string check: {inside}")
+```
+
+```text
+'notes/report.md'  -> inside according to the string check: True
+'../secrets.txt'   -> inside according to the string check: True
+'/etc/passwd'      -> inside according to the string check: False
+```
+
+The middle line is the lie: `workspace/../secrets.txt` *starts with* the
+workspace prefix as a string, and names a file outside it. And the third line
+hides a second trap — `root / "/etc/passwd"` did not join anything;
+`pathlib` treats an absolute right-hand side as a full **replacement** of the
+left. The string check happened to catch it here, but the join itself
+silently became an absolute escape.
+
+### The join that refuses by shape
+
+```python
+def safe_join(root, relative):
+    relative = str(relative)
+    if not relative.strip():
+        raise PermissionError("refused: empty path")
+    if pathlib.PurePosixPath(relative).is_absolute():
+        raise PermissionError(f"refused: absolute path {relative!r}")
+    candidate = (root / relative).resolve()
+    if not candidate.is_relative_to(root.resolve()):
+        raise PermissionError(f"refused: {relative!r} escapes the workspace")
+    return candidate
+
+
+for attempt in ["notes/report.md", "../secrets.txt", "/etc/passwd", "a/../../secrets.txt"]:
+    try:
+        safe_join(root, attempt)
+        print(f"{attempt!r:22} -> allowed")
+    except PermissionError as error:
+        print(f"{attempt!r:22} -> {error}")
+```
+
+```text
+'notes/report.md'      -> allowed
+'../secrets.txt'       -> refused: '../secrets.txt' escapes the workspace
+'/etc/passwd'          -> refused: absolute path '/etc/passwd'
+'a/../../secrets.txt'  -> refused: 'a/../../secrets.txt' escapes the workspace
+```
+
+Two decisions carry the weight. The check runs on the **resolved filesystem
+path**, not the string — `.resolve()` collapses every `..` before the
+comparison. And an absolute path is refused **outright**, even one that would
+happen to resolve inside the root: the contract is "name something inside the
+workspace, relatively," and accepting an absolute path only when the caller's
+filesystem happens to put it somewhere agreeable makes the refusal depend on
+luck instead of shape. Production `safe_join` in
+`sovereign_agent/workspace.py` documents exactly this reasoning.
+
+### The symlink that points out, and the root that is a symlink
+
+String-free resolution earns its keep when links enter the picture. Plant a
+symlink *inside* the workspace that points outside it:
+
+```python
+(root / "cellar").mkdir()
+(root / "cellar" / "door").symlink_to(root.parent)  # a symlink pointing OUT of the workspace
+
+try:
+    safe_join(root, "cellar/door/secrets.txt")
+except PermissionError as error:
+    print(error)
+
+link_root = root.parent / "link-to-workspace"
+link_root.symlink_to(root)  # the workspace reached via a symlinked root
+print("same file either way:", safe_join(link_root, "notes/x") == safe_join(root, "notes/x"))
+```
+
+```text
+refused: 'cellar/door/secrets.txt' escapes the workspace
+same file either way: True
+```
+
+`cellar/door/secrets.txt` contains no `..` and no absolute prefix — as a
+*string* it is impeccable. Resolution follows the link, lands outside the
+resolved root, and the refusal fires. The reverse case matters equally: when
+the *root itself* is reached through a symlink, resolving both sides means a
+legitimate path is not spuriously refused. Refuse by where bytes would
+actually land, not by how the name is spelled.
+
+### The deliverable that existed before the run
+
+A subtler attack: the provider (or anything else) plants the expected
+deliverable *before* the invocation, hoping presence gets mistaken for work.
+The counter is a snapshot taken before the run:
+
+```python
+def snapshot(root):
+    return {str(p.relative_to(root)) for p in sorted(root.rglob("*")) if p.is_file()}
+
+
+(root / "notes").mkdir()
+(root / "report.md").write_text("I did the restock, trust me")  # planted BEFORE the run
+
+expected_outputs = {"report.md"}
+preplanted = expected_outputs & snapshot(root)
+if preplanted:
+    print(f"refused before invocation: deliverable(s) already exist: {sorted(preplanted)}")
+```
+
+```text
+refused before invocation: deliverable(s) already exist: ['report.md']
+```
+
+This is Chapter 6's crash-recovery rule arriving early: **a file's presence
+is never proof that work happened.** A deliverable that predates the run
+proves nothing about the run, so the run refuses to start over it.
+
+### The comparison after the run — and what it cannot see
+
+```python
+(root / "report.md").unlink()  # remove the plant; now run for real
+before = snapshot(root)
+
+(root / "report.md").write_text("restocked 6 tubs")  # the provider writes its outputs
+(root / "notes" / "scratch.txt").write_text("thinking...")
+(root.parent / "outside.txt").write_text("this write is INVISIBLE to the snapshot")
+
+appeared = snapshot(root) - before
+print("appeared inside the boundary:", sorted(appeared))
+```
+
+```text
+appeared inside the boundary: ['notes/scratch.txt', 'report.md']
+```
+
+Honest reading, both directions. The comparison names exactly what appeared
+inside the observed root — that is real, useful evidence. And
+`outside.txt` is simply absent from the report: not caught, not flagged,
+invisible, because it landed outside what the snapshot observes. A snapshot
+diff **detects, after the fact, inside its observed scope** — it neither
+prevents the write nor sees beyond its root. (The production check watches
+the *organization* root and excludes the workspace and ledger — the
+scope-naming discussion below — but the structural limit is identical.)
+
+### The receipt, sealed
+
+What survives the run is the receipt: canonical JSON plus a SHA-256 sidecar,
+so later readers can prove the bytes they hold are the bytes that were
+written:
+
+```python
+import hashlib
+import json
+
+canonical = (
+    json.dumps(
+        {"status": "completed", "outputs": sorted(appeared), "actor": "operator-lucy"},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    + "\n"
+)
+(root / "receipt.json").write_text(canonical)
+recorded = hashlib.sha256(canonical.encode()).hexdigest()
+(root / "receipt.json.sha256").write_text(recorded + "\n")
+print("receipt digest:", recorded[:12])
+
+tampered = canonical.replace("completed", "heroic")
+(root / "receipt.json").write_text(tampered)
+current = hashlib.sha256((root / "receipt.json").read_text().encode()).hexdigest()
+print("sidecar still matches the bytes:", current == recorded)
+```
+
+```text
+receipt digest: 9bf55dc8898a
+sidecar still matches the bytes: False
+```
+
+Canonical form (`sort_keys`, fixed separators) matters: the digest is only
+reproducible if the bytes are. And carry Chapter 2's honesty forward: the
+sidecar proves the receipt **bytes are unchanged** — consistency, not
+authorship. Whoever can rewrite the receipt can rewrite the sidecar beside
+it. Byte-integrity and authenticity are different claims, and this mechanism
+makes only the first.
+
+### Why `shell=False` is not a style preference
+
+Chapter 3 asserted that providers are invoked with argv lists and no shell.
+Here is the difference, live, with a filename a provider might "choose":
+
+```python
+import subprocess
+
+evil_name = "cones.txt; echo INJECTED"
+
+shell_run = subprocess.run(f"echo {evil_name}", shell=True, capture_output=True, text=True)
+print("shell=True :", shell_run.stdout.strip())
+
+argv_run = subprocess.run(["echo", evil_name], capture_output=True, text=True)
+print("argv list  :", argv_run.stdout.strip())
+```
+
+```text
+shell=True : cones.txt
+INJECTED
+argv list  : cones.txt; echo INJECTED
+```
+
+Under `shell=True` the `;` ended one command and started another — the
+`INJECTED` on its own line is a *second program that ran*. As an argv element
+the same string is inert data passed to `echo` verbatim. Every production
+invocation goes through `run_spec` in `execution.py`: argv list,
+`shell=False`, and an environment allowlisted down to `PATH`/`HOME`/`LANG`
+plus what the provider spec explicitly adds. A command that cannot be parsed
+cannot be injected into.
+
+### Extend it (before running the production version)
+
+Add one new protected artifact to the toy: the `receipt.json.sha256` sidecar
+itself must not be preplanted before a run. Write **both** tests — the bypass
+test (plant it, run the unmodified check, watch the plant survive
+undetected) and the enforcement test (add the sidecar to `expected_outputs`,
+watch the refusal fire). A boundary change without its bypass test is a
+claim; with it, it is a measurement.
+
 ## The exercise
 
 ```bash

--- a/book/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/ch04_work_stays_inside_its_boundary/README.md
@@ -334,6 +334,12 @@ invocation.
     "output_dir_preserved": true,
     "scratch_removed": true
   },
+  "persistent_reclaim": {
+    "assignment_state": "COMPLETED",
+    "reclaimed_something": false,
+    "tree_unchanged": true,
+    "scratch_still_present": true
+  },
   "workspace_policy_default": "temporary_directory"
 }
 ```
@@ -356,20 +362,35 @@ Four things worth reading closely:
    shows up in `added`, because nothing in this system relies on a provider's
    own good behavior to prove the boundary held — it is checked from outside,
    after the fact.
-4. **Reclaim is a policy decision, not an automatic cleanup.** `provider-raw`
-   (the disposable scratch space) is gone after reclaim; `receipt.json`,
-   `receipt.json.sha256`, and `.sovereign-out` (the durable proof of what ran,
-   and its declared output) are not touched. `_require_deliverables` and
-   `accept()` both read from `.sovereign-out` long after `run_assignment`
-   returns — a reclaim policy that deleted it would silently break
-   re-verification.
+4. **Reclaim is a policy decision, not an automatic cleanup — and BOTH
+   policies are exercised, not just named.** Under `temporary_directory`,
+   `provider-raw` (the disposable scratch space) is gone after reclaim;
+   `receipt.json`, `receipt.json.sha256`, and `.sovereign-out` (the durable
+   proof of what ran, and its declared output) are not touched.
+   `_require_deliverables` and `accept()` both read from `.sovereign-out`
+   long after `run_assignment` returns — a reclaim policy that deleted it
+   would silently break re-verification. Then a *second* real assignment
+   plants the same scratch and reclaims under `persistent`:
+   `tree_unchanged: true`, `scratch_still_present: true` — nothing removed,
+   the entire run left inspectable. Reading a policy's default value proves
+   a configuration exists; only running the reclaim under each policy and
+   diffing the tree proves the *behavior*.
 
 ## Why detection, not prevention
 
-Only Codex's adapter gives real OS-level containment (`--sandbox
-workspace-write`). `claude`, `cursor`, and `scripted` have none — Chapter 3
-already told you `--workspace` is a selected directory, not a sandbox. This
-chapter does not invent containment those providers don't have. It makes the
+Only Codex's adapter even *requests* OS-level containment: it probes for
+`--sandbox` in the CLI's own help and supplies `--sandbox workspace-write`,
+refusing to run when that support cannot be proven. State the evidence for
+that precisely, because it is capability evidence, not containment evidence:
+the production bytes and tests prove the flag is discovered and correctly
+placed on argv — they do **not** attempt a live filesystem escape from
+inside a sandboxed Codex run and observe it blocked. "The adapter requests
+the sandbox and fails closed without it" is what is proven; "the sandbox
+holds" is Codex's claim, which a live escape test would be needed to
+verify behaviorally. `claude`, `cursor`, and `scripted` do not even request
+one — Chapter 3 already told you `--workspace` is a selected directory, not
+a sandbox. This chapter does not invent containment those providers don't
+have. It makes the
 *absence* of containment checkable: a clean boundary report is evidence that,
 for this one invocation, nothing outside the workspace changed — not a claim
 that anything was stopped from changing. A dirty report does not block the

--- a/book/ch04_work_stays_inside_its_boundary/solution.py
+++ b/book/ch04_work_stays_inside_its_boundary/solution.py
@@ -98,6 +98,18 @@ def explore_workspace_lifecycle(root: Path) -> dict[str, Any]:
     reclaimed = reclaim_workspace(temp_workspace, "temporary_directory")
     after_reclaim = sorted(p.name for p in temp_workspace.iterdir())
 
+    # 4. The persistent policy is EXERCISED, not merely read: a second real
+    # assignment, the same planted scratch, and a reclaim under "persistent"
+    # that must remove nothing at all -- the whole run stays inspectable.
+    persistent_state, persistent_workspace = _run_one_assignment(
+        org, "Write the required offline report again."
+    )
+    (persistent_workspace / "provider-raw").mkdir(exist_ok=True)
+    (persistent_workspace / "provider-raw" / "scratch.log").write_text("scratch", encoding="utf-8")
+    before_persistent = sorted(p.name for p in persistent_workspace.iterdir())
+    persistent_reclaimed = reclaim_workspace(persistent_workspace, "persistent")
+    after_persistent = sorted(p.name for p in persistent_workspace.iterdir())
+
     org.rebind_actor("operator-course", "scripted", "principal-human")
     persistent_actor = org.actor("operator-course")
 
@@ -119,6 +131,12 @@ def explore_workspace_lifecycle(root: Path) -> dict[str, Any]:
             "receipt_preserved": "receipt.json" in after_reclaim,
             "output_dir_preserved": ".sovereign-out" in after_reclaim,
             "scratch_removed": "provider-raw" not in after_reclaim,
+        },
+        "persistent_reclaim": {
+            "assignment_state": persistent_state,
+            "reclaimed_something": persistent_reclaimed,
+            "tree_unchanged": before_persistent == after_persistent,
+            "scratch_still_present": "provider-raw" in after_persistent,
         },
         "workspace_policy_default": persistent_actor.workspace_policy,
     }

--- a/book/ch05_authority_needs_a_fence/README.md
+++ b/book/ch05_authority_needs_a_fence/README.md
@@ -39,6 +39,331 @@ nothing before this chapter's mechanism could tell them apart.
 mutate canonical execution state, acknowledge mailbox work, or reclaim the
 active workspace.**
 
+## Build the mailbox yourself, then break it
+
+The fence is easiest to understand where the organization first needed it: the
+**mailbox** — durable messages that workers claim, work, and complete. Build
+it on real table rows, wrong version first.
+
+```python
+import sqlite3
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE messages (id TEXT PRIMARY KEY, body TEXT, state TEXT NOT NULL,
+                           claim_owner TEXT, fencing_token INT, retry_count INT DEFAULT 0);
+    CREATE TABLE lease_tokens (token INTEGER PRIMARY KEY, kind TEXT);
+""")
+db.execute("INSERT INTO messages(id, body, state) VALUES ('msg-1', 'Restock vanilla', 'NEW')")
+db.commit()
+```
+
+`lease_tokens` looks useless — one autoincrement column and a label. It is the
+most important table in this chapter: **one shared, strictly increasing
+counter**, from which every claim of every kind will draw its number. Hold
+that thought.
+
+### The claim that reads, then writes
+
+The obvious claim: read the message's state, and if it is `NEW`, write your
+name on it.
+
+```python
+def decide_from(state):  # the read half: the worker decides from what it SAW
+    return state == "NEW"
+
+
+def write_claim(db, message_id, actor_id):  # the write half
+    db.execute(
+        "UPDATE messages SET state = 'CLAIMED', claim_owner = ? WHERE id = ?",
+        (actor_id, message_id),
+    )
+    db.commit()
+
+
+a_saw = db.execute("SELECT state FROM messages WHERE id = 'msg-1'").fetchone()[0]
+b_saw = db.execute("SELECT state FROM messages WHERE id = 'msg-1'").fetchone()[0]
+print("worker-a saw:", a_saw, "-> decides to claim:", decide_from(a_saw))
+print("worker-b saw:", b_saw, "-> decides to claim:", decide_from(b_saw))
+write_claim(db, "msg-1", "worker-a")
+write_claim(db, "msg-1", "worker-b")
+owner = db.execute("SELECT claim_owner FROM messages WHERE id = 'msg-1'").fetchone()[0]
+print("owner on disk:", owner)
+```
+
+```text
+worker-a saw: NEW -> decides to claim: True
+worker-b saw: NEW -> decides to claim: True
+owner on disk: worker-b
+```
+
+The interleaving is spelled out — both reads happen before either write,
+which is exactly what two busy processes produce — and the result is the
+disease this chapter exists to cure: **both workers believe they own the
+message.** Worker-a is off doing the restock right now, convinced the job is
+its; the row says worker-b. Nothing crashed, nothing errored, and the shop
+has two people counting one till. The production mailbox paid this exact
+bill: the docstring of `relay.claim()` records that an earlier version "read
+the message, decided in Python, and wrote it back: two connections both read
+NEW, both wrote, and both believed they owned the lease."
+
+### The claim that decides and writes in one statement
+
+The repair is to collapse the read and the write into a single atomic
+**compare-and-set**: the `WHERE` clause does the deciding, at the same
+instant as the writing, and the row count tells you whether you won.
+
+```python
+def mint_token(db):
+    return db.execute("INSERT INTO lease_tokens(kind) VALUES ('mailbox_claim')").lastrowid
+
+
+def claim(db, message_id, actor_id):
+    token = mint_token(db)
+    cursor = db.execute(
+        "UPDATE messages SET state = 'CLAIMED', claim_owner = ?, fencing_token = ?"
+        " WHERE id = ? AND state = 'NEW'",
+        (actor_id, token, message_id),
+    )
+    db.commit()
+    if cursor.rowcount != 1:
+        return f"{actor_id}: refused, not claimable"
+    return f"{actor_id}: claimed with token {token}"
+
+
+db.execute("UPDATE messages SET state = 'NEW', claim_owner = NULL, fencing_token = NULL")
+db.commit()
+print(claim(db, "msg-1", "worker-a"))
+print(claim(db, "msg-1", "worker-b"))
+```
+
+```text
+worker-a: claimed with token 1
+worker-b: refused, not claimable
+```
+
+Exactly one winner, and no window in which both can believe otherwise: either
+the row was `NEW` at the moment of the `UPDATE` or it was not, and SQLite
+serializes the two. Note the claim also stamped a **fencing token** — number
+`1`, drawn from the shared counter. That number is about to matter more than
+the owner's name.
+
+### Completing under the token, not the name
+
+```python
+def complete(db, message_id, actor_id, fencing_token):
+    cursor = db.execute(
+        "UPDATE messages SET state = 'DONE' WHERE id = ? AND claim_owner = ?"
+        " AND fencing_token IS ?",
+        (message_id, actor_id, fencing_token),
+    )
+    db.commit()
+    if cursor.rowcount != 1:
+        return f"{actor_id}: refused, stale or wrong token"
+    return f"{actor_id}: completed"
+
+
+print(complete(db, "msg-1", "worker-a", 99))  # a token it was never issued
+print(complete(db, "msg-1", "worker-a", 1))  # the token its own claim returned
+```
+
+```text
+worker-a: refused, stale or wrong token
+worker-a: completed
+```
+
+Two disciplines hide in these few lines. The token is checked **in the same
+statement** that performs the write — never read from the row first and
+compared in Python, because the row's own current token always matches
+itself, which would make staleness undetectable by construction. And the
+caller must *present* its token (production makes the argument keyword-only
+with no default, so it cannot be silently skipped): the token must be the one
+your own most recent successful claim returned, not something re-derived on
+the spot.
+
+### Leases: ownership that expires, and the token that guards the handover
+
+`claim_owner == actor_id` alone is not exclusivity — it is the check that
+made the pre-fencing mailbox *actor*-idempotent rather than
+*process*-exclusive. Two processes hosting the same actor id both pass it.
+The missing ingredients are a **lease** (ownership with an expiry) and the
+rule for what happens at every handover:
+
+```python
+db.execute("ALTER TABLE messages ADD COLUMN claim_expires_at INT")
+db.execute("INSERT INTO messages(id, body, state) VALUES ('msg-2', 'Order cones', 'NEW')")
+db.commit()
+
+LEASE_MINUTES = 15
+
+
+def claim_leased(db, message_id, actor_id, now):
+    row = db.execute(
+        "SELECT claim_owner, fencing_token, claim_expires_at FROM messages WHERE id = ?",
+        (message_id,),
+    ).fetchone()
+    owner, token, expires = row
+    if owner == actor_id and expires is not None and expires > now:
+        return f"{actor_id}: still mine, SAME token {token}"  # idempotent -- no new mint
+    new_token = mint_token(db)
+    cursor = db.execute(
+        "UPDATE messages SET state = 'CLAIMED', claim_owner = ?, fencing_token = ?,"
+        " claim_expires_at = ?"
+        " WHERE id = ? AND (state = 'NEW' OR claim_expires_at <= ?)",
+        (actor_id, new_token, now + LEASE_MINUTES, message_id, now),
+    )
+    db.commit()
+    if cursor.rowcount != 1:
+        return f"{actor_id}: refused, unexpired lease held by {owner}"
+    return f"{actor_id}: claimed with FRESH token {new_token}"
+
+
+print(claim_leased(db, "msg-2", "worker-a", now=0))
+print(claim_leased(db, "msg-2", "worker-a", now=5))
+print(claim_leased(db, "msg-2", "worker-b", now=10))
+print(claim_leased(db, "msg-2", "worker-b", now=20))
+print(claim_leased(db, "msg-2", "worker-a", now=25))
+```
+
+```text
+worker-a: claimed with FRESH token 3
+worker-a: still mine, SAME token 3
+worker-b: refused, unexpired lease held by worker-a
+worker-b: claimed with FRESH token 5
+worker-a: refused, unexpired lease held by worker-b
+```
+
+Read the five lines as a timeline of one message's life:
+
+```text
+minute  0   worker-a claims ................... token 3, lease until 15
+minute  5   worker-a retries .................. SAME token 3 (idempotent)
+minute 10   worker-b contends ................. refused, lease still live
+minute 15   -- worker-a's lease expires --
+minute 20   worker-b takes over ............... FRESH token 5, lease until 35
+minute 25   worker-a resumes, tries again ..... refused, worker-b holds it
+```
+
+The two claim outcomes for the *same* owner are the heart of the design. A
+retry **inside** your own lease window returns the **same** token — that is
+what makes retries idempotent rather than a silent takeover of your own
+lease (minting a fresh token here would invalidate your own in-flight
+completion). But a claim after your lease lapsed — even by *you* — falls
+through into the CAS exactly like any contender's, and wins it only by
+minting a **fresh, strictly greater** token. The production mailbox got this
+wrong the first time: the original same-owner short-circuit fired
+unconditionally, even when that owner's lease had already expired, which
+made the CAS's expired-lease branch unreachable for the owner — only a
+*different* actor could ever take over from a lapsed worker. The gap was
+recorded as a named limit in a dated ruling rather than silently patched,
+and closed properly once fencing tokens existed to define what a takeover
+even means.
+
+### Why the takeover mints a fresh token
+
+Because of what happens next. Worker-a is *still running* — it never crashed,
+it just stalled past its lease. It finishes the work and tries to complete
+with the token its claim returned:
+
+```python
+print(complete(db, "msg-2", "worker-a", 3))  # the token a's lapsed claim returned
+print(complete(db, "msg-2", "worker-b", 5))  # the current holder's token
+```
+
+```text
+worker-a: refused, stale or wrong token
+worker-b: completed
+```
+
+This is the fence doing its one job. Nothing stopped worker-a from running —
+fencing is not an OS sandbox, and a stale worker can burn CPU, write files,
+even finish the task. What it cannot do is make its result **canonical**: its
+token no longer matches the durable row, and the same-statement check refuses
+the write. The tokens work because they come from **one shared counter in the
+database** — durable, monotonic, visible to every contender. Tokens from
+process memory would restart from zero with the process; timestamps would
+tie; and the operating system's PIDs get *reused*, which is why process
+identity in production is a fresh `uuid4`, never a PID.
+
+### Retries are budgeted, and the budget ends somewhere honest
+
+A message that keeps failing must neither vanish nor loop forever:
+
+```python
+MAX_RETRIES = 3
+
+
+def dead_letter(db, message_id, presented_token):
+    retry = db.execute("SELECT retry_count FROM messages WHERE id = ?", (message_id,)).fetchone()[0]
+    if retry < MAX_RETRIES:
+        cursor = db.execute(
+            "UPDATE messages SET state = 'NEW', claim_owner = NULL, claim_expires_at = NULL,"
+            " fencing_token = NULL, retry_count = retry_count + 1"
+            " WHERE id = ? AND fencing_token IS ?",
+            (message_id, presented_token),
+        )
+        verdict = "retried"
+    else:
+        cursor = db.execute(
+            "UPDATE messages SET state = 'DEAD' WHERE id = ? AND fencing_token IS ?",
+            (message_id, presented_token),
+        )
+        verdict = "dead-lettered"
+    db.commit()
+    if cursor.rowcount != 1:
+        return "refused: stale in-memory message, re-read before retrying"
+    return verdict
+
+
+db.execute("INSERT INTO messages(id, body, state) VALUES ('msg-3', 'Call the supplier', 'NEW')")
+db.commit()
+for attempt in range(4):
+    claim_leased(db, "msg-3", "worker-a", now=100 + attempt)
+    token = db.execute("SELECT fencing_token FROM messages WHERE id = 'msg-3'").fetchone()[0]
+    print(f"attempt {attempt}: {dead_letter(db, 'msg-3', token)}")
+print("final:", db.execute("SELECT state, retry_count FROM messages WHERE id = 'msg-3'").fetchone())
+```
+
+```text
+attempt 0: retried
+attempt 1: retried
+attempt 2: retried
+attempt 3: dead-lettered
+final: ('DEAD', 3)
+```
+
+Even this administrative transition presents the token (`fencing_token IS ?`
+— SQLite's null-safe comparison, so it matches correctly when the token is
+`NULL`, a never-claimed message's own starting state). A stale in-memory
+copy of the message — read before a fresher claim took over the row — must
+not be able to drive a retry or a dead-lettering either; the refusal tells
+the caller to re-read, not to force. `DEAD` is a terminal parking spot a
+human can inspect, not a deletion: the message, its body, and its retry
+history all remain on the ledger.
+
+**Two honest limits of this toy, both deliberate.** First, notice the token
+numbers in the outputs skip (1, 3, 5…): the toy mints a token *before* the
+CAS and commits it even when the claim is refused, burning numbers.
+Production mints **inside the same `BEGIN IMMEDIATE` transaction** as the
+CAS it fences, so a refused claim's mint rolls back with it. Either way the
+guarantee is untouched — what matters is that tokens are *monotonic*, not
+*dense*. Second, the toy passes `now` in as a parameter rather than reading
+a clock — which is exactly what production does too (`clock:
+Callable[[], datetime]`, injectable), because lease-expiry tests that
+depend on real `sleep()` are slow and flaky, and a fake clock you can
+advance makes every expiry case in this chapter a fast, deterministic
+assertion.
+
+The production versions of everything you just built live in
+`src/sovereign_agent/relay.py` — `claim()` (the CAS with the same-owner
+idempotency and expired-lease takeover), `complete()` (keyword-only
+required token, same-statement check), and `dead_letter()` (budget,
+null-safe token check, terminal `DEAD`) — with `_mint_claim_token` drawing
+from the same `lease_tokens` counter that `fencing.py` uses for actor
+leases and execution attempts. One counter, every fence: that is what makes
+"a strictly higher token than any minted before it, forever" a property of
+the *organization*, not of one table.
+
 ## The exercise
 
 ```bash
@@ -135,6 +460,15 @@ cannot bypass either.
 5. "A worker that no longer holds the current lease may still be running."
    What, precisely, does the fence guarantee stop that worker from doing,
    and what does it explicitly *not* stop?
+6. The naive claim read the state and then wrote. Explain why no amount of
+   "reading faster" or "reading again right before writing" fixes it, and
+   what the CAS changes structurally.
+7. A retry inside your own unexpired lease returns the SAME token; a claim
+   after your lease lapsed mints a FRESH one. Swap those two behaviors and
+   describe the concrete failure each swap causes.
+8. The toy's token numbers skip (1, 3, 5…) because refused claims burn a
+   mint. Why does this not weaken the guarantee, and what property of the
+   counter is actually load-bearing?
 
 ## Where to look next
 

--- a/book/ch05_authority_needs_a_fence/README.md
+++ b/book/ch05_authority_needs_a_fence/README.md
@@ -1,5 +1,21 @@
 # Chapter 5 — Authority needs a fence
 
+Two of Lucy's staff each believe they are closing tonight. One of them is wrong —
+maybe they swapped shifts and forgot, maybe one went home and came back. It does
+not matter *why*. What matters is that only one person can count the till, lock
+the freezer, and set the alarm, and the shop must never let *both* do it, because
+two people each doing "the closing" is how money goes missing and doors get left
+open.
+
+Software has exactly this problem, and it is sneakier there. A worker process
+crashes and gets restarted; for a moment, *two* processes both believe they are
+the same actor, `operator-course`, finishing the same job. If both are allowed to
+write "done," the ledger ends up with two conflicting truths. This chapter builds
+the fence that makes that impossible — not by trusting workers to behave, but with
+a numbered claim (think of it as a numbered key) that only one process can hold at
+a time, where every handover mints a *higher* number so a stale worker's old key
+simply stops turning.
+
 ## Learning objective
 
 Understand the difference between an **actor** (a durable, governed identity)
@@ -26,7 +42,7 @@ active workspace.**
 ## The exercise
 
 ```bash
-python book/ch05_authority_needs_a_fence/solution.py --root /tmp/andrea-ch05
+python book/ch05_authority_needs_a_fence/solution.py --root /tmp/lucy-ch05
 ```
 
 Exercises `fencing.acquire_actor_lease` and `fencing.acquire_execution_attempt`
@@ -71,10 +87,10 @@ Read this in order:
    for one that no longer matches any real row) is refused — the check is
    never merely "trust the caller's earlier acquisition."
 3. **The decisive property: two DIFFERENT assignments for the SAME actor,
-   two SEPARATE processes.** This is the exact gap Unit 4's mailbox left
-   open — it proved two distinct *actors* contending for one message
-   produces one winner, but said nothing about two *processes* both
-   claiming to be the same actor. `second_process_same_actor_different_
+   two SEPARATE processes.** This is the gap an ordinary message queue leaves
+   open: it can prove two distinct *actors* contending for one message produce
+   one winner, but says nothing about two *processes* both claiming to be the
+   same actor. `second_process_same_actor_different_
    assignment` shows the refusal happening through the ordinary
    `run_assignment` call, before the provider is ever invoked —
    `assignment_never_reached_running` confirms the second assignment stayed
@@ -122,13 +138,10 @@ cannot bypass either.
 
 ## Where to look next
 
-- `src/sovereign_agent/fencing.py` — process identity, actor leases,
-  execution-attempt fencing
-- `docs/v1-unit8-supervisor-fencing-recovery.md` — the full contract,
-  including the two rounds of review correction this mechanism survived
-  (F-R2-1: a leak on every refusal path, not only success)
-- `docs/rulings/2026-08-26-one-process-per-actor.md` — the gap this
-  chapter's mechanism closes
+- `src/sovereign_agent/fencing.py` — process identity, actor leases, and the
+  execution-attempt compare-and-set. Note that the lease is released on every
+  refusal path, not only on success — a leak there would strand an actor after
+  any failure.
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch06_the_organization_recovers/README.md
+++ b/book/ch06_the_organization_recovers/README.md
@@ -33,6 +33,220 @@ happens when the process holding it simply stops existing.
 | **Hard-kill recovery** | The supervisor writing a durable `FAILED` receipt for an assignment whose execution attempt expired with no worker left to finish it — `failure_category="worker_lost"`. |
 | **Worker lost** | The one failure category this recovery path ever writes. Never inferred success, however far the dead subprocess might actually have gotten. |
 
+## Build the recovery yourself, then watch it almost lie
+
+Before the real supervisor and the real `SIGKILL`, build recovery small
+enough to see every decision — including the one that goes wrong.
+
+The scene: assignment `run-9` went `RUNNING` with fencing token 41 and an
+execution attempt that expired at minute 115. It is now minute 130 and the
+worker has not been heard from. Crucially, its workspace is **not empty** —
+there is diagnostic scratch, and there is a `report.json` that says
+`completed`:
+
+```python
+import pathlib
+import sqlite3
+import tempfile
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE assignments (id TEXT PRIMARY KEY, state TEXT NOT NULL,
+                              fencing_token INT, attempt_expires_at INT);
+    CREATE TABLE receipts (assignment_id TEXT PRIMARY KEY, status TEXT,
+                           failure_category TEXT);
+""")
+workspace = pathlib.Path(tempfile.mkdtemp())
+(workspace / "provider-raw").mkdir()
+(workspace / "provider-raw" / "stream.log").write_text("...half a stream...")
+(workspace / "report.json").write_text('{"status": "completed"}')  # the TRAP
+
+db.execute("INSERT INTO assignments VALUES ('run-9', 'RUNNING', 41, 115)")
+db.commit()
+```
+
+### The recoverer that wants to be kind
+
+The tempting recovery logic looks *diligent*: before declaring failure, check
+whether the worker actually finished — and if a valid-looking completed
+report is sitting right there, honor the poor worker's last act.
+
+```python
+import json
+
+
+def recover_naive(db, assignment_id, workspace, now):
+    state, expires = db.execute(
+        "SELECT state, attempt_expires_at FROM assignments WHERE id = ?", (assignment_id,)
+    ).fetchone()
+    if state != "RUNNING" or expires > now:
+        return "nothing to recover"
+    report = workspace / "report.json"
+    if report.is_file() and json.loads(report.read_text()).get("status") == "completed":
+        db.execute("UPDATE assignments SET state = 'COMPLETED' WHERE id = ?", (assignment_id,))
+        db.commit()
+        return "worker left a completed report -- marked COMPLETED"
+    db.execute("UPDATE assignments SET state = 'FAILED' WHERE id = ?", (assignment_id,))
+    db.commit()
+    return "marked FAILED"
+
+
+print(recover_naive(db, "run-9", workspace, now=130))
+```
+
+```text
+worker left a completed report -- marked COMPLETED
+```
+
+The ledger now says `COMPLETED`, and nobody decided that — a *file* did. Ask
+what that file actually proves. Chapter 3 taught that a report is a
+**proposal** the host validates: no terminal event was seen, no session
+identity extracted, no protocol completed. Chapter 4 taught that **presence
+is not work**: that file could be preplanted, half-written-but-parseable, or
+written by a stale process that is *still running somewhere* and about to do
+who-knows-what. The killed worker might genuinely have been one line from
+finishing correctly — and the organization has no way to know. Blessing the
+file converts "unknown" into "success" on zero evidence, which is precisely
+the lie a governed ledger exists to make unwritable.
+
+### The recoverer that refuses to guess
+
+The honest version writes the only thing that is actually known — *we don't
+know it finished, so it didn't* — and does all of its writes in **one
+transaction**:
+
+```python
+def recover(db, assignment_id, now):
+    cursor = db.execute(
+        "UPDATE assignments SET state = 'FAILED', fencing_token = NULL,"
+        " attempt_expires_at = NULL"
+        " WHERE id = ? AND state = 'RUNNING' AND attempt_expires_at <= ?",
+        (assignment_id, now),
+    )
+    if cursor.rowcount != 1:
+        db.commit()
+        return "nothing to recover"
+    db.execute("INSERT INTO receipts VALUES (?, 'failed', 'worker_lost')", (assignment_id,))
+    db.commit()  # ONE commit: terminal state, cleared fence, receipt -- together
+    return "recovered: FAILED, category worker_lost, fence cleared"
+
+
+db.execute(
+    "UPDATE assignments SET state = 'RUNNING', fencing_token = 41, attempt_expires_at = 115"
+    " WHERE id = 'run-9'"
+)
+db.commit()
+print(recover(db, "run-9", now=130))
+print(recover(db, "run-9", now=131))  # the second tick
+row = db.execute(
+    "SELECT status, failure_category FROM receipts WHERE assignment_id = 'run-9'"
+).fetchone()
+print("receipt:", row)
+```
+
+```text
+recovered: FAILED, category worker_lost, fence cleared
+nothing to recover
+receipt: ('failed', 'worker_lost')
+```
+
+Three deliberate choices, each doing real work:
+
+- **The `WHERE` clause is the detector.** `state = 'RUNNING' AND
+  attempt_expires_at <= now` — recovery is a compare-and-set, the exact
+  pattern Chapter 5 built, aimed at a different table. Expiry alone is not a
+  fault; it just makes the row *recoverable*.
+- **The fence clears in the same transaction as the terminal write.** So
+  there is never a moment when the assignment is terminal but still fenced
+  (stranding the workspace) or unfenced but still `RUNNING` (inviting a
+  second writer). And it is why the second tick finds *nothing*: idempotency
+  falls out of the CAS, rather than needing a "did I already recover this?"
+  memory.
+- **`worker_lost` is the only category this path ever writes**, and
+  production names it exactly once, as a module constant — so no receipt
+  reader ever reconciles two spellings of "the worker never came back."
+  Richer failure taxonomy (timeout vs. nonzero exit vs. interruption, and
+  which wins when several are observed at once) is decided at *execution*
+  time by the host that watched the process die; the supervisor never
+  re-litigates it. It handles only the case where nobody was left to decide.
+
+### Two supervisors, one recovery
+
+Nothing above assumed the supervisor is unique — and it must not, because
+supervisors crash too, and someone restarts them. Run two against the same
+abandoned assignment:
+
+```python
+db.execute("INSERT INTO assignments VALUES ('run-10', 'RUNNING', 55, 220)")
+db.commit()
+
+print("supervisor-1:", recover(db, "run-10", now=230))
+print("supervisor-2:", recover(db, "run-10", now=230))
+count = db.execute("SELECT COUNT(*) FROM receipts WHERE assignment_id = 'run-10'").fetchone()[0]
+print("receipts written:", count)
+```
+
+```text
+supervisor-1: recovered: FAILED, category worker_lost, fence cleared
+supervisor-2: nothing to recover
+receipts written: 1
+```
+
+One winner, one receipt, no coordination protocol between the supervisors —
+the same CAS that made one tick idempotent makes two supervisors safe. This
+is the payoff of Chapter 5 generalizing: every "exactly once against shared
+state" problem in this system is solved by the same shape.
+
+### Reclaim comes last, and keeps the evidence
+
+The workspace still holds the dead worker's scratch — and the trap file.
+Reclaiming is a *policy* act, gated on the durable terminal state:
+
+```python
+def reclaim(db, assignment_id, workspace):
+    state = db.execute("SELECT state FROM assignments WHERE id = ?", (assignment_id,)).fetchone()[0]
+    if state == "RUNNING":
+        return "refused: assignment not terminal, scratch may still be in use"
+    scratch = workspace / "provider-raw"
+    if scratch.is_dir():
+        for item in sorted(scratch.rglob("*")):
+            item.unlink()
+        scratch.rmdir()
+    return f"reclaimed scratch; kept: {sorted(p.name for p in workspace.iterdir())}"
+
+
+db.execute("INSERT INTO assignments VALUES ('run-11', 'RUNNING', 60, 320)")
+db.commit()
+print(reclaim(db, "run-11", workspace))
+print(recover(db, "run-11", now=330))
+print(reclaim(db, "run-11", workspace))
+```
+
+```text
+refused: assignment not terminal, scratch may still be in use
+recovered: FAILED, category worker_lost, fence cleared
+reclaimed scratch; kept: ['report.json']
+```
+
+Order is everything: reclaim before the terminal state is durable and you
+might delete the scratch of a worker that turns out to be alive; production
+applies workspace policy strictly **after** the recovery transaction
+commits. And notice what survived: `report.json` — the trap — is *kept*. Not
+as a result (its assignment is `FAILED`, permanently, whatever the file
+says) but as **evidence** a human can inspect when they ask what the dead
+worker was doing. Deleting it would be laundering the crash; blessing it
+would be laundering the guess. Keeping it, attached to an honest `FAILED`,
+is the only move that lies about nothing.
+
+The production versions live in `src/sovereign_agent/supervisor.py`: a
+`tick` does exactly four things in a fixed order — report expired actor
+leases (read-only), sweep expired mailbox claims back to `NEW`, recover
+abandoned assignments as you just built, and *nothing else*. The governing
+contract is explicit that the supervisor never creates work, never reads a
+Pulse signal, never installs itself as a service — because "a process cannot
+record its own death" cuts both ways: the one process allowed to declare
+others dead must itself stay too simple to need declaring.
+
 ## A note on realism, before you run this
 
 This exercise does not simulate a crash with a caught exception. It starts a
@@ -136,6 +350,14 @@ only after the recovery transaction is durable.
 5. No new `AssignmentState` was added for a recovered assignment — it reuses
    `FAILED`. What would a dedicated `RECOVERED` state let a reader assume
    that they should not be allowed to assume?
+6. `recover_naive` looked *more* diligent than `recover` — it checked the
+   report before deciding. Explain precisely why the extra check made it
+   less honest, not more.
+7. Two supervisors recovered `run-10` with no coordination protocol between
+   them, yet wrote exactly one receipt. Name the mechanism, and say where
+   you built it before.
+8. Reclaim kept `report.json` on a `FAILED` assignment. Defend keeping a
+   file whose contents the ledger explicitly refuses to believe.
 
 ## Where to look next
 

--- a/book/ch06_the_organization_recovers/README.md
+++ b/book/ch06_the_organization_recovers/README.md
@@ -1,9 +1,24 @@
 # Chapter 6 — The organization recovers
 
+Imagine the worker who was closing Lucy's shop collapses mid-count and is rushed
+out the door. The till is half-counted, the freezer maybe locked, maybe not.
+Nobody can ask *them* what got done — they're gone. So someone else has to walk
+in, notice the shift never properly ended, and write down the only honest thing
+that can be written: *we don't know it was finished, so it wasn't.* Not "probably
+fine." Not "looked done to me." Unknown is not success.
+
+That is recovery, and it is subtler than it sounds, because the tempting move —
+"the worker got most of the way, let's call it done" — is exactly the lie a
+governed organization must never tell. In Chapter 5 you built the fence that
+decides who holds authority *right now*. This chapter is about what happens when
+the process holding it simply stops existing, and why a *different* process must
+be the one to record its death — because a process, like that collapsed worker,
+cannot certify its own.
+
 ## Learning objective
 
-Understand why "a process cannot record its own death" (Unit 5's own rule)
-forces a *second* process to own recovery, and see the supervisor do exactly
+Understand why "a process cannot record its own death" forces a *second*
+process to own recovery, and see the supervisor do exactly
 that: recover a genuinely, violently killed worker's assignment — never
 guessing that it might have succeeded.
 
@@ -35,7 +50,7 @@ disappears.
 ## The exercise
 
 ```bash
-python book/ch06_the_organization_recovers/solution.py --root /tmp/andrea-ch06
+python book/ch06_the_organization_recovers/solution.py --root /tmp/lucy-ch06
 ```
 
 Takes a few seconds — it genuinely waits for a real subprocess to reach
@@ -82,8 +97,8 @@ Four things worth reading closely:
 4. **The recovered receipt is always `failed`, never a guess.** However far
    the killed subprocess might actually have gotten — it might have been
    about to write a valid `report.json` — the organization has no way to know
-   that, and Unit 5's own rule ("nothing is ever a guessed success") extends
-   here without exception.
+   that, and the rule you met in Chapter 5 — nothing is ever a guessed success —
+   extends here without exception.
 
 ## Why this is not a cancellation
 
@@ -127,8 +142,8 @@ only after the recovery transaction is durable.
 - `src/sovereign_agent/supervisor.py` — `tick`, `recover_abandoned_assignments`
 - `tests/fixtures/hard_kill_worker.py` — the real child process this
   exercise's own `solution.py` reuses
-- `docs/v1-unit8-supervisor-fencing-recovery.md` — the full contract,
-  Property 4 in particular
+- `tests/test_supervisor.py` — the hard-kill proof matrix, if you want to see
+  every recovery property exercised at once
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -1,15 +1,20 @@
 # Chapter 7 — The organization wakes itself
 
-Every chapter so far began the same way: *you* typed a command. The sale, the
-signal, the restock — nothing moved until a human poked it. Lucy noticed this
-too. She doesn't want to *remember* to check the freezer; she wants the shop to
-notice its own low stock and start the reorder while she's busy scooping.
+Every chapter so far began the same way: a human *dispatched* the work — wrote the
+statement of work, made the assignment. Lucy wants something narrower but
+important: when a sale drops the freezer below its line, she wants the reorder
+*work itself* to be created from that signal, without her writing the dispatch by
+hand each time.
 
-That is a genuinely different and more dangerous capability, and most systems
-fake it — they run a loop, do something, and print "autonomous!" This chapter
-builds the real version and then does the thing this whole book insists on:
-proves it. When Lucy's organization creates work with nobody prompting it, it
-leaves a durable, traceable record that it did — a record you can walk backward
+Be precise about the claim, because most systems overstate exactly this. This
+chapter builds three separable things and is careful not to confuse them: (1) a
+**signal-driven decision** — a durable low-stock fact turned into a wake
+decision; (2) **one Pulse tick** — a single call that derives governed work from
+that decision; and (3) an **external scheduler or daemon** that would run ticks
+unattended on a timer. This chapter builds and proves (1) and (2). It does **not**
+build (3): *you* invoke the tick. "The organization wakes itself" means it creates
+its own work from its own signals — not that it runs forever on its own. And when
+it does create work, it leaves a durable, traceable record you can walk backward
 from the finished work all the way to the sale that woke it. No record, no claim.
 
 ## Learning objective

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -1,5 +1,17 @@
 # Chapter 7 — The organization wakes itself
 
+Every chapter so far began the same way: *you* typed a command. The sale, the
+signal, the restock — nothing moved until a human poked it. Lucy noticed this
+too. She doesn't want to *remember* to check the freezer; she wants the shop to
+notice its own low stock and start the reorder while she's busy scooping.
+
+That is a genuinely different and more dangerous capability, and most systems
+fake it — they run a loop, do something, and print "autonomous!" This chapter
+builds the real version and then does the thing this whole book insists on:
+proves it. When Lucy's organization creates work with nobody prompting it, it
+leaves a durable, traceable record that it did — a record you can walk backward
+from the finished work all the way to the sale that woke it. No record, no claim.
+
 ## Learning objective
 
 Watch the organization create governed work **without a human prompt**, and
@@ -8,11 +20,10 @@ learn what makes that claim honest rather than theater: a durable
 real mechanism, both checkable after the fact — never a status string, never
 an inference from "nobody typed a command."
 
-Chapter 0 ended by telling you the truth: "you started this... the
-organization has no heartbeat yet." That was accurate when it was written.
-This chapter is where that stops being true — and it is truthful about the
-difference, because the ledger this exercise produces proves it rather than
-merely claiming it.
+Chapter 0 ended by telling you the truth: you started everything; the
+organization had no heartbeat yet. This chapter is where that stops being true —
+and it earns the change honestly, because the ledger this exercise produces
+proves the organization woke itself rather than merely claiming it did.
 
 ## Vocabulary this chapter adds
 
@@ -26,7 +37,7 @@ merely claiming it.
 ## The exercise
 
 ```bash
-python book/ch07_the_organization_wakes_itself/solution.py --root /tmp/andrea-ch07
+python book/ch07_the_organization_wakes_itself/solution.py --root /tmp/lucy-ch07
 ```
 
 Read the file before you run it. Notice what is missing: no `create_sow`, no
@@ -81,10 +92,10 @@ This is the whole chapter, in four facts:
    in prose, read back from the ledger after the fact, the same way Chapter
    0 taught you to check every other claim in this book.
 2. **`origin_kind: "pulse"`.** Not inferred from the absence of a manual
-   dispatch call — a column, read directly.
-   `docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md`
-   states the holding this row exists to prove: "absence of a CLI
-   invocation, process logs, or a manual-origin row is NOT proof."
+   dispatch call — a column, read directly. This is a deliberate design
+   principle: the absence of a CLI invocation, of process logs, or of a
+   manual-origin row is *not* proof that work was self-generated. Only a
+   positive, recorded origin is.
 3. **`wake_decision_traces_back_to_this_signal: true`.** The full chain —
    signal → wake decision → Pulse event → SOW → assignment — is walkable,
    not merely claimed. The wake decision's own `source_signal_id` matches
@@ -97,7 +108,7 @@ This is the whole chapter, in four facts:
 Confirm it yourself, independent of this exercise's own summary:
 
 ```bash
-sqlite3 /tmp/andrea-ch07/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch07/.sovereign/organization.db <<'SQL'
 SELECT po.origin_kind, po.sow_id, po.assignment_id,
        wd.source_signal_id, wd.source_event_id
 FROM pulse_origins po
@@ -114,12 +125,11 @@ source event.
 Chapters 0 through 3 say the organization has no heartbeat, and mean it — no
 chapter before this one ever calls `run_pulse_once`, and this project's own
 curriculum checker refuses any of them from claiming otherwise, mechanically,
-every time it runs. That is not this chapter overwriting an old truth; it is
-this book being honest about when a truth changed. Chapter 0 itself was
-updated, additively, the moment Pulse became real: "Pulse is now real, as a
-separate mechanism you invoke yourself... it is not this chapter's exercise,
-and it never runs itself." That sentence is still true. This is the chapter
-where you invoke it.
+every time it runs. That is not this chapter overwriting an old truth; it is this book being honest
+about *when* a capability arrives. Chapter 0 was careful to say the organization
+cannot yet wake itself, and to show you a ledger with no `pulse.*` event in it.
+Pulse is a separate mechanism you invoke yourself — it never runs on its own —
+and this is the chapter where you invoke it for the first time.
 
 The same curriculum checker that refuses an early chapter's Pulse claim
 holds THIS chapter to a stricter standard than "the words are true": it
@@ -141,7 +151,7 @@ python scripts/verify_curriculum.py
 
 Expected: all pass. The pytest selection proves the full sale-to-accepted
 slice through the real mechanism, the source-event-to-SOW attribution chain,
-and that Pulse-created work is not exempt from Unit 8's fencing.
+and that Pulse-created work is not exempt from Chapter 5's fencing.
 `verify_curriculum.py` proves this chapter's own claim is backed by durable
 evidence, not merely present in the prose — the mechanical guard this
 project's own curriculum checker enforces specifically for Chapter 7.
@@ -169,16 +179,15 @@ project's own curriculum checker enforces specifically for Chapter 7.
 - `src/sovereign_agent/pulse.py` — `run_pulse_once`, the whole mechanism
 - `src/reference_organizations/store/pulse_gate.py` — the Store's own wake
   gate, deliberately outside `sovereign_agent`'s own module budget
-- `docs/v1-unit9-pulse-proactive-work.md` — the full contract and proof
-  matrix, including the F-U9-1 correction that made the canonical creation
-  transaction genuinely atomic
-- `docs/rulings/2026-08-29-unit9-pulse-is-separate-from-supervisor.md` — why
-  Pulse is not a fourth step of the supervisor's own tick
+- `tests/test_pulse.py` — the full proof matrix, including that the canonical
+  creation transaction (signal → wake decision → SOW → assignment) is genuinely
+  atomic, so a crash mid-creation cannot strand a half-woken piece of work
 
 `solution.py` imports the production package rather than copying it.
 
-You have now completed all seven chapters. **Added, Unit 11:** the Store's
-own governed territory now expands — Chapters 8 through 12 land alongside
-it, the same way Chapters 4 through 7 landed alongside Units 7 through 9.
+You have now built the whole spine of a governed organization: memory,
+judgement, bounded work, fenced authority, recovery, and a heartbeat. Chapters 8
+through 12 turn from the machinery to the shop itself — Lucy's catalog grows, and
+you watch every guarantee you built hold up as it scales.
 
 Next: [Chapter 8 — The Store becomes a catalog](../ch08_the_store_becomes_a_catalog/README.md)

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -39,6 +39,229 @@ proves the organization woke itself rather than merely claiming it did.
 | **Wake decision** | The durable, `UNIQUE(source_signal_id)` claim that one signal fired — the SQLite-boundary enforcement of "exactly one canonical decision per signal," not a preflight check a race can slip past. |
 | **Pulse origin** | The structured, queryable answer to "manual or Pulse, and from what?" — every SOW, manual or Pulse-created, has exactly one row. Absence of a row is never the definition of manual. |
 
+## Build the tick yourself, then double-order the cones
+
+Before running the real mechanism, build a pulse tick small enough to watch
+it make the one mistake every naive version makes.
+
+The scene: a sale dropped vanilla to 2 against a reorder point of 3, and the
+sale committed a durable **signal** — a fact, not a task:
+
+```python
+import sqlite3
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE inventory (sku TEXT PRIMARY KEY, on_hand INT NOT NULL, reorder INT NOT NULL);
+    CREATE TABLE signals (id TEXT PRIMARY KEY, sku TEXT, kind TEXT);
+    CREATE TABLE wake_decisions (id INTEGER PRIMARY KEY, source_signal_id TEXT UNIQUE,
+                                 sow_id TEXT);
+    CREATE TABLE sows (id TEXT PRIMARY KEY, title TEXT, state TEXT);
+""")
+db.execute("INSERT INTO inventory VALUES ('SKU-VANILLA', 2, 3)")
+db.execute("INSERT INTO signals VALUES ('sig-1', 'SKU-VANILLA', 'low_stock')")
+db.commit()
+```
+
+Note the `UNIQUE` on `wake_decisions.source_signal_id`. It looks like a
+detail. It is the entire chapter.
+
+### The gate decides WHAT — and nothing else
+
+```python
+def wake_gate(db, signal_sku):
+    on_hand, reorder = db.execute(
+        "SELECT on_hand, reorder FROM inventory WHERE sku = ?", (signal_sku,)
+    ).fetchone()
+    if on_hand < reorder:
+        return f"Replenish {signal_sku} to {reorder}"
+    return None
+
+
+print(wake_gate(db, "SKU-VANILLA"))
+```
+
+```text
+Replenish SKU-VANILLA to 3
+```
+
+The gate is a pure read: world in, decision out, no writes. That split is
+deliberate and mirrored in production — the gate decides *what* should
+happen (domain logic about SKUs and reorder points, owned by the Store, not
+by the Pulse mechanism), while the tick alone decides *how* work gets
+created. Keep the gate pure and every hard question in this chapter lands in
+one place.
+
+### The tick that creates work every time you ask
+
+```python
+def tick_naive(db, signal_id):
+    sku = db.execute("SELECT sku FROM signals WHERE id = ?", (signal_id,)).fetchone()[0]
+    scope = wake_gate(db, sku)
+    if scope is None:
+        return "signal does not qualify"
+    count = db.execute("SELECT COUNT(*) FROM sows").fetchone()[0]
+    sow_id = f"sow-for-{signal_id}-{count}"
+    db.execute("INSERT INTO sows VALUES (?, ?, 'READY')", (sow_id, scope))
+    db.commit()
+    return f"created {sow_id}"
+
+
+print(tick_naive(db, "sig-1"))
+print(tick_naive(db, "sig-1"))  # a retry, a second runner, a crash-and-rerun...
+print("SOWs on the ledger:", db.execute("SELECT COUNT(*) FROM sows").fetchone()[0])
+```
+
+```text
+created sow-for-sig-1-0
+created sow-for-sig-1-1
+SOWs on the ledger: 2
+```
+
+One sale, one signal, **two** replenishment jobs — and nothing about the
+second call was unreasonable. Ticks get retried; supervisors get restarted;
+a crash right after a tick makes rerunning it the obviously safe move. Every
+one of those ordinary events is now a duplicate freezer order. The naive
+tick's flaw is structural: nothing durable records that *this signal was
+already decided*, so every evaluation decides it again.
+
+### The tick that claims the decision, atomically
+
+The repair binds three things into **one transaction**: re-checking the
+world, claiming the decision, and creating the work. The claim is the
+`UNIQUE(source_signal_id)` insert — enforced by the database at the moment
+of writing, not by a Python check a race can slip past — and a loser does
+not fail: it returns the **winner's canonical identifiers**.
+
+```python
+db.execute("DELETE FROM sows")
+db.commit()
+
+
+def tick(db, signal_id):
+    sku = db.execute("SELECT sku FROM signals WHERE id = ?", (signal_id,)).fetchone()[0]
+    try:
+        db.execute("BEGIN IMMEDIATE")
+        scope = wake_gate(db, sku)  # REVALIDATED inside the transaction
+        if scope is None:
+            db.execute("ROLLBACK")
+            return "signal no longer qualifies"
+        cursor = db.execute(
+            "INSERT INTO wake_decisions(source_signal_id, sow_id) VALUES (?, ?)",
+            (signal_id, f"sow-{signal_id}"),
+        )
+        db.execute("INSERT INTO sows VALUES (?, ?, 'READY')", (f"sow-{signal_id}", scope))
+        db.execute("COMMIT")
+        return f"created sow-{signal_id} (decision {cursor.lastrowid})"
+    except sqlite3.IntegrityError:
+        db.execute("ROLLBACK")
+        winner = db.execute(
+            "SELECT sow_id FROM wake_decisions WHERE source_signal_id = ?", (signal_id,)
+        ).fetchone()[0]
+        return f"already decided: canonical work is {winner}"
+
+
+print(tick(db, "sig-1"))
+print(tick(db, "sig-1"))
+print("SOWs on the ledger:", db.execute("SELECT COUNT(*) FROM sows").fetchone()[0])
+```
+
+```text
+created sow-sig-1 (decision 1)
+already decided: canonical work is sow-sig-1
+SOWs on the ledger: 1
+```
+
+Run it a hundred more times: one SOW, forever. And look at what the loser
+got back — not an error, but the canonical answer. A contender that loses
+the race learns *which* work is the real one, which is exactly what a
+restarted runner needs in order to carry on. This is also the crash-window
+resume in miniature: a tick that finds the decision already committed but
+the work not yet run doesn't create anything — it picks up the canonical
+identifiers and resumes from there, which is precisely `run_pulse_once`'s
+step one in production.
+
+### The fault that leaves nothing behind
+
+The claim and the work must commit **together**, or a crash between them
+strands a decided-but-workless signal forever:
+
+```python
+db.execute("INSERT INTO signals VALUES ('sig-2', 'SKU-VANILLA', 'low_stock')")
+db.commit()
+
+
+def tick_with_fault(db, signal_id):
+    sku = db.execute("SELECT sku FROM signals WHERE id = ?", (signal_id,)).fetchone()[0]
+    try:
+        db.execute("BEGIN IMMEDIATE")
+        wake_gate(db, sku)
+        db.execute(
+            "INSERT INTO wake_decisions(source_signal_id, sow_id) VALUES (?, ?)",
+            (signal_id, f"sow-{signal_id}"),
+        )
+        raise RuntimeError("power cut before the SOW was written")
+    except RuntimeError as error:
+        db.execute("ROLLBACK")
+        return f"fault: {error}"
+
+
+print(tick_with_fault(db, "sig-2"))
+count = db.execute(
+    "SELECT COUNT(*) FROM wake_decisions WHERE source_signal_id = 'sig-2'"
+).fetchone()[0]
+print("half-made decisions left behind:", count)
+print(tick(db, "sig-2"))  # the next tick simply tries again, cleanly
+```
+
+```text
+fault: power cut before the SOW was written
+half-made decisions left behind: 0
+created sow-sig-2 (decision 2)
+```
+
+Chapter 1's migration lesson, at the work-creation layer: a failure at *any*
+boundary rolls the whole creation back, so recovery is never a repair — it
+is just the next tick doing its ordinary job.
+
+### The world moved; the signal did not
+
+A signal records that something *was* true. Between the sale and the tick, a
+manual restock can land — and the tick must ask the world again, inside its
+own transaction, rather than trust the signal's snapshot:
+
+```python
+db.execute("INSERT INTO signals VALUES ('sig-3', 'SKU-VANILLA', 'low_stock')")
+db.execute("UPDATE inventory SET on_hand = 9")  # a manual restock landed first
+db.commit()
+print(tick(db, "sig-3"))
+print("SOWs on the ledger:", db.execute("SELECT COUNT(*) FROM sows").fetchone()[0])
+```
+
+```text
+signal no longer qualifies
+SOWs on the ledger: 2
+```
+
+This is Chapter 2's deepest rule — *re-read the world at the moment of the
+act* — applied at the moment work is **born** instead of the moment it is
+accepted. The signal was honest when written; the gate is honest now; no
+work is created for a freezer that is already full.
+
+The production mechanism, `run_pulse_once` in `src/sovereign_agent/pulse.py`,
+is everything you just built plus the integration your toy elides: it resumes
+already-fired signals whose canonical assignment never ran (the crash
+window), asks the caller-supplied gate exactly as yours did, creates the
+canonical SOW *and* assignment *and* origin rows through
+`Organization.create_pulse_work` in one transaction, and then runs the
+assignment through the very same fenced `run_assignment` path as Chapter 5 —
+no Pulse-only bypass. One boundary is load-bearing enough to be a ruling:
+the supervisor from Chapter 6 **never calls this**, and this module never
+calls the supervisor — the two compose only through a foreground caller
+running each as its own separate operation. Recovery reconciles work that
+exists; Pulse creates work that should; a mechanism that did both would be a
+process nobody could reason about when it failed halfway through either job.
+
 ## The exercise
 
 ```bash
@@ -178,6 +401,15 @@ project's own curriculum checker enforces specifically for Chapter 7.
 5. What specifically would make this chapter's own Pulse claim FALSE — name
    at least two different ways the underlying ledger could fail to back up
    the prose above, and explain how you would notice.
+6. `tick_naive` was defeated by perfectly reasonable behavior — retries and
+   restarts, not attacks. Why is "just don't call it twice" not an
+   acceptable fix, and what does the UNIQUE claim change structurally?
+7. The losing contender returns the winner's canonical identifiers instead
+   of an error. Name the caller that specifically needs that behavior, and
+   what it would wrongly do if it got an exception instead.
+8. `sig-3` was honest when recorded, yet created no work. Reconcile "signals
+   are durable append-only facts" with "this signal produced nothing" —
+   which of the two would it be dishonest to change?
 
 ## Where to look next
 

--- a/book/ch08_the_store_becomes_a_catalog/README.md
+++ b/book/ch08_the_store_becomes_a_catalog/README.md
@@ -1,5 +1,19 @@
 # Chapter 8 — The Store becomes a catalog
 
+Up to now Lucy's shop has sold exactly one thing. That was a convenient lie — it
+let us build memory, judgement, boundaries, fencing, recovery, and a heartbeat
+without the distraction of a second product. But a real ice cream shop has
+vanilla *and* chocolate, and the moment there are two, a new question appears that
+never existed with one: **when something happens to one product, does it stay
+contained to that product?** A run on vanilla must not quietly change the
+chocolate count. A low-stock signal for one flavor must not reorder the other.
+
+This chapter is the smallest possible version of that step — turning the single
+product into a genuine *catalog* of independent SKUs — because independence is
+easiest to get right at the very beginning, at the schema, before any sale or
+signal can blur the lines. (The shipped catalog uses two example SKUs to make the
+mechanics concrete; they behave exactly as Lucy's vanilla and chocolate would.)
+
 ## Learning objective
 
 See the Store's single-product fixture become a genuine catalog: two
@@ -25,7 +39,7 @@ real store with more than one product on the shelf actually needs.
 ## The exercise
 
 ```bash
-python book/ch08_the_store_becomes_a_catalog/solution.py --root /tmp/andrea-ch08
+python book/ch08_the_store_becomes_a_catalog/solution.py --root /tmp/lucy-ch08
 ```
 
 Read the file first. `seed_catalog` is called once, with the default
@@ -92,7 +106,7 @@ Three facts this run proves, not merely states:
 Confirm it yourself, independent of this exercise's own summary:
 
 ```bash
-sqlite3 /tmp/andrea-ch08/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch08/.sovereign/organization.db <<'SQL'
 SELECT sku, on_hand, reorder_point FROM inventory ORDER BY sku;
 SQL
 ```
@@ -109,7 +123,7 @@ python scripts/verify_curriculum.py
 
 Expected: all pass. The pytest selection proves a sale of one SKU cannot
 touch another SKU's own row — this chapter only seeds the catalog, but the
-isolation the rest of this unit relies on starts here, at the schema.
+isolation the next chapters rely on starts here, at the schema.
 
 ## Explain it back
 
@@ -128,9 +142,8 @@ isolation the rest of this unit relies on starts here, at the schema.
 
 - `src/reference_organizations/store/__init__.py` — `seed_catalog`,
   `CatalogEntry`, `DEFAULT_CATALOG`
-- `tests/test_store_multi_sku.py` — the full multi-SKU isolation proof
-  matrix this unit's own acceptance requires
-- `docs/v1-unit11-store-expansion-pilot-start.md` — the full contract
+- `tests/test_store_multi_sku.py` — the full multi-SKU isolation proof matrix:
+  every way one SKU's row could leak into another's, and the proof it cannot
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch08_the_store_becomes_a_catalog/README.md
+++ b/book/ch08_the_store_becomes_a_catalog/README.md
@@ -36,6 +36,237 @@ real store with more than one product on the shelf actually needs.
 | **`CatalogEntry`** | One SKU's own opening position: the product itself, plus its own starting `on_hand` and `reorder_point`, independent of every other entry in the same catalog. |
 | **`seed_catalog`** | The production function that writes a whole catalog in one transaction. Additive alongside `seed`, never a replacement for it. |
 
+## Build the migration yourself: one product becomes a catalog, without losing the shop
+
+"Add a SKU" sounds like data entry. It is a **schema evolution on populated
+data** — the exact discipline Chapter 1 built — and the shop that needs it
+is already running, with money in the till and history in the ledger. Start
+from the tempting one-product schema most systems begin with:
+
+```python
+import sqlite3
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE shop (id INTEGER PRIMARY KEY CHECK (id = 1),
+                       product_name TEXT, on_hand INT, reorder INT);
+    CREATE TABLE events (seq INTEGER PRIMARY KEY, kind TEXT, sku TEXT);
+""")
+db.execute("INSERT INTO shop VALUES (1, 'Assam tea', 4, 3)")
+db.execute("INSERT INTO events(kind, sku) VALUES ('sale.committed', 'SKU-TEA')")
+db.execute("INSERT INTO events(kind, sku) VALUES ('replenishment.committed', 'SKU-TEA')")
+db.commit()
+print(db.execute("SELECT * FROM shop").fetchone())
+print("history rows:", db.execute("SELECT COUNT(*) FROM events").fetchone()[0])
+```
+
+```text
+(1, 'Assam tea', 4, 3)
+history rows: 2
+```
+
+The `CHECK (id = 1)` is the one-product assumption made structural: this
+table *cannot* hold a second product. Before reading further, design the
+replacement yourself — you need product **identity**, product **display
+name**, and stock **quantities**, and the design question is which of those
+are the same concern. Predict what goes wrong if the name is the key. Then
+compare with what follows.
+
+### The migration, on live data, in one transaction
+
+Three separate concerns get three separate homes: identity (`sku`, the
+primary key — opaque, stable, never shown to customers), the display name
+(mutable prose *about* the identity), and quantities (their own row, with a
+constraint that makes negative stock unrepresentable):
+
+```python
+def migrate_to_catalog(db):
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        db.execute("""
+            CREATE TABLE products (sku TEXT PRIMARY KEY, name TEXT NOT NULL,
+                                   price_cents INT NOT NULL)
+        """)
+        db.execute("""
+            CREATE TABLE inventory (sku TEXT PRIMARY KEY REFERENCES products(sku),
+                                    on_hand INT NOT NULL CHECK (on_hand >= 0),
+                                    reserved INT NOT NULL DEFAULT 0,
+                                    reorder INT NOT NULL)
+        """)
+        name, on_hand, reorder = db.execute(
+            "SELECT product_name, on_hand, reorder FROM shop WHERE id = 1"
+        ).fetchone()
+        db.execute("INSERT INTO products VALUES ('SKU-TEA', ?, 400)", (name,))
+        db.execute(
+            "INSERT INTO inventory(sku, on_hand, reorder) VALUES ('SKU-TEA', ?, ?)",
+            (on_hand, reorder),
+        )
+        migrated = db.execute("SELECT COUNT(*) FROM inventory").fetchone()[0]
+        original = db.execute("SELECT COUNT(*) FROM shop").fetchone()[0]
+        if migrated != original:
+            raise RuntimeError(f"row count mismatch: {original} became {migrated}")
+        db.execute("DROP TABLE shop")
+        db.execute("COMMIT")
+        return "migrated: singleton shop is now a catalog"
+    except BaseException:
+        db.execute("ROLLBACK")
+        raise
+
+
+print(migrate_to_catalog(db))
+print(db.execute("SELECT sku, name, price_cents FROM products").fetchone())
+print(db.execute("SELECT sku, on_hand, reserved, reorder FROM inventory").fetchone())
+print("history rows survived:", db.execute("SELECT COUNT(*) FROM events").fetchone()[0])
+```
+
+```text
+migrated: singleton shop is now a catalog
+('SKU-TEA', 'Assam tea', 400)
+('SKU-TEA', 4, 0, 3)
+history rows survived: 2
+```
+
+Everything from Chapter 1 is load-bearing here: the copy, the count check,
+the `DROP`, and the version stamp of a real migration all ride one
+`BEGIN IMMEDIATE` — and the count check is the migration verifying *itself*
+before it burns the bridge. The four on-hand tubs and both history rows
+crossed intact. This is a guest arriving in a house where data already
+lives, exactly as the production schema's own sixteen forward-only
+migrations each had to be.
+
+### Seeding a catalog is a validated act, not a loop of inserts
+
+```python
+def seed_catalog(db, entries):
+    if len(entries) < 2:
+        return "refused: a catalog needs at least two distinct SKUs"
+    skus = [sku for sku, _, _, _, _ in entries]
+    if len(set(skus)) != len(skus):
+        return f"refused: duplicate SKUs in catalog: {skus}"
+    if any(on_hand < 0 for _, _, _, on_hand, _ in entries):
+        return "refused: negative opening stock is unrecorded debt, not inventory"
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        for sku, name, price, on_hand, reorder in entries:
+            db.execute("INSERT OR REPLACE INTO products VALUES (?, ?, ?)", (sku, name, price))
+            db.execute(
+                "INSERT OR REPLACE INTO inventory(sku, on_hand, reorder) VALUES (?, ?, ?)",
+                (sku, on_hand, reorder),
+            )
+        db.execute("COMMIT")
+        return f"seeded {len(entries)} SKUs"
+    except BaseException:
+        db.execute("ROLLBACK")
+        raise
+
+
+print(seed_catalog(db, [("SKU-TEA", "Assam tea", 400, 4, 3)]))
+print(seed_catalog(db, [("SKU-TEA", "Assam tea", 400, 4, 3), ("SKU-TEA", "Also tea", 500, 9, 6)]))
+print(
+    seed_catalog(
+        db, [("SKU-TEA", "Assam tea", 400, 4, 3), ("SKU-COFFEE", "Kenyan coffee", 650, -2, 6)]
+    )
+)
+print(
+    seed_catalog(
+        db, [("SKU-TEA", "Assam tea", 400, 4, 3), ("SKU-COFFEE", "Kenyan coffee", 650, 10, 6)]
+    )
+)
+rows = db.execute("SELECT sku, on_hand, reorder FROM inventory ORDER BY sku").fetchall()
+print(rows)
+```
+
+```text
+refused: a catalog needs at least two distinct SKUs
+refused: duplicate SKUs in catalog: ['SKU-TEA', 'SKU-TEA']
+refused: negative opening stock is unrecorded debt, not inventory
+seeded 2 SKUs
+[('SKU-COFFEE', 10, 6), ('SKU-TEA', 4, 3)]
+```
+
+Three refusals, three different edge cases the map warned about. A
+one-entry "catalog" is the singleton assumption sneaking back in a list
+costume. Duplicate SKUs would make `INSERT OR REPLACE` silently collapse
+two products into one — validated *before* the transaction opens, so the
+refusal costs nothing. And negative opening stock is refused twice over:
+once by the seed's own validation, and structurally by the `CHECK
+(on_hand >= 0)` the migration installed — belt because the error message is
+better, suspenders because a seed that skipped validation still cannot
+write the lie. Production's `seed_catalog` carries the first two refusals
+almost verbatim (`a catalog needs at least two distinct SKUs`,
+`duplicate SKUs in catalog`), seeds everything in one transaction, and adds
+the one deliberate shared resource — a single opening cash balance, because
+a store has one till, not one per SKU.
+
+### The fault, again, because populated data raises the stakes
+
+```python
+db2 = sqlite3.connect(":memory:")
+db2.executescript("""
+    CREATE TABLE shop (id INTEGER PRIMARY KEY CHECK (id = 1),
+                       product_name TEXT, on_hand INT, reorder INT);
+    CREATE TABLE events (seq INTEGER PRIMARY KEY, kind TEXT, sku TEXT);
+""")
+db2.execute("INSERT INTO shop VALUES (1, 'Assam tea', 4, 3)")
+db2.commit()
+
+
+def migrate_but_crash(db):
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        db.execute("CREATE TABLE products (sku TEXT PRIMARY KEY, name TEXT, price_cents INT)")
+        db.execute("INSERT INTO products VALUES ('SKU-TEA', 'Assam tea', 400)")
+        raise RuntimeError("power cut before inventory was copied and shop dropped")
+    except RuntimeError as error:
+        db.execute("ROLLBACK")
+        return f"fault: {error}"
+
+
+print(migrate_but_crash(db2))
+tables = [
+    r[0] for r in db2.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+]
+print("tables after the fault:", tables)
+print("the shop row, untouched:", db2.execute("SELECT * FROM shop").fetchone())
+```
+
+```text
+fault: power cut before inventory was copied and shop dropped
+tables after the fault: ['events', 'shop']
+the shop row, untouched: (1, 'Assam tea', 4, 3)
+```
+
+No `products` table left behind, no half-copied catalog, and the running
+shop exactly as it was — the second half of Chapter 1's migration lesson,
+now with live inventory on the line. A migration that can strand a shop
+between two schemas is worse than no migration.
+
+### The payoff of identity: the name is free to change
+
+```python
+db.execute("UPDATE products SET name = 'Lucy''s house blend' WHERE sku = 'SKU-TEA'")
+db.commit()
+print(db.execute("SELECT sku, name FROM products WHERE sku = 'SKU-TEA'").fetchone())
+linked = db.execute("SELECT COUNT(*) FROM events WHERE sku = 'SKU-TEA'").fetchone()[0]
+print("history rows still bound to the identity:", linked)
+```
+
+```text
+('SKU-TEA', "Lucy's house blend")
+history rows still bound to the identity: 2
+```
+
+Lucy rebrands the tea; every sale, signal, and replenishment in the history
+still points at `SKU-TEA`, untouched. Had the *name* been the key, that
+rename would have orphaned the entire history — or been forbidden forever.
+Identity is what the ledger binds to; the display name is prose about it.
+One more design note worth carrying from production: `seed_catalog` is
+*additive alongside* the old single-product `seed`, never a replacement —
+every chapter and test written before the catalog existed still relies on
+the old contract, and breaking it out from under them is exactly the
+revert-what-works move this book's Chapter 1 warned against. Schemas grow
+the way ledgers do: forward.
+
 ## The exercise
 
 ```bash
@@ -137,6 +368,18 @@ isolation the next chapters rely on starts here, at the schema.
    the correct design, not a gap?
 4. What would make this chapter's own "at least two independent SKUs" claim
    FALSE, even if `distinct_skus_seeded` still printed `2`?
+5. The migration's count check runs BEFORE `DROP TABLE shop`, inside the
+   same transaction. Explain what each of those two placement decisions
+   protects, separately.
+6. Negative opening stock is refused twice — by the seed's validation and
+   by the `CHECK` constraint. Why keep both, when either alone would stop
+   the write?
+7. The rename demo changed the display name and every history row survived.
+   Walk through exactly what would have broken, table by table, if
+   `product_name` had been the primary key instead of `sku`.
+8. `CHECK (id = 1)` made the one-product assumption structural. Was that a
+   mistake? Argue both sides in a sentence each, then say which this book's
+   own migration discipline favors and why.
 
 ## Where to look next
 

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -29,6 +29,238 @@ exact same-shaped sale already flagged tea.
 | **Per-SKU threshold** | `below_reorder` evaluates EACH SKU's `on_hand` against THAT SKU's own `reorder_point` — never a catalog-wide number. |
 | **Signal severity** | `record_sale`'s own `warning`/`info` distinction, now shown to depend on the selling SKU's own threshold, not a shared one. |
 
+## Build the sale yourself, then oversell the freezer
+
+A sale looks like one act. It is at least **five writes that must be true
+together**: inventory down, cash up, a severity-judged signal, a committed
+event, and the total derived — never trusted. Build it whole, then watch the
+one-line shortcut sell ice cream that does not exist.
+
+```python
+import sqlite3
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE inventory (sku TEXT PRIMARY KEY, on_hand INT NOT NULL,
+                            reserved INT NOT NULL DEFAULT 0, reorder INT NOT NULL);
+    CREATE TABLE cash_entries (id INTEGER PRIMARY KEY, amount_cents INT NOT NULL);
+    CREATE TABLE events (seq INTEGER PRIMARY KEY, kind TEXT NOT NULL);
+    CREATE TABLE signals (id TEXT PRIMARY KEY, dedupe_key TEXT UNIQUE, severity TEXT);
+""")
+db.execute("INSERT INTO inventory VALUES ('SKU-TEA', 4, 0, 3)")
+db.execute("INSERT INTO inventory VALUES ('SKU-COFFEE', 10, 0, 6)")
+db.commit()
+```
+
+### One exact sale, traced through every write
+
+```python
+def record_sale(db, sku, quantity, unit_price_cents):
+    if quantity <= 0:
+        return "refused: quantity must be positive"
+    db.execute("BEGIN IMMEDIATE")
+    row = db.execute(
+        "SELECT on_hand, reserved, reorder FROM inventory WHERE sku = ?", (sku,)
+    ).fetchone()
+    if row is None:
+        db.execute("ROLLBACK")
+        return "refused: unknown SKU -- actors cannot invent inventory"
+    on_hand, reserved, reorder = row
+    available = on_hand - reserved
+    if quantity > available:
+        db.execute("ROLLBACK")
+        return f"refused: only {available} available ({on_hand} on hand, {reserved} reserved)"
+    new_on_hand = on_hand - quantity
+    total = quantity * unit_price_cents
+    db.execute("UPDATE inventory SET on_hand = ? WHERE sku = ?", (new_on_hand, sku))
+    db.execute("INSERT INTO cash_entries(amount_cents) VALUES (?)", (total,))
+    severity = "warning" if new_on_hand <= reorder else "info"
+    count = db.execute("SELECT COUNT(*) FROM signals").fetchone()[0]
+    sig_id = f"sig-{count}"
+    db.execute(
+        "INSERT INTO signals VALUES (?, ?, ?)",
+        (sig_id, f"inventory:{sku}:{new_on_hand}:{sig_id}", severity),
+    )
+    db.execute("INSERT INTO events(kind) VALUES ('sale.committed')")
+    db.execute("COMMIT")
+    return f"sold {quantity} {sku} for {total}c -> on_hand {new_on_hand}, signal {severity}"
+
+
+print(record_sale(db, "SKU-TEA", 2, 400))
+print(record_sale(db, "SKU-COFFEE", 2, 500))  # the SAME quantity, deliberately
+```
+
+```text
+sold 2 SKU-TEA for 800c -> on_hand 2, signal warning
+sold 2 SKU-COFFEE for 1000c -> on_hand 8, signal info
+```
+
+The two sales are **genuinely identical in shape** — two units each — and
+their signals still split `warning`/`info`. That is the chapter's thesis
+made mechanical: severity is not a property of how much sold, but of where
+each SKU landed **relative to its own line** (tea: 2 ≤ 3; coffee: 8 > 6).
+Note also the total: `quantity * unit_price_cents`, *derived* inside the
+sale — a caller-supplied total would be a self-graded number, the boolean-
+authority mistake from Chapter 3 wearing a price tag. And the signal's
+`dedupe_key` carries the signal's own id as a suffix: production learned
+this the hard way when an older key of just `inventory:{sku}:{on_hand}` let
+two *different* sales that happened to land on the same stock level collide
+— and `INSERT OR REPLACE` silently **deleted the first sale's signal row**,
+history a Pulse origin might already reference. The per-occurrence suffix
+plus a plain `INSERT` under a `UNIQUE` constraint makes that failure loud
+instead of silent.
+
+### The refusals, each for its own reason
+
+```python
+print(record_sale(db, "SKU-TEA", -1, 400))
+print(record_sale(db, "SKU-PISTACHIO", 1, 400))
+print(record_sale(db, "SKU-TEA", 5, 400))
+```
+
+```text
+refused: quantity must be positive
+refused: unknown SKU -- actors cannot invent inventory
+refused: only 2 available (2 on hand, 0 reserved)
+```
+
+A negative quantity is not a small sale, it is a disguised restock that
+bypasses purchasing. An unknown SKU is not an empty shelf, it is inventory
+being invented. And the oversell refusal reads **availability**, not
+`on_hand` — hold that distinction two sections.
+
+### Break it: the sale that checks first and writes later
+
+The tempting optimization: check availability once, up front, then just
+decrement. Two sales arrive; both check before either writes:
+
+```python
+def sell_naive(db, sku, quantity, available_seen):
+    if quantity > available_seen:
+        return "refused"
+    db.execute("UPDATE inventory SET on_hand = on_hand - ? WHERE sku = ?", (quantity, sku))
+    db.commit()
+    return f"sold {quantity} {sku}"
+
+
+seen = db.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'").fetchone()[0]
+print("both sales saw availability:", seen)
+print(sell_naive(db, "SKU-TEA", 2, seen))
+print(sell_naive(db, "SKU-TEA", 2, seen))
+on_hand = db.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'").fetchone()[0]
+print("on hand now:", on_hand)
+```
+
+```text
+both sales saw availability: 2
+sold 2 SKU-TEA
+sold 2 SKU-TEA
+on hand now: -2
+```
+
+Minus two tubs of tea. Two customers paid for four units of a stock of two,
+and the ledger — the thing whose whole job is refusing unrecorded stock —
+now promises ice cream that does not exist. This is Chapter 5's
+read-then-write race selling groceries: the check was true *when it ran*,
+and stale *when it mattered*.
+
+### Repair: the read moves inside the transaction
+
+`record_sale` already contains the fix — look back at its shape. The
+`SELECT` happens **after** `BEGIN IMMEDIATE`, inside the same transaction as
+the writes, so no second sale can sneak between the check and the decrement:
+
+```python
+db.execute("UPDATE inventory SET on_hand = 2 WHERE sku = 'SKU-TEA'")  # undo the lie
+db.commit()
+print(record_sale(db, "SKU-TEA", 2, 400))
+print(record_sale(db, "SKU-TEA", 2, 400))
+on_hand = db.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'").fetchone()[0]
+print("on hand now:", on_hand)
+```
+
+```text
+sold 2 SKU-TEA for 800c -> on_hand 0, signal warning
+refused: only 0 available (0 on hand, 0 reserved)
+on hand now: 0
+```
+
+Production's `record_sale` states this rule in its own docstring: "The read
+of current stock happens INSIDE the immediate transaction. Reading first and
+writing later lets two concurrent sales both see enough stock and both sell
+it." One honest note about the toy: these two calls run on one connection,
+so what you watched is the *logic* refusing on a re-read, not two OS
+processes colliding — `BEGIN IMMEDIATE`'s reserved lock is what serializes
+genuinely concurrent connections, and the production suite proves that case
+with real separate connections.
+
+### Available is not on-hand
+
+Chapter 2's acceptance checks counted reservations; the sale must too. Six
+tubs physically in the freezer, five promised to a wedding order:
+
+```python
+db.execute("UPDATE inventory SET on_hand = 6, reserved = 5 WHERE sku = 'SKU-TEA'")
+db.commit()
+print(record_sale(db, "SKU-TEA", 2, 400))
+print(record_sale(db, "SKU-TEA", 1, 400))
+```
+
+```text
+refused: only 1 available (6 on hand, 5 reserved)
+sold 1 SKU-TEA for 400c -> on_hand 5, signal info
+```
+
+Selling from `on_hand` alone would double-promise the wedding's tubs to a
+walk-in customer — both truths recorded, both impossible to honor.
+`available = on_hand - reserved` is one subtraction, and it is the entire
+difference between a ledger that models commitments and one that models
+shelves.
+
+### All five writes, or none
+
+Finally, the crash test every multi-write act in this book must pass:
+
+```python
+def record_sale_but_crash(db, sku, quantity, unit_price_cents):
+    db.execute("BEGIN IMMEDIATE")
+    on_hand = db.execute("SELECT on_hand FROM inventory WHERE sku = ?", (sku,)).fetchone()[0]
+    db.execute("UPDATE inventory SET on_hand = ? WHERE sku = ?", (on_hand - quantity, sku))
+    db.execute("INSERT INTO cash_entries(amount_cents) VALUES (?)", (quantity * unit_price_cents,))
+    raise RuntimeError("power cut before the signal and event were written")
+
+
+def snapshot(db):
+    on_hand = db.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'").fetchone()[0]
+    cash = db.execute("SELECT COUNT(*) FROM cash_entries").fetchone()[0]
+    events = db.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    return f"on_hand={on_hand} cash_rows={cash} events={events}"
+
+
+print("before:", snapshot(db))
+try:
+    record_sale_but_crash(db, "SKU-TEA", 1, 400)
+except RuntimeError as error:
+    db.execute("ROLLBACK")
+    print("failed:", error)
+print("after: ", snapshot(db))
+```
+
+```text
+before: on_hand=5 cash_rows=4 events=4
+failed: power cut before the signal and event were written
+after:  on_hand=5 cash_rows=4 events=4
+```
+
+Inventory and cash had already been written when the power died — and the
+rollback took both back. A sale that decrements stock but records no cash,
+or takes cash but emits no signal for Pulse to wake on, is not a partial
+sale; it is a ledger at war with itself. The production version —
+`record_sale` in `src/reference_organizations/store/__init__.py` — is this
+function with real models: same inside-the-transaction read, same derived
+total, same per-SKU severity judgment, same per-occurrence dedupe key, same
+all-or-nothing commit.
+
 ## The exercise
 
 ```bash
@@ -114,6 +346,19 @@ Expected: all pass.
 3. If `CatalogEntry.reorder_point` were removed and replaced with one
    module-level constant shared by every SKU, which specific line of this
    chapter's own JSON output would become false first?
+4. `sell_naive` produced `on_hand = -2` without any bug in its arithmetic.
+   Name the exact property the check had at decision time but lacked at
+   write time, and where `record_sale` relocates the check to fix it.
+5. The sale's total is derived (`quantity * unit_price_cents`), never
+   accepted from the caller. Which earlier chapter's lesson is this, and
+   what lie does a caller-supplied total enable?
+6. Six on hand, five reserved, and a two-unit sale is refused. Who is being
+   protected — the walk-in customer, the wedding order, or the ledger — and
+   why is "all three" the right answer?
+7. The old dedupe key `inventory:{sku}:{on_hand}` plus `INSERT OR REPLACE`
+   silently deleted an earlier sale's signal. Explain who downstream was
+   harmed (name the mechanism from Chapter 7) and why the fix adds the
+   signal's own id to the key instead of just switching to plain INSERT.
 
 ## Where to look next
 

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -74,12 +74,15 @@ The two facts this run proves:
 1. **`coffee_on_hand_unaffected: true`.** Selling tea changed exactly one
    row in `inventory` — coffee's own `on_hand` is untouched, read back after
    the tea sale, not merely assumed.
-2. **`signal_severity` differs by SKU, correctly.** The tea sale's signal is
-   `warning` (2 remaining is at-or-below its own reorder point of 3). The
-   coffee sale's signal is `info` (9 remaining is still above its own
-   reorder point of 6) — the identical 1-unit-sold shape that would have
-   been a `warning` for tea is correctly `info` for coffee, because each
-   evaluation reads THAT SKU's own threshold.
+2. **`signal_severity` is judged per SKU, against that SKU's own line.** The tea
+   sale leaves 2 on hand, at-or-below tea's reorder point of 3, so its signal is
+   `warning`. The coffee sale leaves 9, still above coffee's reorder point of 6,
+   so its signal is `info`. These are two different-sized sales — that is the
+   point: severity is not a property of how much sold, but of where each SKU
+   landed relative to *its own* threshold. (Try editing the exercise to sell the
+   *same* quantity from both — selling 2 of each still warns tea and leaves coffee
+   at `info`, because 8 is above coffee's line of 6. The split follows the
+   thresholds, not the quantities.)
 
 Confirm it yourself:
 

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -1,5 +1,19 @@
 # Chapter 9 — Each product has its own threshold
 
+Lucy sells a *lot* of vanilla and only a little of her weird lavender-honey
+flavor. If both had the same "reorder when you hit 3 tubs" rule, one of two bad
+things would happen: either she'd run out of vanilla constantly (3 is far too low
+for something that flies out the door), or she'd drown in lavender-honey (3 is far
+too high for something nobody buys). Different products need different thresholds.
+That is obvious in a shop and surprisingly easy to get wrong in code, where it is
+tempting to reach for one tidy constant.
+
+Chapter 8 seeded a catalog where each SKU *had* its own reorder point, sitting in
+its own row. This chapter proves that number actually *does its job* once real
+sales start moving — that selling one product past its own line never trips
+another's, and that the very same sale can be an alarm for one product and a
+shrug for another.
+
 ## Learning objective
 
 Prove, with real sales, that "independent reorder point" from Chapter 8
@@ -18,7 +32,7 @@ exact same-shaped sale already flagged tea.
 ## The exercise
 
 ```bash
-python book/ch09_each_product_has_its_own_threshold/solution.py --root /tmp/andrea-ch09
+python book/ch09_each_product_has_its_own_threshold/solution.py --root /tmp/lucy-ch09
 ```
 
 Read the file first. Two sales happen: 2 units of tea (4 on hand, reorder at
@@ -70,7 +84,7 @@ The two facts this run proves:
 Confirm it yourself:
 
 ```bash
-sqlite3 /tmp/andrea-ch09/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch09/.sovereign/organization.db <<'SQL'
 SELECT sku, on_hand, reorder_point, on_hand <= reorder_point AS below FROM inventory ORDER BY sku;
 SQL
 ```
@@ -103,8 +117,7 @@ Expected: all pass.
 - `src/reference_organizations/store/__init__.py` — `record_sale`,
   `below_reorder`
 - `tests/test_store_multi_sku.py` — the signal-isolation and
-  wake-decision-isolation tests this chapter's own proof extends into
-  Chapter 10
+  wake-decision-isolation tests this chapter's proof extends into Chapter 10
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch10_one_signal_wakes_one_need/README.md
+++ b/book/ch10_one_signal_wakes_one_need/README.md
@@ -1,5 +1,19 @@
 # Chapter 10 — One signal wakes one need
 
+It's a busy Saturday. Lucy's vanilla drops below its line at 2:00 and her
+chocolate drops below its line at 2:05. Two alarms, close together. The one thing
+that must never happen is a crossed wire: the vanilla alarm starting a chocolate
+reorder, or both alarms collapsing into a single order that restocks one flavor
+twice and the other not at all. Each signal has to wake *its own* need, and only
+its own.
+
+This sounds trivial — of course a vanilla alarm is about vanilla — but "which
+signal is about which product" is precisely the kind of thing that goes wrong
+when work is created from events rather than from a human pointing at a form. In
+Chapter 7 you watched one signal correctly wake one need. This chapter makes sure
+that stays true when two needs are in flight at once, by pinning the decision to a
+fact carried *on the signal itself*, not to timing or arrival order.
+
 ## Learning objective
 
 Watch the Store's own wake gate (`store_wake_gate`, the exact mechanism
@@ -21,7 +35,7 @@ belongs to which outcome.
 ## The exercise
 
 ```bash
-python book/ch10_one_signal_wakes_one_need/solution.py --root /tmp/andrea-ch10
+python book/ch10_one_signal_wakes_one_need/solution.py --root /tmp/lucy-ch10
 ```
 
 Read the file first. Two outcomes are created, one per SKU. Two sales
@@ -67,7 +81,7 @@ Three facts this run proves:
 Confirm it yourself:
 
 ```bash
-sqlite3 /tmp/andrea-ch10/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch10/.sovereign/organization.db <<'SQL'
 SELECT wd.source_signal_id, wd.subject, po.sow_id
 FROM pulse_wake_decisions wd JOIN pulse_origins po ON po.wake_decision_id = wd.id
 ORDER BY wd.decided_at;
@@ -100,10 +114,10 @@ Expected: all pass.
 
 ## Where to look next
 
-- `src/reference_organizations/store/pulse_gate.py` — `store_wake_gate`,
-  unchanged since Unit 9, now proven across two SKUs
+- `src/reference_organizations/store/pulse_gate.py` — `store_wake_gate`, the
+  same gate from Chapter 7, now proven across two SKUs at once
 - `tests/test_store_multi_sku.py` — the wake-decision-isolation and
-  Pulse-origin-isolation tests this chapter's own proof extends
+  Pulse-origin-isolation tests this chapter's proof extends
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch10_one_signal_wakes_one_need/README.md
+++ b/book/ch10_one_signal_wakes_one_need/README.md
@@ -32,6 +32,258 @@ belongs to which outcome.
 | --- | --- |
 | **Signal-to-SKU binding** | A signal's own `subject_ref` field is what the wake gate reads to decide which outcome it is about — not the order signals arrive in, not which one was created first. |
 
+## Three different questions that all sound like "is it done?"
+
+Before building anything, split one innocent question into the three it
+actually contains, because the whole chapter turns on refusing to let them
+blur:
+
+- **Authentication** — *who or what produced this artifact?* (Out of scope
+  for this ledger, honestly and explicitly — Chapter 2's Exercise 6.)
+- **Corroboration** — *do independent observations agree the world is in
+  the right state?* (Chapter 2's re-run-the-checks discipline.)
+- **Causal binding** — *did THIS exact execution contribute the required
+  effect to THIS exact subject and outcome?*
+
+The third is the deepest idea in this system, and the easiest to fake:
+"the world looks right" is necessary — and radically insufficient — for
+"this work made it right." Build the check that only asks the second
+question, and watch what it credits.
+
+## Build the acceptance check yourself, five generations of it
+
+```python
+import sqlite3
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE inventory (sku TEXT PRIMARY KEY, on_hand INT, reorder INT);
+    CREATE TABLE outcomes (id TEXT PRIMARY KEY, subject TEXT);
+    CREATE TABLE sows (id TEXT PRIMARY KEY, outcome_id TEXT, required_kind TEXT);
+    CREATE TABLE executions (id TEXT PRIMARY KEY, sow_id TEXT, actor TEXT);
+    CREATE TABLE effects (id TEXT PRIMARY KEY, execution_id TEXT, kind TEXT, subject TEXT);
+""")
+db.execute("INSERT INTO inventory VALUES ('SKU-TEA', 8, 3)")
+db.execute("INSERT INTO inventory VALUES ('SKU-COFFEE', 9, 6)")
+db.execute("INSERT INTO outcomes VALUES ('out-tea', 'SKU-TEA')")
+db.execute("INSERT INTO outcomes VALUES ('out-coffee', 'SKU-COFFEE')")
+db.execute("INSERT INTO sows VALUES ('sow-tea', 'out-tea', 'replenishment')")
+db.execute("INSERT INTO sows VALUES ('sow-coffee', 'out-coffee', 'replenishment')")
+db.execute("INSERT INTO executions VALUES ('run-t', 'sow-tea', 'operator-lucy')")
+db.commit()
+```
+
+Note the opening state carefully: tea is at 8 against a reorder point of 3 —
+**comfortably stocked** — and `run-t`, the execution assigned to keep it
+that way, has done *nothing yet*. The freezer is full because the delivery
+driver restocked it this morning, off the books.
+
+### Generation 1: the check that sees a full freezer
+
+```python
+def world_is_right(db, sku):
+    on_hand, reorder = db.execute(
+        "SELECT on_hand, reorder FROM inventory WHERE sku = ?", (sku,)
+    ).fetchone()
+    return on_hand >= reorder
+
+
+def accept_v1(db, sku, execution_id):
+    if world_is_right(db, sku):
+        return f"ACCEPTED: {sku} is stocked, crediting {execution_id}"
+    return "refused: condition false"
+
+
+print(accept_v1(db, "SKU-TEA", "run-t"))
+count = db.execute("SELECT COUNT(*) FROM effects WHERE execution_id = 'run-t'").fetchone()[0]
+print("effects recorded by run-t:", count)
+```
+
+```text
+ACCEPTED: SKU-TEA is stocked, crediting run-t
+effects recorded by run-t: 0
+```
+
+Accepted, with a straight face, on **zero recorded effects**. The condition
+is true — for reasons that have nothing to do with the execution being
+credited. v1 asked the corroboration question and then answered the causal
+one. Every downstream consumer of this acceptance — payment, reputation,
+Chapter 12's release evidence — now believes `run-t` did work it never did.
+
+### Generation 2: "did it do anything?" — the wrong repair
+
+```python
+def accept_v2(db, sku, execution_id):
+    if not world_is_right(db, sku):
+        return "refused: condition false"
+    effects = db.execute(
+        "SELECT COUNT(*) FROM effects WHERE execution_id = ?", (execution_id,)
+    ).fetchone()[0]
+    if effects == 0:
+        return f"refused: {sku} is stocked, but {execution_id} contributed nothing"
+    return f"ACCEPTED: {sku} stocked AND {execution_id} did something"
+
+
+print(accept_v2(db, "SKU-TEA", "run-t"))
+db.execute("INSERT INTO effects VALUES ('eff-1', 'run-t', 'replenishment', 'SKU-COFFEE')")
+db.commit()
+print(accept_v2(db, "SKU-TEA", "run-t"))
+```
+
+```text
+refused: SKU-TEA is stocked, but run-t contributed nothing
+ACCEPTED: SKU-TEA stocked AND run-t did something
+```
+
+The first refusal is progress. Then `run-t` records one effect — a
+replenishment of **coffee** — and v2 accepts the **tea** outcome on the
+strength of it. "Did something" is a nonzero row count; "did *the* thing"
+is a binding. Activity is not contribution.
+
+### Generation 3: the right effect — presented by the wrong hands
+
+```python
+def accept_v3(db, sku, execution_id, required_kind):
+    if not world_is_right(db, sku):
+        return "refused: condition false"
+    match = db.execute(
+        "SELECT COUNT(*) FROM effects WHERE execution_id = ? AND kind = ? AND subject = ?",
+        (execution_id, required_kind, sku),
+    ).fetchone()[0]
+    if match == 0:
+        return f"refused: no {required_kind} effect on {sku} by {execution_id}"
+    return f"ACCEPTED: {execution_id} caused a {required_kind} on {sku}"
+
+
+print(accept_v3(db, "SKU-TEA", "run-t", "replenishment"))
+db.execute("INSERT INTO executions VALUES ('run-x', 'sow-coffee', 'operator-mo')")
+db.execute("INSERT INTO effects VALUES ('eff-2', 'run-x', 'replenishment', 'SKU-TEA')")
+db.commit()
+print(accept_v3(db, "SKU-TEA", "run-x", "replenishment"))  # crediting sow-tea with run-x's work
+```
+
+```text
+refused: no replenishment effect on SKU-TEA by run-t
+ACCEPTED: run-x caused a replenishment on SKU-TEA
+```
+
+v3 binds kind and subject correctly — and is defeated by its own argument
+list. `run-x` belongs to `sow-coffee`; it happened to restock tea; and
+because the *caller* chooses which execution id to present, tea's SOW just
+took credit for the coffee crew's work. Chapter 2 met this exact disease:
+**a caller-supplied fact is a fact the caller chose.** The execution must be
+*derived* from the SOW under judgment, never handed in beside it.
+
+### Generation 4: derive the execution — and meet the swapped subject
+
+```python
+def accept_v4(db, sow_id, sku, required_kind):
+    if not world_is_right(db, sku):
+        return "refused: condition false"
+    row = db.execute("SELECT id FROM executions WHERE sow_id = ?", (sow_id,)).fetchone()
+    if row is None:
+        return f"refused: {sow_id} has no execution of its own"
+    execution_id = row[0]
+    match = db.execute(
+        "SELECT COUNT(*) FROM effects WHERE execution_id = ? AND kind = ? AND subject = ?",
+        (execution_id, required_kind, sku),
+    ).fetchone()[0]
+    if match == 0:
+        return f"refused: {sow_id}'s own {execution_id} produced no {required_kind} on {sku}"
+    return f"ACCEPTED: {sow_id} -> {execution_id} -> {required_kind} on {sku}"
+
+
+print(accept_v4(db, "sow-tea", "SKU-TEA", "replenishment"))
+db.execute("INSERT INTO effects VALUES ('eff-3', 'run-t', 'replenishment', 'SKU-TEA')")
+db.commit()
+print(accept_v4(db, "sow-tea", "SKU-TEA", "replenishment"))
+```
+
+```text
+refused: sow-tea's own run-t produced no replenishment on SKU-TEA
+ACCEPTED: sow-tea -> run-t -> replenishment on SKU-TEA
+```
+
+The refusal fires on the borrowed-credit attack — and then, at last, `run-t`
+actually restocks tea (`eff-3`) and the chain accepts honestly. Done? One
+argument is still caller-supplied. Watch:
+
+```python
+print(accept_v4(db, "sow-tea", "SKU-COFFEE", "replenishment"))
+```
+
+```text
+ACCEPTED: sow-tea -> run-t -> replenishment on SKU-COFFEE
+```
+
+The crossed wire this chapter opened with, in its purest form: tea's SOW,
+**accepted against coffee's condition**, credited by `eff-1` — that stray
+coffee side-effect from Generation 2. Every individual binding held; the
+caller simply pointed the whole apparatus at the wrong subject.
+
+### Generation 5: the caller supplies one fact only
+
+```python
+def accept_v5(db, sow_id):
+    outcome_id, required_kind = db.execute(
+        "SELECT outcome_id, required_kind FROM sows WHERE id = ?", (sow_id,)
+    ).fetchone()
+    sku = db.execute("SELECT subject FROM outcomes WHERE id = ?", (outcome_id,)).fetchone()[0]
+    if not world_is_right(db, sku):
+        return "refused: condition false"
+    row = db.execute("SELECT id FROM executions WHERE sow_id = ?", (sow_id,)).fetchone()
+    if row is None:
+        return f"refused: {sow_id} has no execution of its own"
+    execution_id = row[0]
+    match = db.execute(
+        "SELECT COUNT(*) FROM effects WHERE execution_id = ? AND kind = ? AND subject = ?",
+        (execution_id, required_kind, sku),
+    ).fetchone()[0]
+    if match == 0:
+        return f"refused: {sow_id}'s own {execution_id} produced no {required_kind} on {sku}"
+    return f"ACCEPTED: {outcome_id}[{sku}] <- {sow_id} <- {execution_id} <- {required_kind}"
+
+
+print(accept_v5(db, "sow-tea"))
+print(accept_v5(db, "sow-coffee"))
+```
+
+```text
+ACCEPTED: out-tea[SKU-TEA] <- sow-tea <- run-t <- replenishment
+refused: sow-coffee's own run-x produced no replenishment on SKU-COFFEE
+```
+
+The caller names the SOW. *Everything else* — outcome, subject, required
+kind, execution — is read from the ledger's own bindings. And the final
+refusal is this chapter's quiet masterpiece: `sow-coffee` is refused because
+its execution, `run-x`, spent its one effect restocking **tea**. Doing
+*someone else's* work does not satisfy *your own* SOW — the sibling that
+donated its labor in Generation 3 cannot claim it back for itself either.
+Causal binding cuts in both directions.
+
+The chain v5 walks is worth seeing as a graph — each arrow is a foreign key
+the caller cannot forge, plus the one live check:
+
+```text
+Outcome  out-tea  (subject: SKU-TEA) ......... world_is_right(SKU-TEA), NOW
+   ^  sows.outcome_id
+SOW      sow-tea  (required_kind: replenishment)
+   ^  executions.sow_id
+Execution run-t
+   ^  effects.execution_id  AND  effects.kind = required_kind
+      AND  effects.subject = outcome's subject
+Effect   eff-3   (replenishment on SKU-TEA)
+```
+
+Production's `accept()` walks exactly this graph — "Subject is read from the
+outcome, not supplied" is a literal comment in `organization.py`, the
+`required_effect_kind` clause carries the no-vacuous-guard rule Chapter 2
+quoted, and `tests/test_causal_binding.py` attacks every arrow above the
+same way this section did. What the graph still does *not* prove is
+authentication: an actor with raw database access could forge every row in
+it, agreeing with itself perfectly. Chapter 2 drew that boundary; Chapter 12
+will price it.
+
 ## The exercise
 
 ```bash
@@ -111,6 +363,19 @@ Expected: all pass.
 3. `decisions_never_cross` compares two `outcome_id` strings for
    inequality. Why is that a meaningful proof of isolation, rather than an
    accident of how identifiers happen to be generated?
+4. State the three questions (authentication, corroboration, causal
+   binding) and say which one each of accept_v1 through accept_v5 actually
+   answers. Which generation is the first to answer the causal one at all?
+5. Generation 4 had every individual binding right and was still defeated.
+   What single design rule closes it, and where else in this book have you
+   seen the same rule?
+6. `sow-coffee` was refused even though its execution genuinely restocked a
+   real SKU. Explain why "causal binding cuts in both directions" is a
+   feature and not bureaucratic cruelty — what would crediting `run-x`'s
+   tea work to `sow-coffee` corrupt downstream?
+7. Every arrow in the proof graph is a foreign key. Name the one claim in
+   the graph that is NOT a stored row but a live act, and say why it cannot
+   be replaced by a stored row.
 
 ## Where to look next
 

--- a/book/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/ch11_replenishment_scales_without_losing_governance/README.md
@@ -1,5 +1,18 @@
 # Chapter 11 — Replenishment scales without losing governance
 
+Here is the failure mode that ends most "it works!" demos: the guarantee that
+held beautifully for one order quietly breaks the first time two orders run at
+once. Two restocks in flight, and an effect meant for vanilla lands on chocolate;
+or a retried order double-charges because "we already did this" was checked in
+Python a heartbeat too late. A guarantee that only holds when the shop is quiet is
+worse than no guarantee at all, because you will have learned to trust it.
+
+So this chapter does the unglamorous, essential thing: it runs *two* complete
+governed replenishment chains — every step you have built, from the self-woken
+signal all the way to acceptance — and checks that every property still holds with
+two SKUs in play. Nothing new is introduced. That is the point: scaling should
+add products, not exceptions.
+
 ## Learning objective
 
 Run TWO full governed replenishment chains to completion — Pulse-created
@@ -18,7 +31,7 @@ wake gate, Pulse) and proves they compose correctly at more than one SKU.
 ## The exercise
 
 ```bash
-python book/ch11_replenishment_scales_without_losing_governance/solution.py --root /tmp/andrea-ch11
+python book/ch11_replenishment_scales_without_losing_governance/solution.py --root /tmp/lucy-ch11
 ```
 
 Read the file first. Both SKUs' signals fire, both get their own canonical
@@ -59,7 +72,7 @@ Three facts this run proves:
 1. **`second_call_idempotent_replay: true`, for BOTH SKUs.** Calling
    `apply_restock` a second time with the SAME assignment id never moves
    inventory or cash twice — `effects`' own `UNIQUE(assignment_id, kind,
-   subject)` constraint (unchanged since before this unit) refuses the
+   subject)` constraint (the same constraint from the single-SKU case) refuses the
    second write and returns the first call's own recorded payload instead.
    This is not new behavior; this chapter proves it still holds with two
    assignments in play, not one.
@@ -75,7 +88,7 @@ Three facts this run proves:
 Confirm it yourself:
 
 ```bash
-sqlite3 /tmp/andrea-ch11/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch11/.sovereign/organization.db <<'SQL'
 SELECT assignment_id, subject, kind FROM effects ORDER BY created_at;
 SELECT id, state FROM outcomes ORDER BY id;
 SQL
@@ -118,8 +131,8 @@ exercise cannot demonstrate by itself.
 - `tests/test_store_multi_sku.py` — the full isolation matrix, including
   the real two-connection concurrency proof this chapter's own exercise
   cannot show by itself
-- `docs/v1-unit9-pulse-proactive-work.md` — the canonical-creation
-  transaction this chapter's own Pulse pass relies on, unchanged
+- `tests/test_store_multi_sku.py::...racing_two_different_skus...` — the
+  canonical-creation transaction under genuine concurrent pressure
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/ch11_replenishment_scales_without_losing_governance/README.md
@@ -37,6 +37,224 @@ None new — this chapter combines every mechanism Chapters 0-10 already
 named (outcome, SOW, assignment, effect, verification, review, acceptance,
 wake gate, Pulse) and proves they compose correctly at more than one SKU.
 
+## Build the restock yourself, then double-order under retry
+
+Production paid a specific bill here, and its own docstring names it: "An
+earlier version scanned the event log and validated cash before opening its
+transaction, so two concurrent retries both passed the scan and both
+ordered: on_hand went to 14 with two purchase entries." Reproduce that exact
+failure, to the digit, then repair it.
+
+```python
+import sqlite3
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE inventory (sku TEXT PRIMARY KEY, on_hand INT, reorder INT);
+    CREATE TABLE cash_entries (id INTEGER PRIMARY KEY, amount_cents INT NOT NULL);
+    CREATE TABLE assignments (id TEXT PRIMARY KEY);
+    CREATE TABLE effects (id INTEGER PRIMARY KEY, assignment_id TEXT, kind TEXT,
+                          subject TEXT, payload TEXT,
+                          UNIQUE(assignment_id, kind, subject));
+""")
+db.execute("INSERT INTO inventory VALUES ('SKU-TEA', 2, 3)")
+db.execute("INSERT INTO cash_entries(amount_cents) VALUES (4000)")  # opening cash
+db.execute("INSERT INTO assignments VALUES ('asg-1')")
+db.execute("INSERT INTO assignments VALUES ('asg-2')")
+db.execute("INSERT INTO assignments VALUES ('asg-3')")
+db.commit()
+
+
+def state(db):
+    on_hand = db.execute("SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'").fetchone()[0]
+    entries = db.execute("SELECT COUNT(*) FROM cash_entries WHERE amount_cents < 0").fetchone()[0]
+    cash = db.execute("SELECT SUM(amount_cents) FROM cash_entries").fetchone()[0]
+    return f"on_hand={on_hand} purchase_entries={entries} cash={cash}c"
+
+
+print(state(db))
+```
+
+```text
+on_hand=2 purchase_entries=0 cash=4000c
+```
+
+The `UNIQUE(assignment_id, kind, subject)` on `effects` is the chapter's
+protagonist. It looks like a data-hygiene constraint. It is a concurrency
+mechanism.
+
+### Break it: scan first, order later
+
+The tempting shape: check whether this restock already happened, and if
+not, do it. Two retries of the same assignment arrive close together — both
+scan **before** either writes:
+
+```python
+def restock_naive(db, sku, quantity, unit_cost, already_done_seen):
+    if already_done_seen:
+        return "skipped: already restocked"
+    db.execute("UPDATE inventory SET on_hand = on_hand + ? WHERE sku = ?", (quantity, sku))
+    db.execute("INSERT INTO cash_entries(amount_cents) VALUES (?)", (-quantity * unit_cost,))
+    db.commit()
+    return f"ordered {quantity} {sku}"
+
+
+done_a = db.execute("SELECT COUNT(*) FROM effects WHERE assignment_id = 'asg-1'").fetchone()[0] > 0
+done_b = db.execute("SELECT COUNT(*) FROM effects WHERE assignment_id = 'asg-1'").fetchone()[0] > 0
+print("retry-a scanned first, saw done:", done_a, "| retry-b scanned too, saw done:", done_b)
+print(restock_naive(db, "SKU-TEA", 6, 250, done_a))
+print(restock_naive(db, "SKU-TEA", 6, 250, done_b))
+print(state(db))
+```
+
+```text
+retry-a scanned first, saw done: False | retry-b scanned too, saw done: False
+ordered 6 SKU-TEA
+ordered 6 SKU-TEA
+on_hand=14 purchase_entries=2 cash=1000c
+```
+
+`on_hand=14 purchase_entries=2` — the production docstring's exact numbers,
+resurrected. Lucy paid twice, twelve tubs arrive for a freezer that needed
+six, and both retries behaved "correctly" against what they saw. Chapter 9's
+oversell race, mirrored: there stale reads sold stock twice; here they
+*bought* it twice.
+
+### Repair: the claim is a row, not a scan
+
+Everything that decides — the idempotency claim, the authorization, the cash
+check — moves **inside** the transaction that acts, and the claim itself
+becomes an insert under the `UNIQUE` constraint:
+
+```python
+db.execute("UPDATE inventory SET on_hand = 2 WHERE sku = 'SKU-TEA'")
+db.execute("DELETE FROM cash_entries WHERE amount_cents < 0")
+db.commit()
+
+
+def apply_restock(db, sku, quantity, unit_cost, assignment_id):
+    db.execute("BEGIN IMMEDIATE")
+    existing = db.execute(
+        "SELECT payload FROM effects WHERE assignment_id = ? AND kind = 'replenishment'"
+        " AND subject = ?",
+        (assignment_id, sku),
+    ).fetchone()
+    if existing is not None:
+        db.execute("COMMIT")
+        return f"idempotent replay: {existing[0]}"
+    known = db.execute(
+        "SELECT COUNT(*) FROM assignments WHERE id = ?", (assignment_id,)
+    ).fetchone()[0]
+    if not known:
+        db.execute("ROLLBACK")
+        return f"refused: {assignment_id} is not an authorized assignment"
+    total = quantity * unit_cost
+    cash = db.execute("SELECT SUM(amount_cents) FROM cash_entries").fetchone()[0]
+    if total > cash:
+        db.execute("ROLLBACK")
+        return f"refused: costs {total}c, only {cash}c on hand"
+    db.execute("UPDATE inventory SET on_hand = on_hand + ? WHERE sku = ?", (quantity, sku))
+    db.execute("INSERT INTO cash_entries(amount_cents) VALUES (?)", (-total,))
+    payload = f"{quantity} {sku} for {total}c"
+    db.execute(
+        "INSERT INTO effects(assignment_id, kind, subject, payload)"
+        " VALUES (?, 'replenishment', ?, ?)",
+        (assignment_id, sku, payload),
+    )
+    db.execute("COMMIT")
+    return f"ordered {payload}"
+
+
+print(apply_restock(db, "SKU-TEA", 6, 250, "asg-1"))
+print(apply_restock(db, "SKU-TEA", 6, 250, "asg-1"))
+print(state(db))
+```
+
+```text
+ordered 6 SKU-TEA for 1500c
+idempotent replay: 6 SKU-TEA for 1500c
+on_hand=8 purchase_entries=1 cash=2500c
+```
+
+The retry does not fail, and does not re-order: it returns the **canonical
+prior result** — the same payload the winner committed — which is exactly
+what a confused retry mechanism needs to hear. In the toy the replay is
+caught by the read inside `BEGIN IMMEDIATE`; under genuine two-connection
+contention the second claimant's *insert itself* collides with the `UNIQUE`
+constraint inside the transaction that does the work, and production
+converts that `IntegrityError` into the same canonical replay — the
+database refuses the duplicate, so nothing depends on timing.
+
+### The key must name the operation, not the attempt
+
+Idempotency is only as good as the key's identity. Suppose the retry
+infrastructure mints a *fresh assignment id per attempt* — or keys the claim
+on a timestamp, or a process id:
+
+```python
+print(apply_restock(db, "SKU-TEA", 6, 250, "asg-2"))  # same logical restock, fresh id per retry
+print(state(db))
+```
+
+```text
+ordered 6 SKU-TEA for 1500c
+on_hand=14 purchase_entries=2 cash=1000c
+```
+
+Fourteen again — the naive failure, walked straight back in through the
+front door, past a perfectly functioning `UNIQUE` constraint. The mechanism
+held; the *key* lied. An idempotency key must be derived from the
+operation's **stable identity** — this assignment, this kind, this subject —
+never from anything that changes per attempt (time, attempt counters,
+process ids), because a key that varies across retries is a key that never
+matches, which is no key at all.
+
+### Only once is not the same as allowed
+
+Two more refusals, because idempotency answers "*again*?" and says nothing
+about "*may you at all*?":
+
+```python
+print(apply_restock(db, "SKU-TEA", 6, 250, "asg-invented"))
+print(apply_restock(db, "SKU-TEA", 60, 250, "asg-3"))
+print(state(db))
+```
+
+```text
+refused: asg-invented is not an authorized assignment
+refused: costs 15000c, only 1000c on hand
+on_hand=14 purchase_entries=2 cash=1000c
+```
+
+A fabricated assignment is refused before any money moves — production does
+this with `_authorize_effect` plus a foreign key, so an invented assignment
+*cannot be named at all* — and a restock the till cannot cover is refused by
+a cash check that runs inside the same lock as the writes. Both checks
+live **inside** `BEGIN IMMEDIATE` with everything else, because a check
+outside the transaction is a scan, and this chapter opened with what scans
+are worth.
+
+### One shape, many tools: what each mechanism actually prevents
+
+You have now built five exactly-once-flavored mechanisms across four
+chapters. They are not interchangeable:
+
+| Mechanism | Prevents | Does NOT prevent |
+| --- | --- | --- |
+| Exclusive lock (`BEGIN IMMEDIATE`) | two writers interleaving mid-transaction | a retry re-running the whole transaction later |
+| `UNIQUE` constraint | a duplicate row ever existing | the duplicate *attempt* — it only makes it fail loudly |
+| Compare-and-set (`WHERE` + rowcount) | acting on a state that already changed | a stale actor acting under a still-matching old state |
+| Lease (expiry) | a dead holder blocking forever | a slow holder acting after expiry |
+| Fencing token | a stale holder's write becoming canonical | the stale holder from running at all |
+| Idempotency key | the same operation charging twice | an *unauthorized* operation charging once |
+
+Read the right column as carefully as the left: every row's gap is filled by
+another row. `apply_restock` composes four of them in one function — the
+lock serializes, the unique key claims, the derived key names the operation,
+and authorization gates the act — which is why the production docstring can
+promise that two concurrent retries produce one order *without depending on
+timing*.
+
 ## The exercise
 
 ```bash
@@ -132,6 +350,17 @@ exercise cannot demonstrate by itself.
    after the other in Python. What property does the concurrency test
    (`test_two_real_connections_racing_two_different_skus_create_two_
    canonical_sows`) prove that this chapter's own sequential run cannot?
+4. The wrong-key demo reached `on_hand=14` past a perfectly functioning
+   `UNIQUE` constraint. State the rule for what an idempotency key may be
+   derived from, and give two things it must never be derived from.
+5. The retry received the canonical prior payload rather than an error.
+   Which Chapter 7 behavior is this the twin of, and what would a raised
+   exception cause a retry loop to do instead?
+6. Pick two rows of the mechanism table whose right-column gaps are filled
+   by each other, and explain the pairing in one sentence each.
+7. "Only once is not the same as allowed." Which check in `apply_restock`
+   enforces each half, and why must both run inside `BEGIN IMMEDIATE`
+   rather than before it?
 
 ## Where to look next
 

--- a/book/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/ch11_replenishment_scales_without_losing_governance/README.md
@@ -13,6 +13,15 @@ signal all the way to acceptance — and checks that every property still holds 
 two SKUs in play. Nothing new is introduced. That is the point: scaling should
 add products, not exceptions.
 
+One honest caveat about *how* it checks. This chapter's own exercise runs the two
+chains **sequentially**, one after the other — enough to prove the ledger keeps
+each SKU's effects, idempotency, and acceptance separate. The sharper property —
+that two chains running *genuinely at the same time*, on two database connections,
+still produce exactly one canonical effect each — is proven by a dedicated
+two-connection concurrency test named in the verification command below, not by
+this sequential run. The referenced test is where the race actually happens; the
+prose here does not pretend the sequential exercise demonstrates simultaneity.
+
 ## Learning objective
 
 Run TWO full governed replenishment chains to completion — Pulse-created

--- a/book/ch12_the_pilot_begins_with_a_receipt/README.md
+++ b/book/ch12_the_pilot_begins_with_a_receipt/README.md
@@ -1,8 +1,22 @@
 # Chapter 12 — The pilot begins with a receipt
 
+Lucy is ready to let the organization run her shop for real — a trial period, a
+pilot. It is the moment everything has been building toward, and it is exactly the
+moment a lesser system would start lying. "Pilot started!" it would announce, and
+a week later nobody could say for sure whether it actually had, or whether it had
+quietly finished, or stalled, or half-begun twice.
+
+This final chapter builds the smallest, most careful version of that first step —
+and spends as much energy on what it *doesn't* prove as on what it does. Starting
+a pilot leaves a receipt: a durable, queryable record that it began. That receipt
+says nothing about whether the pilot has *finished*, and — crucially — the system
+does not pretend otherwise, because the machinery to check completion does not
+exist. A book about telling the truth ends by drawing the exact line between what
+has been proven and what has not.
+
 ## Learning objective
 
-Run the pilot-start mechanism this unit builds, against a disposable
+Run the pilot-start mechanism, against a disposable
 exercise identity, and read back the durable record and event it produces —
 then understand precisely why that record proves the pilot **started** and
 proves nothing at all about whether it has **finished**.
@@ -26,7 +40,7 @@ a separate, later, separately-authorized act, entirely outside this book.
 ## The exercise
 
 ```bash
-python book/ch12_the_pilot_begins_with_a_receipt/solution.py --root /tmp/andrea-ch12
+python book/ch12_the_pilot_begins_with_a_receipt/solution.py --root /tmp/lucy-ch12
 ```
 
 Read the file first, and read `EXERCISE_PILOT_ID`'s own comment before
@@ -75,13 +89,12 @@ Four facts this run proves:
    — read directly from the `pilots` table after both calls.
 4. **`no_completion_table_exists: true`.** This is the honesty check this
    chapter's own title promises: nothing in this database claims the pilot
-   is finished, because nothing CAN — that mechanism does not exist in this
-   unit.
+   is finished, because nothing CAN — that mechanism does not exist yet.
 
 Confirm it yourself:
 
 ```bash
-sqlite3 /tmp/andrea-ch12/.sovereign/organization.db <<'SQL'
+sqlite3 /tmp/lucy-ch12/.sovereign/organization.db <<'SQL'
 SELECT pilot_id, started_at, store_org_id FROM pilots;
 SELECT pilot_id FROM active_pilot;
 SELECT COUNT(*) FROM events WHERE kind = 'pilot.started';
@@ -125,18 +138,18 @@ one slice of that proof matrix, running.
   `active_pilot_id`, the full mechanism
 - `src/sovereign_agent/database.py` — migration 16, the `pilots` and
   `active_pilot` schema
-- `tests/test_pilot.py` — the full pilot-start proof matrix, including real
-  two-connection concurrency for both the same-identity and different-
-  identity cases
-- `docs/v1-unit11-store-expansion-pilot-start.md` — the full contract,
-  including an explicit statement that the real pilot-start act was **not**
-  performed by this unit
+- `tests/test_pilot.py` — the full pilot-start proof matrix: the
+  different-identity refusal and the two-connection race, which together show
+  the pilot's identity is claimed exactly once, atomically, or not at all
 
 `solution.py` imports the production package rather than copying it.
 
-You have now completed all twelve chapters. The real 30-day Store pilot has
-not started — only this chapter's own disposable exercise identity has.
-Starting the real pilot, finishing it, assembling and accepting its
-redacted proof pack, and everything after that is Unit 12's own future
-territory, the same way this book has named its own gaps honestly at every
-chapter boundary before this one.
+You have now completed all twelve chapters — and built, from an empty
+directory, an organization that remembers, refuses, fences, recovers, wakes
+itself, scales, and can begin a pilot without lying about it. That last verb is
+the one that matters. At every boundary this book named exactly what it had not
+yet done, and it ends the same way: the real, live 30-day pilot has not started
+here — only a disposable exercise identity has. Starting it for real, running it,
+and judging whether it succeeded are the next work, beyond this book. Knowing
+precisely where the proven part ends is not a limitation of the system. It is the
+system.

--- a/book/ch12_the_pilot_begins_with_a_receipt/README.md
+++ b/book/ch12_the_pilot_begins_with_a_receipt/README.md
@@ -41,6 +41,244 @@ is a separate, later, separately-authorized act, entirely outside this book.
 | **Fail-closed refusal** | A DIFFERENT pilot identity, while one is already active, is refused outright — never silently ignored, never silently allowed to proceed. |
 | **Started vs. finished** | This mechanism proves a pilot BEGAN. Nothing in this project claims, or could currently check, that a pilot has ENDED — there is no completion mechanism yet. |
 
+## Build the pilot start yourself, then hand Mo's diner Lucy's data
+
+A pilot start looks like an INSERT. It is a **contract**: the same request
+replayed must return the canonical original, a *colliding id with a
+different request behind it* must be refused, only one pilot may be active,
+and a failed start must strand nothing. Build the version that skips the
+second clause and watch what it hands out:
+
+```python
+import sqlite3
+
+db = sqlite3.connect(":memory:")
+db.executescript("""
+    CREATE TABLE pilots (pilot_id TEXT PRIMARY KEY, store_org TEXT, profile TEXT);
+    CREATE TABLE active_pilot (slot_id INTEGER PRIMARY KEY CHECK (slot_id = 1),
+                               pilot_id TEXT);
+""")
+
+
+def start_naive(db, pilot_id, store_org, profile):
+    existing = db.execute(
+        "SELECT store_org, profile FROM pilots WHERE pilot_id = ?", (pilot_id,)
+    ).fetchone()
+    if existing is not None:
+        return f"replay: pilot {pilot_id} already started"
+    db.execute("INSERT INTO pilots VALUES (?, ?, ?)", (pilot_id, store_org, profile))
+    db.commit()
+    return f"started pilot {pilot_id} for {store_org}"
+
+
+print(start_naive(db, "pilot-1", "lucys-shop", "standard"))
+print(start_naive(db, "pilot-1", "mos-diner", "premium"))  # a DIFFERENT request, same id
+row = db.execute("SELECT store_org, profile FROM pilots WHERE pilot_id = 'pilot-1'").fetchone()
+print("who pilot-1 actually belongs to:", row)
+```
+
+```text
+started pilot pilot-1 for lucys-shop
+replay: pilot pilot-1 already started
+who pilot-1 actually belongs to: ('lucys-shop', 'standard')
+```
+
+Mo's diner asked to start *its* premium pilot, was told "already started,"
+and will now read Lucy's standard pilot as if it were its own. The naive
+version treated **id collision** as **identity match** — but an id is a
+name, and a replay is only a replay when *the whole request* matches.
+Same-id-different-request is not a retry; it is a different customer
+holding the same ticket number.
+
+### Replay on exact identity; refuse everything else
+
+```python
+def start_pilot(db, pilot_id, store_org, profile):
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        db.execute("INSERT INTO pilots VALUES (?, ?, ?)", (pilot_id, store_org, profile))
+    except sqlite3.IntegrityError:
+        db.execute("ROLLBACK")
+        existing_store, existing_profile = db.execute(
+            "SELECT store_org, profile FROM pilots WHERE pilot_id = ?", (pilot_id,)
+        ).fetchone()
+        if (existing_store, existing_profile) != (store_org, profile):
+            return (
+                f"refused: {pilot_id} already exists with DIFFERENT identity"
+                f" ({existing_store}/{existing_profile})"
+            )
+        return f"replay: {pilot_id} is canonical, identity matches exactly"
+    try:
+        db.execute("INSERT INTO active_pilot VALUES (1, ?)", (pilot_id,))
+    except sqlite3.IntegrityError:
+        db.execute("ROLLBACK")
+        active = db.execute("SELECT pilot_id FROM active_pilot").fetchone()[0]
+        return f"refused: {active} is already the active pilot (one at a time)"
+    db.execute("COMMIT")
+    return f"started {pilot_id}, now active"
+
+
+db.execute("DELETE FROM pilots")
+db.commit()
+print(start_pilot(db, "pilot-1", "lucys-shop", "standard"))
+print(start_pilot(db, "pilot-1", "lucys-shop", "standard"))  # the exact same request again
+print(start_pilot(db, "pilot-1", "mos-diner", "premium"))  # the collision
+print(start_pilot(db, "pilot-2", "mos-diner", "premium"))  # a second active pilot
+```
+
+```text
+started pilot-1, now active
+replay: pilot-1 is canonical, identity matches exactly
+refused: pilot-1 already exists with DIFFERENT identity (lucys-shop/standard)
+refused: pilot-1 is already the active pilot (one at a time)
+```
+
+Four calls, four different verdicts, each earned by a different clause. The
+collision path reads the **canonical durable row first** and compares every
+identity-defining field before trusting anything as a replay — production's
+`start_pilot` does exactly this, with its refusal explaining that a reused
+id with different fields "is an incompatible start under a reused id, not a
+replay." The singleton `active_pilot` slot (`CHECK (slot_id = 1)`) is
+Chapter 8's structural-assumption trick used *on purpose*: here, one-at-a-
+time is the requirement, so the schema enforces it.
+
+And the fourth call hides the fourth clause. `pilot-2`'s start had already
+written its `pilots` row when the slot refused it — where did that row go?
+
+```python
+count = db.execute("SELECT COUNT(*) FROM pilots WHERE pilot_id = 'pilot-2'").fetchone()[0]
+print("orphaned pilot-2 rows after the refusal:", count)
+```
+
+```text
+orphaned pilot-2 rows after the refusal: 0
+```
+
+The `ROLLBACK` in the slot-refusal path took the pilot row with it — one
+transaction, so a refused start strands nothing. A pilot that exists but
+was never allowed to activate would be exactly the half-woken orphan
+Chapter 7's creation transaction refused to leave behind.
+
+## Build the proof pack yourself, then forge one
+
+The pilot ran; the release ships; and what travels with it is a **proof
+pack**: artifacts plus a manifest binding each to a digest and an honest
+status. Build a small one, honestly — including the honest `NOT_RUN` for
+what this environment genuinely cannot run:
+
+```python
+import hashlib
+import json
+import pathlib
+import tempfile
+
+pack = pathlib.Path(tempfile.mkdtemp())
+(pack / "gates.txt").write_text("pytest: 413 passed\nruff: clean\n")
+(pack / "live-provider.txt").write_text("NOT RUN: no credentials in this environment\n")
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+manifest = {
+    "artifacts": [
+        {"path": "gates.txt", "sha256": digest(pack / "gates.txt"), "status": "PASS"},
+        {
+            "path": "live-provider.txt",
+            "sha256": digest(pack / "live-provider.txt"),
+            "status": "NOT_RUN",
+            "note": "no credentials in this environment",
+        },
+    ]
+}
+(pack / "manifest.json").write_text(json.dumps(manifest, indent=2))
+
+
+def verify_pack(pack):
+    problems = []
+    manifest = json.loads((pack / "manifest.json").read_text())
+    for artifact in manifest["artifacts"]:
+        path = pack / artifact["path"]
+        if not path.is_file():
+            problems.append(f"missing artifact: {artifact['path']}")
+            continue
+        if digest(path) != artifact["sha256"]:
+            problems.append(f"digest mismatch: {artifact['path']}")
+        note = artifact.get("note", "").lower()
+        if artifact["status"].startswith("NOT_RUN") and ("pass" in note or "success" in note):
+            problems.append(f"dishonest NOT_RUN: {artifact['path']} claims success in prose")
+    return problems or ["pack internally consistent"]
+
+
+print(verify_pack(pack))
+```
+
+```text
+['pack internally consistent']
+```
+
+### The lies it catches
+
+```python
+(pack / "gates.txt").write_text("pytest: 999999 passed, definitely\n")  # a quiet edit
+print(verify_pack(pack))
+
+(pack / "gates.txt").write_text("pytest: 413 passed\nruff: clean\n")  # restore the bytes
+manifest["artifacts"][1]["note"] = "not run but it definitely would pass"
+(pack / "manifest.json").write_text(json.dumps(manifest))
+print(verify_pack(pack))
+```
+
+```text
+['digest mismatch: gates.txt']
+['dishonest NOT_RUN: live-provider.txt claims success in prose']
+```
+
+The first lie is tampering: bytes changed after the manifest bound them.
+The second is subtler and important enough that the production verifier
+names it explicitly: **"NOT_RUN means PASS" prose** — an honest status
+wearing dishonest commentary. `NOT_RUN` with a reason is one of the most
+truthful things a release can say; `NOT_RUN` with "it would definitely
+pass" is a claim of success with the evidence requirement quietly deleted.
+The production `verify_proof_pack.py` checks the same families and more:
+allowed status vocabularies, path containment, secret-shaped content, and
+this exact lie-scan.
+
+### The lie it structurally cannot catch
+
+Now forge properly. Change the artifact **and** its manifest digest,
+together, and keep every status-note pair honest-looking:
+
+```python
+(pack / "gates.txt").write_text("pytest: 999999 passed, definitely\n")
+manifest["artifacts"][0]["sha256"] = digest(pack / "gates.txt")  # forge BOTH sides together
+manifest["artifacts"][1]["note"] = "no credentials in this environment"
+(pack / "manifest.json").write_text(json.dumps(manifest))
+print(verify_pack(pack))
+```
+
+```text
+['pack internally consistent']
+```
+
+A fully fabricated pack, and the verifier — *correctly executing every one
+of its checks* — calls it consistent. This is not a bug to fix with a
+fourth check inside the pack: any check that lives in the pack can be
+forged along with the pack, agreeing with itself perfectly. It is the
+boundary this whole book has been drawing since Chapter 2's Exercise 6:
+**internal consistency is not authenticity.** The digests prove the
+manifest and the bytes agree; they cannot prove *who* made them agree, or
+that the gates ever ran. What closes that gap lives *outside* the pack, or
+it does not close: a signing key the packer never holds, or a third party
+independently re-running the gates and comparing. The production verifier
+says this about itself, in its own docstring: it exits 0 when the manifest
+is "well-formed and internally truthful," and it "does NOT claim the
+manifest is COMPLETE" — a named refusal to overclaim, and the most
+load-bearing sentence in it. A release process that understands exactly which door is
+open is safer than one that believes every door is shut. That is where
+this book ends, because it is where honest engineering begins.
+
 ## The exercise
 
 ```bash
@@ -142,6 +380,19 @@ one slice of that proof matrix, running.
    concurrency — properties this chapter's own single-process exercise does
    not exercise. Why does this chapter still count as proof that the
    mechanism WORKS, even though it does not run those tests itself?
+5. The naive `start_naive` answered Mo's diner with "replay: pilot pilot-1
+   already started." Name the exact comparison the honest `start_pilot`
+   performs before it is allowed to say the word "replay," and say why
+   comparing the id alone can never be enough.
+6. After `start_pilot(db, "pilot-2", ...)` was refused by the singleton
+   `active_pilot` slot, the orphan check found zero `pilot-2` rows — yet
+   the function HAD already inserted one. Trace where that row went, and
+   name the chapter-7 failure mode that would exist if it hadn't.
+7. The forge-both-sides mutation rewrote `gates.txt` AND its manifest
+   digest together, and `verify_pack` reported the pack internally
+   consistent. Why can no additional check ADDED INSIDE THE PACK ever
+   close this hole, and what are the two things named in this chapter
+   that live outside the pack and could?
 
 ## Where to look next
 

--- a/book/ch12_the_pilot_begins_with_a_receipt/README.md
+++ b/book/ch12_the_pilot_begins_with_a_receipt/README.md
@@ -21,12 +21,16 @@ exercise identity, and read back the durable record and event it produces —
 then understand precisely why that record proves the pilot **started** and
 proves nothing at all about whether it has **finished**.
 
-**This chapter never touches the real named pilot organization.** The
-identity this exercise uses, `book-ch12-exercise-pilot`, is structurally
-distinct from any real pilot identity: it is a fixture value, reserved for
-this exercise, that appears nowhere in this project's own real-pilot
-tooling — because no real-pilot tooling exists yet. The real pilot start is
-a separate, later, separately-authorized act, entirely outside this book.
+**A precise word on safety, because this is a book about not overstating things.**
+The identity this exercise uses, `book-ch12-exercise-pilot`, carries a reserved
+`book-ch12-exercise-` prefix, so it **cannot be confused with the real named
+pilot** — the ids are distinguishable by inspection. What the exercise does *not*
+do is constrain where it writes: `solution.py` opens whatever `--root` you give
+it. The documented command below uses a throwaway `/tmp` path, and you should keep
+it that way — point it at a real organization's database and it would write this
+exercise pilot there. The safety here is "the id is unmistakable and the default
+path is disposable," not "it is impossible by construction." The real pilot start
+is a separate, later, separately-authorized act, entirely outside this book.
 
 ## Vocabulary this chapter adds
 
@@ -43,9 +47,9 @@ a separate, later, separately-authorized act, entirely outside this book.
 python book/ch12_the_pilot_begins_with_a_receipt/solution.py --root /tmp/lucy-ch12
 ```
 
-Read the file first, and read `EXERCISE_PILOT_ID`'s own comment before
-running anything: the whole point of this chapter is that its own exercise
-can never reach a real pilot, by construction, not merely by convention.
+Read the file first, and read `EXERCISE_PILOT_ID`'s own comment before running
+anything: the exercise id is unmistakable and the documented path is disposable —
+keep the `/tmp` root so this writes only to a throwaway database.
 
 ## Expected observations
 
@@ -87,9 +91,16 @@ Four facts this run proves:
    pilot's own identity.
 3. **`pilots_row_count: 1`.** Not a count this exercise computed in Python
    — read directly from the `pilots` table after both calls.
-4. **`no_completion_table_exists: true`.** This is the honesty check this
-   chapter's own title promises: nothing in this database claims the pilot
-   is finished, because nothing CAN — that mechanism does not exist yet.
+4. **`no_completion_table_exists: true`.** Read this claim exactly as narrow as
+   it is: *no table whose name matches the completion pattern exists* in this
+   database. That is a weak check on purpose, and worth being honest about — a
+   completion mechanism hiding in a status column, an event kind, or a
+   differently-named table would slip right past a table-name search. What this
+   chapter can say truthfully is that it starts a pilot and makes no claim about
+   finishing one, because it implements no completion step. Proving the *absence*
+   of a capability rigorously would need an explicit supported-capabilities
+   contract, not a name match — a good example of not letting a detector claim
+   more than it measures.
 
 Confirm it yourself:
 

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -1,0 +1,376 @@
+{
+  "_comment": "Curriculum coverage manifest: concept -> chapter anchor -> production symbols -> production tests -> exercise. Read by scripts/verify_book_depth.py, which mechanically checks every reference. depth 'full' chapters are also held to the structural depth gates; 'pending' chapters are exempt until their rebuild batch lands (era-aware grading, not a free pass).",
+  "chapters": {
+    "ch00_first_shift": {
+      "depth": "pending",
+      "concepts": []
+    },
+    "ch01_organization_remembers": {
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "append-only-enforced-in-the-database",
+          "anchor": "Build it yourself: memory that cannot half-happen",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/database.py",
+              "name": "events_no_update"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_persistence.py",
+              "name": "append_only"
+            }
+          ],
+          "exercise": "book/ch01_organization_remembers/solution.py"
+        },
+        {
+          "concept": "transactional-migrations-forward-only",
+          "anchor": "Growing the schema without losing the shop",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/database.py",
+              "name": "MIGRATIONS"
+            },
+            {
+              "file": "src/sovereign_agent/database.py",
+              "name": "def migrate"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_persistence.py",
+              "name": "migration"
+            }
+          ],
+          "exercise": "book/ch01_organization_remembers/solution.py"
+        },
+        {
+          "concept": "pure-projection-verification-vs-explicit-reconcile",
+          "anchor": "Projections: files the ledger can regenerate",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/governance.py",
+              "name": "def render_outcome"
+            },
+            {
+              "file": "scripts/verify_projections.py",
+              "name": "def check"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_verifier_scripts.py",
+              "name": "projection"
+            }
+          ],
+          "exercise": "book/ch01_organization_remembers/solution.py"
+        },
+        {
+          "concept": "atomic-write-old-or-new-never-torn",
+          "anchor": "Writing a file without tearing it",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/files.py",
+              "name": "def atomic_write"
+            }
+          ],
+          "tests": [],
+          "exercise": "book/ch01_organization_remembers/solution.py"
+        }
+      ],
+      "limits_anchor": "What this does not guarantee",
+      "break_evidence": [
+        "left behind:",
+        "still broken:",
+        "OK\nOK"
+      ]
+    },
+    "ch02_work_needs_governance": {
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "acceptance-as-composed-proof-obligation",
+          "anchor": "Build it yourself: acceptance in seven layers",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "name": "def accept"
+            },
+            {
+              "file": "src/sovereign_agent/policy.py",
+              "name": "def forbid_self_approval"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_acceptance_falsification.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch02_work_needs_governance/solution.py"
+        },
+        {
+          "concept": "checks-reexecuted-at-acceptance-time",
+          "anchor": "Layer 2: re-read the world, right now",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/checks.py",
+              "name": "def run_check"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_acceptance_falsification.py",
+              "name": "stale"
+            }
+          ],
+          "exercise": "book/ch02_work_needs_governance/solution.py"
+        },
+        {
+          "concept": "digest-covers-exactly-what-the-check-observes",
+          "anchor": "Layer 7: the world must not have moved",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/checks.py",
+              "name": "state_digest"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_acceptance_falsification.py",
+              "name": "digest"
+            }
+          ],
+          "exercise": "book/ch02_work_needs_governance/solution.py"
+        },
+        {
+          "concept": "refusal-recovers-through-new-work",
+          "anchor": "Exercise 7: being refused is not the end",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "name": "CHANGES_REQUESTED"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_recovery.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch02_work_needs_governance/solution.py"
+        }
+      ],
+      "limits_anchor": "can rewrite the organization's memory",
+      "break_evidence": [
+        "receipts on file: 0",
+        "evidence reassigned: 1",
+        "holds for OTHER reasons"
+      ]
+    },
+    "ch03_actor_is_not_a_model": {
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "authority-from-role-policy-not-model",
+          "anchor": "Authority is granted by role, not by the model",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/policy.py",
+              "name": "ROLE_AUTHORITY"
+            },
+            {
+              "file": "src/sovereign_agent/policy.py",
+              "name": "def require_authority"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_actors_and_mailbox.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch03_actor_is_not_a_model/solution.py"
+        },
+        {
+          "concept": "rebind-dual-store-seam",
+          "anchor": "The rebind is two writes, and the seam between them",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "name": "def rebind_actor"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_actors_and_mailbox.py",
+              "name": "rebind"
+            }
+          ],
+          "exercise": "book/ch03_actor_is_not_a_model/solution.py"
+        },
+        {
+          "concept": "provider-neutral-envelope-host-validates-proposal",
+          "anchor": "The envelope: what the provider is actually told",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/execution.py",
+              "name": "def build_assignment_envelope"
+            },
+            {
+              "file": "src/sovereign_agent/execution.py",
+              "name": "def write_failed_receipt"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_providers.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch03_actor_is_not_a_model/solution.py"
+        },
+        {
+          "concept": "capability-probe-from-live-help",
+          "anchor": "An adapter is a hostile-boundary parser",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/providers/claude.py",
+              "name": "def probe"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_providers.py",
+              "name": "exact_probe"
+            }
+          ],
+          "exercise": "book/ch03_actor_is_not_a_model/solution.py"
+        }
+      ],
+      "limits_anchor": "know about and detect",
+      "break_evidence": [
+        "ledger's last rebind: scripted",
+        "silence is not success",
+        "cannot prove capability"
+      ]
+    },
+    "ch04_work_stays_inside_its_boundary": {
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "safe-join-refuses-by-shape",
+          "anchor": "The join that refuses by shape",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/workspace.py",
+              "name": "def safe_join"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_workspace_lifecycle.py",
+              "name": "traversal"
+            }
+          ],
+          "exercise": "book/ch04_work_stays_inside_its_boundary/solution.py"
+        },
+        {
+          "concept": "boundary-detected-not-prevented",
+          "anchor": "The comparison after the run \u2014 and what it cannot see",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/workspace.py",
+              "name": "def snapshot_boundary"
+            },
+            {
+              "file": "src/sovereign_agent/workspace.py",
+              "name": "def diff_boundary"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_workspace_lifecycle.py",
+              "name": "outside"
+            }
+          ],
+          "exercise": "book/ch04_work_stays_inside_its_boundary/solution.py"
+        },
+        {
+          "concept": "receipt-canonical-json-sha256-sidecar",
+          "anchor": "The receipt, sealed",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/execution.py",
+              "name": "def write_receipt"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_workspace_lifecycle.py",
+              "name": "receipt"
+            }
+          ],
+          "exercise": "book/ch04_work_stays_inside_its_boundary/solution.py"
+        },
+        {
+          "concept": "argv-shell-false-injection-inert",
+          "anchor": "Why `shell=False` is not a style preference",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/execution.py",
+              "name": "def run_spec"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_providers.py",
+              "name": "argv"
+            }
+          ],
+          "exercise": "book/ch04_work_stays_inside_its_boundary/solution.py"
+        }
+      ],
+      "limits_anchor": "INVISIBLE to the snapshot",
+      "break_evidence": [
+        "inside according to the string check: True",
+        "deliverable(s) already exist",
+        "INJECTED"
+      ]
+    },
+    "ch05_authority_needs_a_fence": {
+      "depth": "pending",
+      "concepts": []
+    },
+    "ch06_the_organization_recovers": {
+      "depth": "pending",
+      "concepts": []
+    },
+    "ch07_the_organization_wakes_itself": {
+      "depth": "pending",
+      "concepts": []
+    },
+    "ch08_the_store_becomes_a_catalog": {
+      "depth": "pending",
+      "concepts": []
+    },
+    "ch09_each_product_has_its_own_threshold": {
+      "depth": "pending",
+      "concepts": []
+    },
+    "ch10_one_signal_wakes_one_need": {
+      "depth": "pending",
+      "concepts": []
+    },
+    "ch11_replenishment_scales_without_losing_governance": {
+      "depth": "pending",
+      "concepts": []
+    },
+    "ch12_the_pilot_begins_with_a_receipt": {
+      "depth": "pending",
+      "concepts": []
+    }
+  }
+}

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -424,8 +424,83 @@
       ]
     },
     "ch06_the_organization_recovers": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "presence-never-blessed-as-success",
+          "anchor": "The recoverer that wants to be kind",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/supervisor.py",
+              "name": "WORKER_LOST"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_supervisor.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch06_the_organization_recovers/solution.py"
+        },
+        {
+          "concept": "fence-cleared-with-terminal-state-one-transaction",
+          "anchor": "The recoverer that refuses to guess",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/supervisor.py",
+              "name": "def recover_abandoned_assignments"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_supervisor.py",
+              "name": "idempotent"
+            }
+          ],
+          "exercise": "book/ch06_the_organization_recovers/solution.py"
+        },
+        {
+          "concept": "two-supervisors-cas-one-winner",
+          "anchor": "Two supervisors, one recovery",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/supervisor.py",
+              "name": "def tick"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_supervisor.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch06_the_organization_recovers/solution.py"
+        },
+        {
+          "concept": "reclaim-after-durable-terminal-keeps-evidence",
+          "anchor": "Reclaim comes last, and keeps the evidence",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/workspace.py",
+              "name": "def reclaim_workspace"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_supervisor.py",
+              "name": "workspace_reclaim"
+            }
+          ],
+          "exercise": "book/ch06_the_organization_recovers/solution.py"
+        }
+      ],
+      "limits_anchor": "never creates work",
+      "break_evidence": [
+        "worker left a completed report -- marked COMPLETED",
+        "nothing to recover",
+        "kept: ['report.json']"
+      ]
     },
     "ch07_the_organization_wakes_itself": {
       "depth": "pending",

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -852,8 +852,99 @@
       ]
     },
     "ch12_the_pilot_begins_with_a_receipt": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "pilot-start-replays-only-on-exact-identity",
+          "anchor": "Replay on exact identity; refuse everything else",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/pilot.py",
+              "name": "start_pilot"
+            },
+            {
+              "file": "src/reference_organizations/store/pilot.py",
+              "name": "PilotRecord"
+            }
+          ],
+          "tests": [
+            "tests/test_pilot.py::test_replaying_the_same_start_request_does_not_create_a_second_pilot",
+            "tests/test_pilot.py::test_a_colliding_pilot_id_with_different_identity_is_refused_not_replayed"
+          ],
+          "exercise": "book/ch12_the_pilot_begins_with_a_receipt/solution.py",
+          "source_text": [
+            {
+              "file": "src/reference_organizations/store/pilot.py",
+              "text": "incompatible start under a reused id, not a replay"
+            }
+          ]
+        },
+        {
+          "concept": "singleton-slot-refusal-strands-nothing",
+          "anchor": "a refused start strands nothing",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/pilot.py",
+              "name": "start_pilot"
+            },
+            {
+              "file": "src/reference_organizations/store/pilot.py",
+              "name": "active_pilot_id"
+            }
+          ],
+          "tests": [
+            "tests/test_pilot.py::test_a_second_different_pilot_is_refused_while_one_is_active",
+            "tests/test_pilot.py::test_a_refused_start_leaves_no_orphaned_pilot_row"
+          ],
+          "exercise": "book/ch12_the_pilot_begins_with_a_receipt/solution.py"
+        },
+        {
+          "concept": "proof-pack-catches-tamper-and-dishonest-not-run",
+          "anchor": "The lies it catches",
+          "symbols": [
+            {
+              "file": "scripts/verify_proof_pack.py",
+              "name": "check_digests"
+            },
+            {
+              "file": "scripts/verify_proof_pack.py",
+              "name": "check_not_run_means_pass_lie"
+            }
+          ],
+          "tests": [
+            "tests/test_proof_pack.py::test_digest_mismatch_still_rejected",
+            "tests/test_proof_pack.py::test_andrea_not_run_with_success_prose_is_rejected"
+          ],
+          "exercise": "book/ch12_the_pilot_begins_with_a_receipt/solution.py"
+        },
+        {
+          "concept": "internal-consistency-is-not-authenticity",
+          "anchor": "The lie it structurally cannot catch",
+          "symbols": [
+            {
+              "file": "scripts/verify_proof_pack.py",
+              "name": "verify"
+            }
+          ],
+          "tests": [
+            "tests/test_proof_pack.py::test_the_real_committed_manifest_passes",
+            "tests/test_proof_pack.py::test_verify_function_import_matches_cli_behavior"
+          ],
+          "exercise": "book/ch12_the_pilot_begins_with_a_receipt/solution.py",
+          "source_text": [
+            {
+              "file": "scripts/verify_proof_pack.py",
+              "text": "does NOT claim the manifest is COMPLETE"
+            }
+          ]
+        }
+      ],
+      "limits_anchor": "internal consistency is not authenticity",
+      "break_evidence": [
+        "who pilot-1 actually belongs to: ('lucys-shop', 'standard')",
+        "refused: pilot-1 already exists with DIFFERENT identity (lucys-shop/standard)",
+        "['dishonest NOT_RUN: live-provider.txt claims success in prose']"
+      ]
     }
   }
 }

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Curriculum coverage manifest: concept -> chapter anchor -> production symbols -> production tests -> exercise. Read by scripts/verify_book_depth.py, which mechanically checks every reference. depth 'full' chapters are also held to the structural depth gates; 'pending' chapters are exempt until their rebuild batch lands (era-aware grading, not a free pass).",
+  "_comment": "Curriculum coverage manifest v2: concept -> chapter anchor -> exact AST symbols -> precise test node ids -> exercise, plus source_text for prose-level evidence and known_gap for machine-readable honesty. Read by scripts/verify_book_depth.py, hardened per the Principal's B3/B4 findings: canonical chapter set enforced, contained paths only, AST-exact names, no fragments.",
   "chapters": {
     "ch00_first_shift": {
       "depth": "pending",
@@ -14,16 +14,20 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/database.py",
-              "name": "events_no_update"
+              "name": "MIGRATIONS"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_persistence.py",
-              "name": "append_only"
-            }
+            "tests/test_persistence.py::test_events_reject_update_and_delete",
+            "tests/test_persistence.py::test_insert_or_replace_cannot_bypass_the_append_only_guard"
           ],
-          "exercise": "book/ch01_organization_remembers/solution.py"
+          "exercise": "book/ch01_organization_remembers/solution.py",
+          "source_text": [
+            {
+              "file": "src/sovereign_agent/database.py",
+              "text": "events are append-only"
+            }
+          ]
         },
         {
           "concept": "transactional-migrations-forward-only",
@@ -31,18 +35,16 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/database.py",
-              "name": "MIGRATIONS"
+              "name": "migrate"
             },
             {
               "file": "src/sovereign_agent/database.py",
-              "name": "def migrate"
+              "name": "MIGRATIONS"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_persistence.py",
-              "name": "migration"
-            }
+            "tests/test_persistence.py::test_a_failed_migration_rolls_back_schema_and_stamp",
+            "tests/test_persistence.py::test_upgrade_from_prior_schema_preserves_data"
           ],
           "exercise": "book/ch01_organization_remembers/solution.py"
         },
@@ -52,18 +54,16 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/governance.py",
-              "name": "def render_outcome"
+              "name": "render_outcome"
             },
             {
               "file": "scripts/verify_projections.py",
-              "name": "def check"
+              "name": "check"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_verifier_scripts.py",
-              "name": "projection"
-            }
+            "tests/test_verifier_scripts.py::test_projection_verification_is_pure",
+            "tests/test_verifier_scripts.py::test_verifier_compares_every_projected_file"
           ],
           "exercise": "book/ch01_organization_remembers/solution.py"
         },
@@ -73,11 +73,12 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/files.py",
-              "name": "def atomic_write"
+              "name": "atomic_write"
             }
           ],
           "tests": [],
-          "exercise": "book/ch01_organization_remembers/solution.py"
+          "exercise": "book/ch01_organization_remembers/solution.py",
+          "known_gap": "files.py atomic_write has no direct behavioral test in the suite; flagged in the Batch 1 filing as scoped follow-up implementation work, not smuggled into book scope."
         }
       ],
       "limits_anchor": "What this does not guarantee",
@@ -96,18 +97,16 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/organization.py",
-              "name": "def accept"
+              "name": "accept"
             },
             {
               "file": "src/sovereign_agent/policy.py",
-              "name": "def forbid_self_approval"
+              "name": "forbid_self_approval"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_acceptance_falsification.py",
-              "name": "def test_"
-            }
+            "tests/test_acceptance_falsification.py::test_refuses_when_inventory_is_below_reorder_point",
+            "tests/test_acceptance_falsification.py::test_refuses_evidence_bound_to_another_execution"
           ],
           "exercise": "book/ch02_work_needs_governance/solution.py"
         },
@@ -117,14 +116,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/checks.py",
-              "name": "def run_check"
+              "name": "run_check"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_acceptance_falsification.py",
-              "name": "stale"
-            }
+            "tests/test_acceptance_falsification.py::test_refuses_stale_evidence_even_when_checks_still_pass"
           ],
           "exercise": "book/ch02_work_needs_governance/solution.py"
         },
@@ -134,14 +130,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/checks.py",
-              "name": "state_digest"
+              "name": "_digest_observation"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_acceptance_falsification.py",
-              "name": "digest"
-            }
+            "tests/test_acceptance_falsification.py::test_refuses_stale_evidence_even_when_checks_still_pass"
           ],
           "exercise": "book/ch02_work_needs_governance/solution.py"
         },
@@ -151,14 +144,16 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/organization.py",
-              "name": "CHANGES_REQUESTED"
+              "name": "review"
+            },
+            {
+              "file": "src/sovereign_agent/policy.py",
+              "name": "advance_sow"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_recovery.py",
-              "name": "def test_"
-            }
+            "tests/test_recovery.py::test_red_repair_reassign_verify_review_accept",
+            "tests/test_recovery.py::test_acceptance_is_refused_while_changes_are_outstanding"
           ],
           "exercise": "book/ch02_work_needs_governance/solution.py"
         }
@@ -183,14 +178,12 @@
             },
             {
               "file": "src/sovereign_agent/policy.py",
-              "name": "def require_authority"
+              "name": "require_authority"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_actors_and_mailbox.py",
-              "name": "def test_"
-            }
+            "tests/test_actors_and_mailbox.py::test_an_actor_cannot_expand_its_own_authority",
+            "tests/test_actors_and_mailbox.py::test_role_separation_covers_operator_reviewer_and_principal"
           ],
           "exercise": "book/ch03_actor_is_not_a_model/solution.py"
         },
@@ -200,14 +193,12 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/organization.py",
-              "name": "def rebind_actor"
+              "name": "rebind_actor"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_actors_and_mailbox.py",
-              "name": "rebind"
-            }
+            "tests/test_actors_and_mailbox.py::test_rebinding_the_provider_preserves_identity_and_authority",
+            "tests/test_actors_and_mailbox.py::test_rebinding_requires_ruling_authority"
           ],
           "exercise": "book/ch03_actor_is_not_a_model/solution.py"
         },
@@ -217,18 +208,15 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/execution.py",
-              "name": "def build_assignment_envelope"
+              "name": "build_assignment_envelope"
             },
             {
               "file": "src/sovereign_agent/execution.py",
-              "name": "def write_failed_receipt"
+              "name": "write_failed_receipt"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_providers.py",
-              "name": "def test_"
-            }
+            "tests/test_providers.py::test_proven_flags_are_the_only_ones_on_argv"
           ],
           "exercise": "book/ch03_actor_is_not_a_model/solution.py"
         },
@@ -238,14 +226,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/providers/claude.py",
-              "name": "def probe"
+              "name": "probe"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_providers.py",
-              "name": "exact_probe"
-            }
+            "tests/test_providers.py::test_cursor_workspace_flag_requires_exact_probe"
           ],
           "exercise": "book/ch03_actor_is_not_a_model/solution.py"
         }
@@ -266,14 +251,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/workspace.py",
-              "name": "def safe_join"
+              "name": "safe_join"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_workspace_lifecycle.py",
-              "name": "traversal"
-            }
+            "tests/test_workspace_lifecycle.py::test_traversal_deliverable_is_refused"
           ],
           "exercise": "book/ch04_work_stays_inside_its_boundary/solution.py"
         },
@@ -283,18 +265,16 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/workspace.py",
-              "name": "def snapshot_boundary"
+              "name": "snapshot_boundary"
             },
             {
               "file": "src/sovereign_agent/workspace.py",
-              "name": "def diff_boundary"
+              "name": "diff_boundary"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_workspace_lifecycle.py",
-              "name": "outside"
-            }
+            "tests/test_workspace_lifecycle.py::test_detects_write_outside_workspace",
+            "tests/test_workspace_lifecycle.py::test_a_new_file_outside_the_workspace_is_also_detected"
           ],
           "exercise": "book/ch04_work_stays_inside_its_boundary/solution.py"
         },
@@ -304,14 +284,15 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/execution.py",
-              "name": "def write_receipt"
+              "name": "write_receipt"
+            },
+            {
+              "file": "src/sovereign_agent/execution.py",
+              "name": "canonical_receipt_json"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_workspace_lifecycle.py",
-              "name": "receipt"
-            }
+            "tests/test_persistence.py::test_receipts_are_deliberately_not_append_only"
           ],
           "exercise": "book/ch04_work_stays_inside_its_boundary/solution.py"
         },
@@ -321,14 +302,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/execution.py",
-              "name": "def run_spec"
+              "name": "run_spec"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_providers.py",
-              "name": "argv"
-            }
+            "tests/test_providers.py::test_proven_flags_are_the_only_ones_on_argv"
           ],
           "exercise": "book/ch04_work_stays_inside_its_boundary/solution.py"
         }
@@ -349,14 +327,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/relay.py",
-              "name": "def claim"
+              "name": "claim"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_actors_and_mailbox.py",
-              "name": "def test_"
-            }
+            "tests/test_actors_and_mailbox.py::test_claim_lease_is_exclusive"
           ],
           "exercise": "book/ch05_authority_needs_a_fence/solution.py"
         },
@@ -366,14 +341,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/relay.py",
-              "name": "def complete"
+              "name": "complete"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_fencing.py",
-              "name": "def test_"
-            }
+            "tests/test_actors_and_mailbox.py::test_only_the_claimant_can_complete"
           ],
           "exercise": "book/ch05_authority_needs_a_fence/solution.py"
         },
@@ -387,14 +359,11 @@
             },
             {
               "file": "src/sovereign_agent/fencing.py",
-              "name": "def new_process_identity"
+              "name": "new_process_identity"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_fencing.py",
-              "name": "acquire_actor_lease"
-            }
+            "tests/test_actors_and_mailbox.py::test_expired_lease_is_reclaimable"
           ],
           "exercise": "book/ch05_authority_needs_a_fence/solution.py"
         },
@@ -404,14 +373,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/relay.py",
-              "name": "def dead_letter"
+              "name": "dead_letter"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_actors_and_mailbox.py",
-              "name": "def test_"
-            }
+            "tests/test_actors_and_mailbox.py::test_expired_lease_is_reclaimable"
           ],
           "exercise": "book/ch05_authority_needs_a_fence/solution.py"
         }
@@ -436,10 +402,7 @@
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_supervisor.py",
-              "name": "def test_"
-            }
+            "tests/test_supervisor.py::test_never_guesses_success_recovery_receipt_is_always_failed"
           ],
           "exercise": "book/ch06_the_organization_recovers/solution.py"
         },
@@ -449,14 +412,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/supervisor.py",
-              "name": "def recover_abandoned_assignments"
+              "name": "recover_abandoned_assignments"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_supervisor.py",
-              "name": "idempotent"
-            }
+            "tests/test_supervisor.py::test_recovery_is_idempotent_a_second_tick_recovers_nothing_more"
           ],
           "exercise": "book/ch06_the_organization_recovers/solution.py"
         },
@@ -466,14 +426,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/supervisor.py",
-              "name": "def tick"
+              "name": "tick"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_supervisor.py",
-              "name": "def test_"
-            }
+            "tests/test_supervisor.py::test_supervisor_recovers_a_real_sigkilled_assignment"
           ],
           "exercise": "book/ch06_the_organization_recovers/solution.py"
         },
@@ -483,14 +440,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/workspace.py",
-              "name": "def reclaim_workspace"
+              "name": "reclaim_workspace"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_supervisor.py",
-              "name": "workspace_reclaim"
-            }
+            "tests/test_supervisor.py::test_workspace_reclaim_applies_only_after_the_terminal_write_is_durable"
           ],
           "exercise": "book/ch06_the_organization_recovers/solution.py"
         }
@@ -512,13 +466,14 @@
             {
               "file": "src/sovereign_agent/pulse.py",
               "name": "WakeGate"
+            },
+            {
+              "file": "src/sovereign_agent/pulse.py",
+              "name": "WakeDecision"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_pulse.py",
-              "name": "def test_"
-            }
+            "tests/test_pulse.py::test_pulse_once_works"
           ],
           "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
         },
@@ -528,18 +483,15 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/pulse.py",
-              "name": "def run_pulse_once"
+              "name": "run_pulse_once"
             },
             {
               "file": "src/sovereign_agent/organization.py",
-              "name": "def create_pulse_work"
+              "name": "create_pulse_work"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_pulse.py",
-              "name": "def test_"
-            }
+            "tests/test_pulse.py::test_two_real_processes_evaluating_the_same_signal_create_one_canonical_sow"
           ],
           "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
         },
@@ -549,14 +501,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/pulse.py",
-              "name": "def run_pulse_once"
+              "name": "run_pulse_once"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_pulse.py",
-              "name": "def test_"
-            }
+            "tests/test_pulse.py::test_canonical_created_work_survives_restart_and_resumes_without_duplication"
           ],
           "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
         },
@@ -570,10 +519,7 @@
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_pulse.py",
-              "name": "def test_"
-            }
+            "tests/test_pulse.py::test_seeded_store_with_no_sale_creates_no_work"
           ],
           "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
         }
@@ -598,14 +544,11 @@
           "symbols": [
             {
               "file": "src/reference_organizations/store/__init__.py",
-              "name": "def record_sale"
+              "name": "record_sale"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_persistence.py",
-              "name": "cash_reconciled"
-            }
+            "tests/test_persistence.py::test_successful_sale_and_replenishment_keep_cash_reconciled"
           ],
           "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
         },
@@ -615,16 +558,19 @@
           "symbols": [
             {
               "file": "src/reference_organizations/store/__init__.py",
-              "name": "happens INSIDE the immediate transaction"
+              "name": "record_sale"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_persistence.py",
-              "name": "never_goes_negative"
-            }
+            "tests/test_persistence.py::test_inventory_never_goes_negative"
           ],
-          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
+          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py",
+          "source_text": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "text": "happens INSIDE the immediate transaction"
+            }
+          ]
         },
         {
           "concept": "reservation-aware-availability",
@@ -632,14 +578,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/checks.py",
-              "name": "reserv"
+              "name": "inventory_at_or_above_reorder_point"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_store_multi_sku.py",
-              "name": "def test_"
-            }
+            "tests/test_acceptance_falsification.py::test_reserved_stock_is_not_available_stock"
           ],
           "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
         },
@@ -649,16 +592,20 @@
           "symbols": [
             {
               "file": "src/reference_organizations/store/__init__.py",
-              "name": "dedupe_key"
+              "name": "record_sale"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_persistence.py",
-              "name": "signal_is_recorded"
-            }
+            "tests/test_persistence.py::test_signal_is_recorded_with_the_sale",
+            "tests/test_store_multi_sku.py::test_signals_for_different_skus_never_share_a_dedupe_key"
           ],
-          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
+          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py",
+          "source_text": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "text": "INSERT OR REPLACE"
+            }
+          ]
         }
       ],
       "limits_anchor": "one connection",
@@ -677,16 +624,19 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/organization.py",
-              "name": "CONTRIBUTED"
+              "name": "accept"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_causal_binding.py",
-              "name": "def test_"
-            }
+            "tests/test_causal_binding.py::test_condition_true_but_no_effects_exist_at_all_is_refused"
           ],
-          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py"
+          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py",
+          "source_text": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "text": "The bound execution must have CONTRIBUTED"
+            }
+          ]
         },
         {
           "concept": "world-right-is-not-work-done",
@@ -694,14 +644,11 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/organization.py",
-              "name": "required_effect_kind"
+              "name": "accept"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_causal_binding.py",
-              "name": "def test_"
-            }
+            "tests/test_causal_binding.py::test_condition_true_but_another_execution_contributed_is_refused"
           ],
           "exercise": "book/ch10_one_signal_wakes_one_need/solution.py"
         },
@@ -715,10 +662,7 @@
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_causal_binding.py",
-              "name": "def test_"
-            }
+            "tests/test_causal_binding.py::test_condition_false_but_contribution_true_is_refused"
           ],
           "exercise": "book/ch10_one_signal_wakes_one_need/solution.py"
         },
@@ -728,16 +672,19 @@
           "symbols": [
             {
               "file": "src/sovereign_agent/organization.py",
-              "name": "Subject is read from the outcome"
+              "name": "accept"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_acceptance_falsification.py",
-              "name": "def test_"
-            }
+            "tests/test_store_multi_sku.py::test_wake_gate_maps_each_signal_to_its_own_skus_outcome_only"
           ],
-          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py"
+          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py",
+          "source_text": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "text": "Subject is read from the outcome, not supplied"
+            }
+          ]
         }
       ],
       "limits_anchor": "forge every row in",
@@ -757,16 +704,19 @@
           "symbols": [
             {
               "file": "src/reference_organizations/store/__init__.py",
-              "name": "on_hand went to 14"
+              "name": "apply_restock"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_persistence.py",
-              "name": "idempotency_is_scoped"
-            }
+            "tests/test_persistence.py::test_idempotency_is_scoped_to_assignment_and_sku"
           ],
-          "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py"
+          "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py",
+          "source_text": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "text": "on_hand went to 14"
+            }
+          ]
         },
         {
           "concept": "unique-claim-inside-transaction-canonical-replay",
@@ -774,14 +724,11 @@
           "symbols": [
             {
               "file": "src/reference_organizations/store/__init__.py",
-              "name": "def apply_restock"
+              "name": "apply_restock"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_store_multi_sku.py",
-              "name": "def test_"
-            }
+            "tests/test_store_multi_sku.py::test_replaying_pulse_for_multiple_skus_creates_no_duplicate_work"
           ],
           "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py"
         },
@@ -791,16 +738,19 @@
           "symbols": [
             {
               "file": "src/reference_organizations/store/__init__.py",
-              "name": "UNIQUE(assignment_id, kind, subject)"
+              "name": "apply_restock"
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_persistence.py",
-              "name": "idempotency_is_scoped"
-            }
+            "tests/test_persistence.py::test_the_effect_key_cannot_collide_across_assignment_and_subject"
           ],
-          "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py"
+          "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py",
+          "source_text": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "text": "UNIQUE(assignment_id, kind, subject)"
+            }
+          ]
         },
         {
           "concept": "authorization-separate-from-idempotency",
@@ -812,10 +762,7 @@
             }
           ],
           "tests": [
-            {
-              "file": "tests/test_store_multi_sku.py",
-              "name": "def test_"
-            }
+            "tests/test_persistence.py::test_a_forged_effect_cannot_be_inserted_from_outside"
           ],
           "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py"
         }

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -2,8 +2,59 @@
   "_comment": "Curriculum coverage manifest v2: concept -> chapter anchor -> exact AST symbols -> precise test node ids -> exercise, plus source_text for prose-level evidence and known_gap for machine-readable honesty. Read by scripts/verify_book_depth.py, hardened per the Principal's B3/B4 findings: canonical chapter set enforced, contained paths only, AST-exact names, no fragments.",
   "chapters": {
     "ch00_first_shift": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "tour",
+      "concepts": [
+        {
+          "concept": "accepted-is-a-claim-the-code-proved",
+          "anchor": "The whole point: break it, and watch the lie get caught",
+          "symbols": [
+            {
+              "file": "scripts/verify_store_outcome.py",
+              "name": "verify"
+            }
+          ],
+          "tests": [
+            "tests/test_acceptance_falsification.py::test_refuses_when_inventory_is_below_reorder_point",
+            "tests/test_acceptance_falsification.py::test_refuses_stale_evidence_even_when_checks_still_pass"
+          ],
+          "exercise": "book/ch00_first_shift/solution.py"
+        },
+        {
+          "concept": "doer-is-never-the-approver",
+          "anchor": "What the organization just did",
+          "symbols": [
+            {
+              "file": "scripts/verify_store_outcome.py",
+              "name": "verify"
+            }
+          ],
+          "tests": [
+            "tests/test_acceptance_falsification.py::test_operator_cannot_accept_its_own_work",
+            "tests/test_acceptance_falsification.py::test_performer_is_derived_from_the_ledger_not_supplied"
+          ],
+          "exercise": "book/ch00_first_shift/solution.py"
+        },
+        {
+          "concept": "no-heartbeat-yet-honest-absence",
+          "anchor": "Why nothing happened until you typed",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/cli.py",
+              "name": "_demo"
+            }
+          ],
+          "tests": [
+            "tests/test_demo_cli.py::test_demo_store_simulated"
+          ],
+          "exercise": "book/ch00_first_shift/solution.py"
+        }
+      ],
+      "limits_anchor": "The organization has no heartbeat yet",
+      "break_evidence": [
+        "UPDATE inventory SET on_hand = 0 WHERE on_hand > 0;",
+        "available=0 (on_hand=0 - reserved=0) vs reorder_point=3",
+        "3 problem(s): this outcome is NOT truthfully accepted."
+      ]
     },
     "ch01_organization_remembers": {
       "depth": "full",

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -749,8 +749,83 @@
       ]
     },
     "ch11_replenishment_scales_without_losing_governance": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "scan-before-transaction-double-orders",
+          "anchor": "Break it: scan first, order later",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "on_hand went to 14"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_persistence.py",
+              "name": "idempotency_is_scoped"
+            }
+          ],
+          "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py"
+        },
+        {
+          "concept": "unique-claim-inside-transaction-canonical-replay",
+          "anchor": "Repair: the claim is a row, not a scan",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "def apply_restock"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_store_multi_sku.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py"
+        },
+        {
+          "concept": "idempotency-key-from-stable-operation-identity",
+          "anchor": "The key must name the operation, not the attempt",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "UNIQUE(assignment_id, kind, subject)"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_persistence.py",
+              "name": "idempotency_is_scoped"
+            }
+          ],
+          "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py"
+        },
+        {
+          "concept": "authorization-separate-from-idempotency",
+          "anchor": "Only once is not the same as allowed",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "_authorize_effect"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_store_multi_sku.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch11_replenishment_scales_without_losing_governance/solution.py"
+        }
+      ],
+      "limits_anchor": "sequential run cannot",
+      "break_evidence": [
+        "on_hand=14 purchase_entries=2",
+        "idempotent replay: 6 SKU-TEA for 1500c",
+        "refused: asg-invented is not an authorized assignment"
+      ]
     },
     "ch12_the_pilot_begins_with_a_receipt": {
       "depth": "pending",

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -590,8 +590,83 @@
       "concepts": []
     },
     "ch09_each_product_has_its_own_threshold": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "sale-five-writes-one-transaction",
+          "anchor": "One exact sale, traced through every write",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "def record_sale"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_persistence.py",
+              "name": "cash_reconciled"
+            }
+          ],
+          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
+        },
+        {
+          "concept": "read-inside-transaction-prevents-oversell",
+          "anchor": "Break it: the sale that checks first and writes later",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "happens INSIDE the immediate transaction"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_persistence.py",
+              "name": "never_goes_negative"
+            }
+          ],
+          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
+        },
+        {
+          "concept": "reservation-aware-availability",
+          "anchor": "Available is not on-hand",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/checks.py",
+              "name": "reserv"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_store_multi_sku.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
+        },
+        {
+          "concept": "dedupe-key-per-occurrence-append-only-signals",
+          "anchor": "loud\ninstead of silent",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "dedupe_key"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_persistence.py",
+              "name": "signal_is_recorded"
+            }
+          ],
+          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
+        }
+      ],
+      "limits_anchor": "one connection",
+      "break_evidence": [
+        "on hand now: -2",
+        "refused: only 1 available (6 on hand, 5 reserved)",
+        "on_hand=5 cash_rows=4 events=4"
+      ]
     },
     "ch10_one_signal_wakes_one_need": {
       "depth": "pending",

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -503,8 +503,87 @@
       ]
     },
     "ch07_the_organization_wakes_itself": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "gate-decides-what-tick-decides-how",
+          "anchor": "The gate decides WHAT \u2014 and nothing else",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/pulse.py",
+              "name": "WakeGate"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_pulse.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
+        },
+        {
+          "concept": "unique-claim-one-canonical-work-per-signal",
+          "anchor": "The tick that claims the decision, atomically",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/pulse.py",
+              "name": "def run_pulse_once"
+            },
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "name": "def create_pulse_work"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_pulse.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
+        },
+        {
+          "concept": "creation-rolls-back-whole-at-any-fault",
+          "anchor": "The fault that leaves nothing behind",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/pulse.py",
+              "name": "def run_pulse_once"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_pulse.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
+        },
+        {
+          "concept": "revalidate-signal-at-transaction-time",
+          "anchor": "The world moved; the signal did not",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/pulse.py",
+              "name": "_still_qualifies"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_pulse.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
+        }
+      ],
+      "limits_anchor": "It does **not**",
+      "break_evidence": [
+        "SOWs on the ledger: 2",
+        "already decided: canonical work is sow-sig-1",
+        "signal no longer qualifies"
+      ]
     },
     "ch08_the_store_becomes_a_catalog": {
       "depth": "pending",

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -669,8 +669,84 @@
       ]
     },
     "ch10_one_signal_wakes_one_need": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "authentication-corroboration-causal-binding-distinct",
+          "anchor": "Three different questions that all sound like",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "name": "CONTRIBUTED"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_causal_binding.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py"
+        },
+        {
+          "concept": "world-right-is-not-work-done",
+          "anchor": "Generation 1: the check that sees a full freezer",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "name": "required_effect_kind"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_causal_binding.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py"
+        },
+        {
+          "concept": "execution-derived-from-sow-never-supplied",
+          "anchor": "Generation 3: the right effect",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "name": "completed_assignment_for_sow"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_causal_binding.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py"
+        },
+        {
+          "concept": "subject-read-from-outcome-not-supplied",
+          "anchor": "Generation 5: the caller supplies one fact only",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/organization.py",
+              "name": "Subject is read from the outcome"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_acceptance_falsification.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py"
+        }
+      ],
+      "limits_anchor": "forge every row in",
+      "break_evidence": [
+        "effects recorded by run-t: 0",
+        "run-t did something",
+        "ACCEPTED: run-x caused a replenishment on SKU-TEA",
+        "replenishment on SKU-COFFEE"
+      ]
     },
     "ch11_replenishment_scales_without_losing_governance": {
       "depth": "pending",

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -341,8 +341,87 @@
       ]
     },
     "ch05_authority_needs_a_fence": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "cas-claim-one-statement-decides",
+          "anchor": "The claim that decides and writes in one statement",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/relay.py",
+              "name": "def claim"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_actors_and_mailbox.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch05_authority_needs_a_fence/solution.py"
+        },
+        {
+          "concept": "same-statement-token-check-never-rederived",
+          "anchor": "Completing under the token, not the name",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/relay.py",
+              "name": "def complete"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_fencing.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch05_authority_needs_a_fence/solution.py"
+        },
+        {
+          "concept": "same-owner-idempotent-vs-expired-fresh-token",
+          "anchor": "Leases: ownership that expires, and the token that guards the handover",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/relay.py",
+              "name": "_mint_claim_token"
+            },
+            {
+              "file": "src/sovereign_agent/fencing.py",
+              "name": "def new_process_identity"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_fencing.py",
+              "name": "acquire_actor_lease"
+            }
+          ],
+          "exercise": "book/ch05_authority_needs_a_fence/solution.py"
+        },
+        {
+          "concept": "retry-budget-dead-letter-terminal",
+          "anchor": "Retries are budgeted, and the budget ends somewhere honest",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/relay.py",
+              "name": "def dead_letter"
+            }
+          ],
+          "tests": [
+            {
+              "file": "tests/test_actors_and_mailbox.py",
+              "name": "def test_"
+            }
+          ],
+          "exercise": "book/ch05_authority_needs_a_fence/solution.py"
+        }
+      ],
+      "limits_anchor": "Two honest limits of this toy",
+      "break_evidence": [
+        "owner on disk: worker-b",
+        "refused, unexpired lease held by worker-b",
+        "refused, stale or wrong token"
+      ]
     },
     "ch06_the_organization_recovers": {
       "depth": "pending",

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -532,8 +532,85 @@
       ]
     },
     "ch08_the_store_becomes_a_catalog": {
-      "depth": "pending",
-      "concepts": []
+      "depth": "full",
+      "concepts": [
+        {
+          "concept": "identity-name-quantity-are-separate-concerns",
+          "anchor": "The migration, on live data, in one transaction",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "CatalogEntry"
+            }
+          ],
+          "tests": [
+            "tests/test_store_multi_sku.py::test_a_sale_of_one_sku_does_not_change_another_skus_inventory"
+          ],
+          "exercise": "book/ch08_the_store_becomes_a_catalog/solution.py"
+        },
+        {
+          "concept": "seed-is-validated-transactional-act",
+          "anchor": "Seeding a catalog is a validated act, not a loop of inserts",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "seed_catalog"
+            }
+          ],
+          "tests": [
+            "tests/test_store_multi_sku.py::test_signals_for_different_skus_never_share_a_dedupe_key"
+          ],
+          "exercise": "book/ch08_the_store_becomes_a_catalog/solution.py",
+          "source_text": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "text": "a catalog needs at least two distinct SKUs"
+            },
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "text": "duplicate SKUs in catalog"
+            }
+          ]
+        },
+        {
+          "concept": "populated-migration-rolls-back-whole",
+          "anchor": "The fault, again, because populated data raises the stakes",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/database.py",
+              "name": "migrate"
+            }
+          ],
+          "tests": [
+            "tests/test_persistence.py::test_migration_13_upgrade_from_a_populated_unit7_database_preserves_every_record"
+          ],
+          "exercise": "book/ch08_the_store_becomes_a_catalog/solution.py"
+        },
+        {
+          "concept": "additive-seed-contract-never-reverted",
+          "anchor": "The payoff of identity: the name is free to change",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "seed"
+            },
+            {
+              "file": "src/reference_organizations/store/__init__.py",
+              "name": "seed_catalog"
+            }
+          ],
+          "tests": [
+            "tests/test_store_multi_sku.py::test_reopening_the_database_preserves_both_skus_canonical_work"
+          ],
+          "exercise": "book/ch08_the_store_becomes_a_catalog/solution.py"
+        }
+      ],
+      "limits_anchor": "one deliberate shared resource",
+      "break_evidence": [
+        "refused: duplicate SKUs in catalog: ['SKU-TEA', 'SKU-TEA']",
+        "refused: negative opening stock is unrecorded debt, not inventory",
+        "the shop row, untouched: (1, 'Assam tea', 4, 3)"
+      ]
     },
     "ch09_each_product_has_its_own_threshold": {
       "depth": "full",

--- a/scripts/verify_book_depth.py
+++ b/scripts/verify_book_depth.py
@@ -3,29 +3,44 @@
 
 Companion to verify_curriculum.py (structure/links/honesty) and
 verify_book_snippets.py (fence execution). This one checks COVERAGE and
-STRUCTURE against book/coverage_manifest.json:
+STRUCTURE against book/coverage_manifest.json.
 
-- every manifest reference is real: anchor text appears in the chapter README,
-  symbol text appears in the named production file, test-name fragment appears
-  in the named test file, the exercise file exists;
-- every chapter marked depth "full" also passes the structural depth gates:
-  at least one inline python fence, at least one expected-output text fence
-  directly after a python fence, an honest-limits anchor, an active-recall
-  section, and the declared break-experiment evidence present verbatim;
-- no reader-facing README leaks internal coordination artifacts (issue/PR
-  numbers, message ids, org/repo coordination names).
+Hardened after the Principal's B3/B4 findings (msg_aa4e52b8), which
+demonstrated four false-green paths in the first version by direct mutation:
+an empty manifest passed with a zero denominator; substring symbol matching
+accepted empty names (which match every file); reference paths accepted
+absolute paths escaping the repository; and generic test fragments like
+"def test_" counted as precise evidence. Every one of those is now a hard
+failure, and tests/test_book_verifiers.py holds a regression test per class.
 
-Deliberately NOT here: fence formatting (ruff, via make lint) and fence
-execution (verify_book_snippets.py). Three instruments, three scopes.
+The contract:
 
-A chapter marked "pending" is exempt from the depth gates but NOT from the
-leak scan — era-aware grading, not a free pass.
+- the manifest's chapter set must equal the canonical 13 chapter slugs
+  exactly -- no missing, no extra, never empty. The claimant does not choose
+  the denominator;
+- every reference path must resolve inside its required repository root
+  (symbols/source under src/ or scripts/, tests under tests/, exercises
+  under the chapter's own book/ directory) -- absolute paths and `..`
+  traversal are rejected before resolution is even attempted;
+- a `symbols` entry names an exact AST node -- a function, class, or
+  module-level assignment target -- in the referenced Python file;
+- a `tests` entry is a precise node id `tests/<file>.py::<test_function>`,
+  and the named test function must exist as an AST node in that file;
+- prose-level evidence (docstring sentences, SQL trigger names, comments)
+  goes in `source_text`, exact-substring checked with a minimum length so a
+  fragment cannot accidentally match;
+- a full-depth concept needs at least one symbol AND (at least one test OR
+  an explicit `known_gap` string). A known gap is machine-readable honesty:
+  it is counted and reported in the summary, so a chapter carrying one can
+  never be mistaken for fully test-backed.
 
-Exits 0 when sound, 1 otherwise.
+Chapters marked "pending" are exempt from the depth gates but NOT from the
+leak scan. Exits 0 when sound, 1 otherwise, printing every problem found.
 """
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 import sys
@@ -35,6 +50,27 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BOOK = REPO_ROOT / "book"
 MANIFEST = BOOK / "coverage_manifest.json"
+
+CANONICAL_CHAPTERS = frozenset(
+    {
+        "ch00_first_shift",
+        "ch01_organization_remembers",
+        "ch02_work_needs_governance",
+        "ch03_actor_is_not_a_model",
+        "ch04_work_stays_inside_its_boundary",
+        "ch05_authority_needs_a_fence",
+        "ch06_the_organization_recovers",
+        "ch07_the_organization_wakes_itself",
+        "ch08_the_store_becomes_a_catalog",
+        "ch09_each_product_has_its_own_threshold",
+        "ch10_one_signal_wakes_one_need",
+        "ch11_replenishment_scales_without_losing_governance",
+        "ch12_the_pilot_begins_with_a_receipt",
+    }
+)
+
+ALLOWED_DEPTHS = frozenset({"full", "pending"})
+MIN_SOURCE_TEXT_LENGTH = 12
 
 # Internal coordination artifacts that must never reach a reader. Domain words
 # the PRODUCT itself uses (SOW, ruling, sparring-as-role) are NOT leaks.
@@ -48,38 +84,158 @@ LEAK_PATTERNS: tuple[tuple[str, str], ...] = (
 )
 
 
+def contained_path(raw: str, required_root: Path) -> Path | None:
+    """Resolve `raw` against REPO_ROOT and require it strictly inside
+    `required_root`.
+
+    Absolute paths and `..` segments are rejected on the STRING, before any
+    filesystem resolution, so acceptance never depends on where the host
+    filesystem happens to put things. Resolution (which also follows
+    symlinks) then enforces real containment.
+    """
+    if not raw or raw.startswith("/") or ".." in Path(raw).parts:
+        return None
+    candidate = (REPO_ROOT / raw).resolve()
+    root = required_root.resolve()
+    if candidate == root or root not in candidate.parents:
+        return None
+    return candidate
+
+
+def source_path(raw: str) -> Path | None:
+    """A path allowed to hold production symbols/source text."""
+    return contained_path(raw, REPO_ROOT / "src") or contained_path(raw, REPO_ROOT / "scripts")
+
+
+def ast_defined_names(source: str) -> set[str]:
+    """Function/class names (at any nesting) plus module-level assignment
+    targets -- the exact nodes a `symbols` entry may name."""
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def check_symbol(chapter: str, concept_name: str, entry: dict[str, Any]) -> list[str]:
+    file_raw = str(entry.get("file", ""))
+    name = str(entry.get("name", ""))
+    if not name:
+        return [f"{chapter}: empty symbol name ({concept_name})"]
+    path = source_path(file_raw)
+    if path is None or not path.is_file():
+        return [
+            f"{chapter}: symbol file {file_raw!r} is not a file under src/ or scripts/ "
+            f"({concept_name})"
+        ]
+    if path.suffix != ".py":
+        return [f"{chapter}: symbol file {file_raw!r} is not a Python file ({concept_name})"]
+    if name not in ast_defined_names(path.read_text(encoding="utf-8")):
+        return [
+            f"{chapter}: {name!r} is not a function/class/module-level assignment "
+            f"in {file_raw} ({concept_name})"
+        ]
+    return []
+
+
+def check_source_text(chapter: str, concept_name: str, entry: dict[str, Any]) -> list[str]:
+    file_raw = str(entry.get("file", ""))
+    text = str(entry.get("text", ""))
+    if len(text) < MIN_SOURCE_TEXT_LENGTH:
+        return [
+            f"{chapter}: source_text {text!r} shorter than {MIN_SOURCE_TEXT_LENGTH} chars "
+            f"({concept_name})"
+        ]
+    path = source_path(file_raw)
+    if path is None or not path.is_file():
+        return [
+            f"{chapter}: source_text file {file_raw!r} is not a file under src/ or scripts/ "
+            f"({concept_name})"
+        ]
+    if text not in path.read_text(encoding="utf-8"):
+        return [f"{chapter}: source_text {text!r} not found in {file_raw} ({concept_name})"]
+    return []
+
+
+def check_test_node(chapter: str, concept_name: str, node_id: str) -> list[str]:
+    if "::" not in node_id:
+        return [f"{chapter}: test reference {node_id!r} is not file::function ({concept_name})"]
+    file_raw, _, function = node_id.partition("::")
+    if not function.startswith("test_") or function == "test_":
+        return [
+            f"{chapter}: test function {function!r} is not a precise test name ({concept_name})"
+        ]
+    path = contained_path(file_raw, REPO_ROOT / "tests")
+    if path is None or not path.is_file():
+        return [f"{chapter}: test file {file_raw!r} is not a file under tests/ ({concept_name})"]
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    functions = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    if function not in functions:
+        return [f"{chapter}: no test function {function!r} in {file_raw} ({concept_name})"]
+    return []
+
+
+def check_concept(chapter: str, concept: dict[str, Any], readme_text: str) -> tuple[list[str], int]:
+    """Validate one concept's references. Returns (problems, known_gap_count)."""
+    problems: list[str] = []
+    name = str(concept.get("concept", "")) or "<unnamed>"
+    if name == "<unnamed>":
+        problems.append(f"{chapter}: concept with no name")
+    anchor = str(concept.get("anchor", ""))
+    if not anchor:
+        problems.append(f"{chapter}: concept {name} has no anchor")
+    elif anchor not in readme_text:
+        problems.append(f"{chapter}: anchor {anchor!r} not found in README ({name})")
+
+    symbols = concept.get("symbols", [])
+    if not symbols:
+        problems.append(f"{chapter}: concept {name} declares no symbols")
+    for entry in symbols:
+        problems.extend(check_symbol(chapter, name, entry))
+
+    for entry in concept.get("source_text", []):
+        problems.extend(check_source_text(chapter, name, entry))
+
+    tests = concept.get("tests", [])
+    known_gap = str(concept.get("known_gap", ""))
+    gap_count = 1 if known_gap else 0
+    if not tests and not known_gap:
+        problems.append(
+            f"{chapter}: concept {name} has neither precise tests nor an explicit known_gap"
+        )
+    for node_id in tests:
+        problems.extend(check_test_node(chapter, name, str(node_id)))
+
+    exercise = str(concept.get("exercise", ""))
+    if not exercise:
+        problems.append(f"{chapter}: concept {name} has no exercise")
+    else:
+        path = contained_path(exercise, BOOK / chapter)
+        if path is None or not path.is_file():
+            problems.append(
+                f"{chapter}: exercise {exercise!r} is not a file under book/{chapter}/ ({name})"
+            )
+    return problems, gap_count
+
+
 def fences(text: str) -> list[tuple[str, str]]:
     """Return (language, body) for every fenced block, in order."""
     return [
         (match.group(1) or "", match.group(2))
         for match in re.finditer(r"```(\w*)\n(.*?)```", text, re.S)
     ]
-
-
-def check_reference(chapter: str, concept: dict[str, Any], readme_text: str) -> list[str]:
-    problems: list[str] = []
-    name = str(concept.get("concept", "<unnamed>"))
-    anchor = str(concept.get("anchor", ""))
-    if anchor and anchor not in readme_text:
-        problems.append(f"{chapter}: anchor {anchor!r} not found in README ({name})")
-    for symbol in concept.get("symbols", []):
-        file = REPO_ROOT / str(symbol["file"])
-        if not file.is_file():
-            problems.append(f"{chapter}: symbol file {symbol['file']} missing ({name})")
-        elif str(symbol["name"]) not in file.read_text(encoding="utf-8"):
-            problems.append(f"{chapter}: {symbol['name']!r} not found in {symbol['file']} ({name})")
-    for test in concept.get("tests", []):
-        file = REPO_ROOT / str(test["file"])
-        if not file.is_file():
-            problems.append(f"{chapter}: test file {test['file']} missing ({name})")
-        elif str(test["name"]) not in file.read_text(encoding="utf-8"):
-            problems.append(
-                f"{chapter}: no test matching {test['name']!r} in {test['file']} ({name})"
-            )
-    exercise = concept.get("exercise")
-    if exercise and not (REPO_ROOT / str(exercise)).is_file():
-        problems.append(f"{chapter}: exercise {exercise} missing ({name})")
-    return problems
 
 
 def check_depth_gates(chapter: str, entry: dict[str, Any], readme_text: str) -> list[str]:
@@ -100,7 +256,10 @@ def check_depth_gates(chapter: str, entry: dict[str, Any], readme_text: str) -> 
         problems.append(f"{chapter}: limits anchor {limits!r} not found in README")
     if "Explain it back" not in readme_text:
         problems.append(f"{chapter}: no active-recall section ('Explain it back')")
-    for evidence in entry.get("break_evidence", []):
+    evidence_list = entry.get("break_evidence", [])
+    if not evidence_list:
+        problems.append(f"{chapter}: depth 'full' but no break_evidence declared")
+    for evidence in evidence_list:
         if str(evidence) not in readme_text:
             problems.append(f"{chapter}: break-experiment evidence {str(evidence)!r} not present")
     return problems
@@ -120,9 +279,28 @@ def main() -> int:
         print("book/coverage_manifest.json is missing")
         return 1
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    chapters = manifest.get("chapters")
+    if not isinstance(chapters, dict) or not chapters:
+        print(
+            "book depth NOT sound: manifest declares no chapters (an empty denominator is refused)"
+        )
+        return 1
+
     problems: list[str] = []
+    declared = set(chapters)
+    for slug in sorted(CANONICAL_CHAPTERS - declared):
+        problems.append(f"manifest missing canonical chapter {slug}")
+    for slug in sorted(declared - CANONICAL_CHAPTERS):
+        problems.append(f"manifest declares unknown chapter {slug}")
+
     full = 0
-    for chapter, entry in manifest["chapters"].items():
+    gaps = 0
+    for chapter in sorted(declared & CANONICAL_CHAPTERS):
+        entry = chapters[chapter]
+        depth = str(entry.get("depth", ""))
+        if depth not in ALLOWED_DEPTHS:
+            problems.append(f"{chapter}: depth {depth!r} is not one of {sorted(ALLOWED_DEPTHS)}")
+            continue
         readme = BOOK / chapter / "README.md"
         if not readme.is_file():
             problems.append(f"{chapter}: README.md missing")
@@ -130,20 +308,25 @@ def main() -> int:
         text = readme.read_text(encoding="utf-8")
         problems.extend(check_leaks(chapter, text))
         for concept in entry.get("concepts", []):
-            problems.extend(check_reference(chapter, concept, text))
-        if entry.get("depth") == "full":
+            concept_problems, gap_count = check_concept(chapter, concept, text)
+            problems.extend(concept_problems)
+            gaps += gap_count
+        if depth == "full":
             full += 1
             problems.extend(check_depth_gates(chapter, entry, text))
+
     if problems:
         print(f"book depth NOT sound: {len(problems)} problem(s)")
         for problem in problems:
             print(f"  - {problem}")
         return 1
-    pending = len(manifest["chapters"]) - full
+
+    pending = len(CANONICAL_CHAPTERS) - full
     print(
-        f"book depth sound: {full} chapter(s) at full depth verified, "
-        f"{pending} pending (exempt from depth gates, leak-scanned)"
+        f"book depth sound: {full} chapter(s) at full depth verified, {pending} pending "
+        f"(exempt from depth gates, leak-scanned), {gaps} explicit known gap(s) on record"
     )
+    print(f"BOOK-DEPTH-COMPLETE chapters={len(CANONICAL_CHAPTERS)}")
     return 0
 
 

--- a/scripts/verify_book_depth.py
+++ b/scripts/verify_book_depth.py
@@ -34,8 +34,11 @@ The contract:
   it is counted and reported in the summary, so a chapter carrying one can
   never be mistaken for fully test-backed.
 
-Chapters marked "pending" are exempt from the depth gates but NOT from the
-leak scan. Exits 0 when sound, 1 otherwise, printing every problem found.
+Chapters marked "tour" are finished guided-tour chapters (bash transcripts,
+no inline python): exempt from the python-construction gate ONLY — concepts,
+limits, recall, break evidence, and the leak scan all still apply. Chapters
+marked "pending" are unfinished: exempt from the depth gates but NOT from
+the leak scan. Exits 0 when sound, 1 otherwise, printing every problem found.
 """
 
 from __future__ import annotations
@@ -69,7 +72,7 @@ CANONICAL_CHAPTERS = frozenset(
     }
 )
 
-ALLOWED_DEPTHS = frozenset({"full", "pending"})
+ALLOWED_DEPTHS = frozenset({"full", "tour", "pending"})
 MIN_SOURCE_TEXT_LENGTH = 12
 
 # Internal coordination artifacts that must never reach a reader. Domain words
@@ -238,27 +241,39 @@ def fences(text: str) -> list[tuple[str, str]]:
     ]
 
 
-def check_depth_gates(chapter: str, entry: dict[str, Any], readme_text: str) -> list[str]:
+def check_depth_gates(
+    chapter: str, entry: dict[str, Any], readme_text: str, depth: str
+) -> list[str]:
+    """Gates for finished chapters.
+
+    Depth 'full' requires inline python construction with paired expected-output
+    fences. Depth 'tour' is a finished guided-tour chapter (bash transcripts, no
+    inline python) — it is exempt from the python-construction gate ONLY; every
+    other finished-chapter gate (concepts, limits, recall, break evidence, leak
+    scan) applies identically. 'tour' is not a loophole for an unfinished
+    chapter: it must still declare and pass real coverage.
+    """
     problems: list[str] = []
-    blocks = fences(readme_text)
-    python_blocks = [i for i, (lang, _) in enumerate(blocks) if lang == "python"]
-    if not python_blocks:
-        problems.append(f"{chapter}: depth 'full' but no inline python construction")
-    paired = any(i + 1 < len(blocks) and blocks[i + 1][0] == "text" for i in python_blocks)
-    if python_blocks and not paired:
-        problems.append(f"{chapter}: no expected-output text fence follows any python fence")
+    if depth == "full":
+        blocks = fences(readme_text)
+        python_blocks = [i for i, (lang, _) in enumerate(blocks) if lang == "python"]
+        if not python_blocks:
+            problems.append(f"{chapter}: depth 'full' but no inline python construction")
+        paired = any(i + 1 < len(blocks) and blocks[i + 1][0] == "text" for i in python_blocks)
+        if python_blocks and not paired:
+            problems.append(f"{chapter}: no expected-output text fence follows any python fence")
     if not entry.get("concepts"):
-        problems.append(f"{chapter}: depth 'full' but empty concept coverage")
+        problems.append(f"{chapter}: depth {depth!r} but empty concept coverage")
     limits = str(entry.get("limits_anchor", ""))
     if not limits:
-        problems.append(f"{chapter}: depth 'full' but no limits_anchor declared")
+        problems.append(f"{chapter}: depth {depth!r} but no limits_anchor declared")
     elif limits not in readme_text:
         problems.append(f"{chapter}: limits anchor {limits!r} not found in README")
     if "Explain it back" not in readme_text:
         problems.append(f"{chapter}: no active-recall section ('Explain it back')")
     evidence_list = entry.get("break_evidence", [])
     if not evidence_list:
-        problems.append(f"{chapter}: depth 'full' but no break_evidence declared")
+        problems.append(f"{chapter}: depth {depth!r} but no break_evidence declared")
     for evidence in evidence_list:
         if str(evidence) not in readme_text:
             problems.append(f"{chapter}: break-experiment evidence {str(evidence)!r} not present")
@@ -294,6 +309,7 @@ def main() -> int:
         problems.append(f"manifest declares unknown chapter {slug}")
 
     full = 0
+    tours = 0
     gaps = 0
     for chapter in sorted(declared & CANONICAL_CHAPTERS):
         entry = chapters[chapter]
@@ -313,7 +329,10 @@ def main() -> int:
             gaps += gap_count
         if depth == "full":
             full += 1
-            problems.extend(check_depth_gates(chapter, entry, text))
+            problems.extend(check_depth_gates(chapter, entry, text, depth))
+        elif depth == "tour":
+            tours += 1
+            problems.extend(check_depth_gates(chapter, entry, text, depth))
 
     if problems:
         print(f"book depth NOT sound: {len(problems)} problem(s)")
@@ -321,9 +340,10 @@ def main() -> int:
             print(f"  - {problem}")
         return 1
 
-    pending = len(CANONICAL_CHAPTERS) - full
+    pending = len(CANONICAL_CHAPTERS) - full - tours
     print(
-        f"book depth sound: {full} chapter(s) at full depth verified, {pending} pending "
+        f"book depth sound: {full} chapter(s) at full depth verified, "
+        f"{tours} tour chapter(s) verified, {pending} pending "
         f"(exempt from depth gates, leak-scanned), {gaps} explicit known gap(s) on record"
     )
     print(f"BOOK-DEPTH-COMPLETE chapters={len(CANONICAL_CHAPTERS)}")

--- a/scripts/verify_book_depth.py
+++ b/scripts/verify_book_depth.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Check that deep chapters actually carry the depth they claim.
+
+Companion to verify_curriculum.py (structure/links/honesty) and
+verify_book_snippets.py (fence execution). This one checks COVERAGE and
+STRUCTURE against book/coverage_manifest.json:
+
+- every manifest reference is real: anchor text appears in the chapter README,
+  symbol text appears in the named production file, test-name fragment appears
+  in the named test file, the exercise file exists;
+- every chapter marked depth "full" also passes the structural depth gates:
+  at least one inline python fence, at least one expected-output text fence
+  directly after a python fence, an honest-limits anchor, an active-recall
+  section, and the declared break-experiment evidence present verbatim;
+- no reader-facing README leaks internal coordination artifacts (issue/PR
+  numbers, message ids, org/repo coordination names).
+
+Deliberately NOT here: fence formatting (ruff, via make lint) and fence
+execution (verify_book_snippets.py). Three instruments, three scopes.
+
+A chapter marked "pending" is exempt from the depth gates but NOT from the
+leak scan — era-aware grading, not a free pass.
+
+Exits 0 when sound, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOOK = REPO_ROOT / "book"
+MANIFEST = BOOK / "coverage_manifest.json"
+
+# Internal coordination artifacts that must never reach a reader. Domain words
+# the PRODUCT itself uses (SOW, ruling, sparring-as-role) are NOT leaks.
+LEAK_PATTERNS: tuple[tuple[str, str], ...] = (
+    (r"\borg #\d+", "org-repo issue reference"),
+    (r"\bPR #\d+", "pull-request reference"),
+    (r"\bmsg_[0-9a-f]{8}", "coordination message id"),
+    (r"\bCLAUDE\.md\b", "fleet doctrine file"),
+    (r"\bzeroemployeeorg/org\b", "org coordination repo"),
+    (r"\bRULING-\d{3}\b", "fleet ruling id"),
+)
+
+
+def fences(text: str) -> list[tuple[str, str]]:
+    """Return (language, body) for every fenced block, in order."""
+    return [
+        (match.group(1) or "", match.group(2))
+        for match in re.finditer(r"```(\w*)\n(.*?)```", text, re.S)
+    ]
+
+
+def check_reference(chapter: str, concept: dict[str, Any], readme_text: str) -> list[str]:
+    problems: list[str] = []
+    name = str(concept.get("concept", "<unnamed>"))
+    anchor = str(concept.get("anchor", ""))
+    if anchor and anchor not in readme_text:
+        problems.append(f"{chapter}: anchor {anchor!r} not found in README ({name})")
+    for symbol in concept.get("symbols", []):
+        file = REPO_ROOT / str(symbol["file"])
+        if not file.is_file():
+            problems.append(f"{chapter}: symbol file {symbol['file']} missing ({name})")
+        elif str(symbol["name"]) not in file.read_text(encoding="utf-8"):
+            problems.append(f"{chapter}: {symbol['name']!r} not found in {symbol['file']} ({name})")
+    for test in concept.get("tests", []):
+        file = REPO_ROOT / str(test["file"])
+        if not file.is_file():
+            problems.append(f"{chapter}: test file {test['file']} missing ({name})")
+        elif str(test["name"]) not in file.read_text(encoding="utf-8"):
+            problems.append(
+                f"{chapter}: no test matching {test['name']!r} in {test['file']} ({name})"
+            )
+    exercise = concept.get("exercise")
+    if exercise and not (REPO_ROOT / str(exercise)).is_file():
+        problems.append(f"{chapter}: exercise {exercise} missing ({name})")
+    return problems
+
+
+def check_depth_gates(chapter: str, entry: dict[str, Any], readme_text: str) -> list[str]:
+    problems: list[str] = []
+    blocks = fences(readme_text)
+    python_blocks = [i for i, (lang, _) in enumerate(blocks) if lang == "python"]
+    if not python_blocks:
+        problems.append(f"{chapter}: depth 'full' but no inline python construction")
+    paired = any(i + 1 < len(blocks) and blocks[i + 1][0] == "text" for i in python_blocks)
+    if python_blocks and not paired:
+        problems.append(f"{chapter}: no expected-output text fence follows any python fence")
+    if not entry.get("concepts"):
+        problems.append(f"{chapter}: depth 'full' but empty concept coverage")
+    limits = str(entry.get("limits_anchor", ""))
+    if not limits:
+        problems.append(f"{chapter}: depth 'full' but no limits_anchor declared")
+    elif limits not in readme_text:
+        problems.append(f"{chapter}: limits anchor {limits!r} not found in README")
+    if "Explain it back" not in readme_text:
+        problems.append(f"{chapter}: no active-recall section ('Explain it back')")
+    for evidence in entry.get("break_evidence", []):
+        if str(evidence) not in readme_text:
+            problems.append(f"{chapter}: break-experiment evidence {str(evidence)!r} not present")
+    return problems
+
+
+def check_leaks(chapter: str, readme_text: str) -> list[str]:
+    problems = []
+    for pattern, label in LEAK_PATTERNS:
+        match = re.search(pattern, readme_text)
+        if match:
+            problems.append(f"{chapter}: internal {label} leaks to readers: {match.group(0)!r}")
+    return problems
+
+
+def main() -> int:
+    if not MANIFEST.is_file():
+        print("book/coverage_manifest.json is missing")
+        return 1
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    problems: list[str] = []
+    full = 0
+    for chapter, entry in manifest["chapters"].items():
+        readme = BOOK / chapter / "README.md"
+        if not readme.is_file():
+            problems.append(f"{chapter}: README.md missing")
+            continue
+        text = readme.read_text(encoding="utf-8")
+        problems.extend(check_leaks(chapter, text))
+        for concept in entry.get("concepts", []):
+            problems.extend(check_reference(chapter, concept, text))
+        if entry.get("depth") == "full":
+            full += 1
+            problems.extend(check_depth_gates(chapter, entry, text))
+    if problems:
+        print(f"book depth NOT sound: {len(problems)} problem(s)")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+    pending = len(manifest["chapters"]) - full
+    print(
+        f"book depth sound: {full} chapter(s) at full depth verified, "
+        f"{pending} pending (exempt from depth gates, leak-scanned)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_book_snippets.py
+++ b/scripts/verify_book_snippets.py
@@ -37,10 +37,28 @@ Scope, deliberately narrow:
   (several ch01/ch02 blocks do exactly this, on purpose, to demonstrate a
   refusal) is not a failure -- only an exception that escapes the `exec` call
   is.
+- `SystemExit` (e.g. a snippet calling `sys.exit(...)`) is treated exactly
+  like any other escaping exception: a hard failure for that one block, and
+  the loop moves on to the next block/chapter. `SystemExit` inherits from
+  `BaseException`, not `Exception`, precisely so `sys.exit()` is NOT
+  accidentally swallowed by ordinary code -- but a checker that lets a single
+  chapter's snippet silently terminate the entire verification run (with exit
+  code 0, no report, and every later chapter unchecked) is a worse failure
+  mode than the one that design guards against. `KeyboardInterrupt` is the one
+  `BaseException` this script does NOT treat as a snippet failure: a real
+  Ctrl-C from whoever is running this tool is re-raised immediately and
+  interrupts the tool, exactly as it would for any other Python program.
+- Each python block runs under a wall-clock timeout (BLOCK_TIMEOUT_SECONDS).
+  A snippet that hangs (an infinite loop, a blocking read with no data) is
+  recorded as a problem for that block, the same way a raised exception is,
+  and the run continues to the next block/chapter rather than hanging the
+  whole verifier forever.
 
-Exits 0 when every chapter's python blocks all ran clean and every
-python-then-text pair matched exactly. Exits 1 otherwise, printing every
-failure found across every chapter -- not just the first.
+Exits 0 only when every chapter's python blocks all ran clean, every
+python-then-text pair matched exactly, AND every chapter that exists under
+book/ch* was actually attempted (see the completion-count assertion in
+main()). Exits 1 otherwise, printing every failure found across every
+chapter -- not just the first.
 """
 
 from __future__ import annotations
@@ -48,19 +66,102 @@ from __future__ import annotations
 import contextlib
 import io
 import re
+import signal
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from types import FrameType
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BOOK = REPO_ROOT / "book"
 sys.path.insert(0, str(REPO_ROOT / "src"))
+
+# Wall-clock ceiling for a single python fenced block. These are teaching
+# snippets -- sqlite writes, small loops, string formatting -- not long
+# computations; anything still running after this long is treated as hung.
+BLOCK_TIMEOUT_SECONDS = 20
+
+# The canonical count of chapters this repo currently ships. main() asserts
+# it actually attempted exactly this many chapters before declaring success,
+# so a future escape that exits the per-chapter loop early (some BaseException
+# this script does not yet know to triage, a bug in the loop itself) fails
+# loudly instead of reporting a partial run as if it were complete. Update
+# this alongside REQUIRED_CHAPTERS in verify_curriculum.py when a chapter is
+# added.
+EXPECTED_CHAPTER_COUNT = 13
+
+
+class SnippetTimeoutError(Exception):
+    """Raised inside a python block's own execution when it runs past
+    BLOCK_TIMEOUT_SECONDS. Deliberately a plain Exception (not BaseException):
+    this is this script's own manufactured signal, not a real interruption,
+    so it should be exactly as catchable/loggable as any other snippet
+    failure -- there is nothing here a caller would need to specifically
+    avoid catching, unlike KeyboardInterrupt.
+    """
+
+
+@contextlib.contextmanager
+def _block_timeout(seconds: int):  # type: ignore[no-untyped-def]
+    """Bound a single `exec()` call to `seconds` of wall-clock time.
+
+    Uses SIGALRM rather than a thread or a subprocess:
+
+    - A thread cannot be forcibly killed in Python. A hung snippet's thread
+      would leak for the rest of the process's life, and -- worse -- it could
+      keep mutating the shared per-chapter `namespace` dict concurrently with
+      whatever runs after the timeout fires, which is exactly the kind of
+      silent corruption this hardening pass exists to remove.
+    - A subprocess (or `multiprocessing`) can be forcibly killed cleanly, but
+      this script's whole design is a SHARED, cumulative namespace across a
+      chapter's blocks (ch01 opens a `:memory:` sqlite connection in one
+      block and reuses it three blocks later) -- and that namespace holds
+      objects (open sqlite connections, etc.) that do not survive a pickle
+      across a process boundary. Moving to a subprocess per block would mean
+      re-architecting the thing this checker exists to verify, not just
+      adding a timeout to it.
+    - `signal.alarm` needs no new process/thread model, runs entirely within
+      the existing single-process, single-threaded `exec()` call, and raises
+      a normal, catchable Python exception at the interrupted instruction --
+      which slots directly into the same "problem for this block, continue to
+      the next" handling already used for every other snippet failure.
+
+    Trade-off, stated plainly: `signal.alarm` is POSIX-only (no Windows) and
+    only fires on the main thread. This script runs as a CI/maintainer gate
+    on Linux (see .github/workflows/ci.yml: ubuntu-latest) invoked from the
+    main thread, so that trade-off costs nothing in this tool's actual
+    environment. If this script is ever run on Windows or off the main
+    thread, this guard degrades to a no-op timeout (the alarm is simply not
+    scheduled) rather than raising an unrelated platform error -- a hung
+    snippet there would hang the run, same as before this hardening pass, but
+    every other platform this tool is actually used on is protected.
+    """
+    has_alarm = hasattr(signal, "SIGALRM") and hasattr(signal, "alarm")
+    if not has_alarm:
+        yield
+        return
+
+    def _on_alarm(signum: int, frame: FrameType | None) -> None:
+        raise SnippetTimeoutError(f"execution exceeded {seconds}s")
+
+    previous_handler = signal.signal(signal.SIGALRM, _on_alarm)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
 
 # Matches a fenced code block's opening line, capturing the language tag (may
 # be empty) and, separately, tracks the block's start/end line numbers and
 # body. Only the three-backtick style is used anywhere in book/.
 FENCE_OPEN = re.compile(r"^```([\w-]*)\s*$")
 FENCE_CLOSE = re.compile(r"^```\s*$")
+
+
+class UnterminatedFenceError(Exception):
+    """A ``` fence was opened but never closed before end-of-file."""
 
 
 @dataclass
@@ -70,15 +171,18 @@ class FencedBlock:
     start_line: int  # 1-based line number of the OPENING ``` fence
 
 
-def parse_fenced_blocks(text: str) -> list[FencedBlock]:
+def parse_fenced_blocks(text: str, *, chapter: str = "<unknown>") -> list[FencedBlock]:
     """Every fenced code block in a Markdown file, in document order.
 
     Deliberately simple line-scanning rather than a full Markdown parser:
     book/ READMEs use plain ``` fences with no nesting, and every existing
     chapter (see ch01-ch03) fits this. A block whose opening fence is never
-    closed is silently ended at end-of-file rather than raising -- malformed
-    fencing is a content bug for a human editor to notice by reading the
-    chapter, not something this script exists to diagnose.
+    closed raises UnterminatedFenceError naming the chapter and the opening
+    fence's line number, rather than silently ending the block (and every
+    fence after it) at end-of-file -- a malformed fence used to mean every
+    block past that point in the file went unparsed and unchecked with no
+    error and no warning, which is the same "false green from silently
+    stopping early" failure family as an escaping SystemExit.
     """
     blocks: list[FencedBlock] = []
     lines = text.splitlines()
@@ -95,7 +199,12 @@ def parse_fenced_blocks(text: str) -> list[FencedBlock]:
         while i < len(lines) and not FENCE_CLOSE.match(lines[i]):
             body_lines.append(lines[i])
             i += 1
-        # i now points at the closing fence (or len(lines) if unterminated)
+        if i >= len(lines):
+            raise UnterminatedFenceError(
+                f"{chapter}: fence opened at line {start_line} is never closed "
+                f"(reached end of file while still inside it)"
+            )
+        # i now points at the closing fence.
         blocks.append(FencedBlock(lang=lang, body="\n".join(body_lines), start_line=start_line))
         i += 1
     return blocks
@@ -117,7 +226,7 @@ def check_chapter(readme: Path) -> tuple[int, int, list[str]]:
     """
     chapter = readme.parent.name
     text = readme.read_text(encoding="utf-8")
-    blocks = parse_fenced_blocks(text)
+    blocks = parse_fenced_blocks(text, chapter=chapter)
 
     problems: list[str] = []
     namespace: dict[str, object] = {}
@@ -131,8 +240,30 @@ def check_chapter(readme: Path) -> tuple[int, int, list[str]]:
 
         captured = io.StringIO()
         try:
-            with contextlib.redirect_stdout(captured):
+            with _block_timeout(BLOCK_TIMEOUT_SECONDS), contextlib.redirect_stdout(captured):
                 exec(compile(block.body, f"{chapter}:L{block.start_line}", "exec"), namespace)
+        except KeyboardInterrupt:
+            # A real Ctrl-C from whoever is running this tool. Re-raise
+            # IMMEDIATELY, before appending to problems, before touching the
+            # loop, before anything else -- this must interrupt the tool the
+            # same way it would interrupt any other Python program, not be
+            # recorded as a snippet failure and quietly continue.
+            raise
+        except SnippetTimeoutError as error:
+            problems.append(
+                f"{chapter}: python block at line {block.start_line} did not finish within "
+                f"{BLOCK_TIMEOUT_SECONDS}s ({error}) -- treated as hung and skipped"
+            )
+            continue
+        except SystemExit as error:
+            problems.append(
+                f"{chapter}: python block at line {block.start_line} called "
+                f"sys.exit({error.code!r}) instead of completing"
+            )
+            # Same reasoning as the Exception branch below: a following text
+            # block would be compared against a run that never finished, so
+            # skip the pair check and move on to the next python block.
+            continue
         except Exception as error:  # noqa: BLE001 - any escape is the failure this catches
             problems.append(
                 f"{chapter}: python block at line {block.start_line} raised "
@@ -143,6 +274,18 @@ def check_chapter(readme: Path) -> tuple[int, int, list[str]]:
             # and move on to the next python block in the same chapter. The
             # namespace already holds whatever the block managed to define
             # before raising, matching real REPL behaviour.
+            continue
+        except BaseException as error:  # noqa: BLE001 - catches GeneratorExit and anything
+            # else that is a BaseException but neither KeyboardInterrupt (re-raised above,
+            # unconditionally, before this) nor SystemExit (its own clause above, for a
+            # clearer message) nor an ordinary Exception (the clause above this one). This
+            # is deliberately last and deliberately broad: the entire point of this
+            # hardening pass is that NO escape from a snippet's exec() -- of any kind --
+            # is allowed to propagate out of check_chapter() and silently end the run.
+            problems.append(
+                f"{chapter}: python block at line {block.start_line} raised "
+                f"{type(error).__name__}: {error} (a BaseException, not caught by Exception)"
+            )
             continue
 
         # A python-then-text pair exists only when the VERY NEXT fenced
@@ -179,9 +322,21 @@ def main() -> int:
     report_rows: list[str] = []
     total_python = 0
     total_pairs = 0
+    chapters_attempted = 0
     for chapter_dir in chapters:
         readme = chapter_dir / "README.md"
-        python_count, pairs_checked, problems = check_chapter(readme)
+        try:
+            python_count, pairs_checked, problems = check_chapter(readme)
+        except UnterminatedFenceError as error:
+            # The chapter WAS attempted -- parsing started and failed loudly,
+            # which is exactly the point: this is a reported problem for this
+            # chapter, not a silent truncation, and the loop still moves on
+            # to check every remaining chapter.
+            chapters_attempted += 1
+            all_problems.append(str(error))
+            report_rows.append(f"  {chapter_dir.name}: FAIL -- {error}")
+            continue
+        chapters_attempted += 1
         all_problems.extend(problems)
         total_python += python_count
         total_pairs += pairs_checked
@@ -199,12 +354,37 @@ def main() -> int:
     for row in report_rows:
         print(row)
 
+    # Defense in depth: even after the BaseException triage above, assert the
+    # loop actually reached every chapter it should have, rather than trusting
+    # that no future escape can ever exit it early. An early, unreported exit
+    # from this loop is precisely how the original SystemExit defect looked
+    # green (exit 0, no output) -- this makes a partial run impossible to
+    # mistake for a complete one, even from a cause this script does not yet
+    # know to name.
+    if chapters_attempted != len(chapters):
+        print(
+            f"\nBOOK SNIPPETS: INCOMPLETE RUN -- attempted {chapters_attempted} of "
+            f"{len(chapters)} discovered chapter(s). A verification run that does not "
+            f"finish must never be reported as passing."
+        )
+        return 1
+    if chapters_attempted != EXPECTED_CHAPTER_COUNT:
+        print(
+            f"\nBOOK SNIPPETS: attempted {chapters_attempted} chapter(s), but "
+            f"EXPECTED_CHAPTER_COUNT in this script is {EXPECTED_CHAPTER_COUNT}. Update "
+            f"EXPECTED_CHAPTER_COUNT in scripts/verify_book_snippets.py to match the "
+            f"book's real chapter count (this guards against BOOK.glob('ch*') silently "
+            f"discovering fewer chapters than the book actually has, e.g. a chapter "
+            f"directory renamed or misplaced outside book/)."
+        )
+        return 1
+
     if all_problems:
         print(f"\n{len(all_problems)} book snippet problem(s).")
         return 1
 
     print(
-        f"\nbook snippets sound: {len(chapters)} chapters, {total_python} python block(s) "
+        f"\nbook snippets sound: {chapters_attempted} chapters, {total_python} python block(s) "
         f"executed, {total_pairs} text-pair(s) checked, all matched"
     )
     return 0

--- a/scripts/verify_book_snippets.py
+++ b/scripts/verify_book_snippets.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Check that a chapter's inline ```python``` snippets actually run, and that
+any ```text``` block immediately following one is the REAL stdout that
+snippet produces -- not prose someone typed and never re-checked.
+
+Catches the ways an embedded "expected output" block rots:
+
+- a `python` block that raises instead of running cleanly
+- a `python` block whose captured stdout no longer matches the `text` block
+  claimed to be its output (the code moved on; the printed transcript did not)
+- a `text` block that was never actually validated against anything, because
+  a human eyeballed it once at write time and nobody has re-run it since
+
+Scope, deliberately narrow:
+
+- Only ```python``` fenced blocks are executed. ```bash``` fenced blocks are
+  shell/CLI transcripts, not Python -- this script skips them silently.
+  Verifying those would mean actually invoking the CLI and filesystem, which
+  is a separate, harder mechanism and out of scope here.
+- A ```text``` block is checked ONLY when the fenced block immediately
+  preceding it (the nearest fence before it in the document, ignoring any
+  non-fenced prose in between) is a ```python``` block. A ```text``` block
+  that follows a ```bash``` block, or any other fence, is skipped entirely --
+  it is not this script's claim to verify, and it is not an error for one to
+  exist there.
+- Each chapter's python blocks execute cumulatively in ONE shared namespace,
+  in document order -- later blocks may reference names (variables,
+  functions, imports) an earlier block in the SAME chapter defined, which is
+  how these chapters are actually written (ch01 opens a `:memory:` sqlite
+  connection in one block and reuses it three blocks later). The namespace
+  resets at the start of every new chapter. A later block reassigning a name
+  an earlier block already used (rebinding `outcome["state"]`, redefining a
+  function) is ordinary `exec()`-into-one-dict behaviour and needs no special
+  handling: the dict is simply updated in place.
+- An exception escaping a python block is a hard failure for that block. A
+  python block that deliberately raises and catches its OWN exception inline
+  (several ch01/ch02 blocks do exactly this, on purpose, to demonstrate a
+  refusal) is not a failure -- only an exception that escapes the `exec` call
+  is.
+
+Exits 0 when every chapter's python blocks all ran clean and every
+python-then-text pair matched exactly. Exits 1 otherwise, printing every
+failure found across every chapter -- not just the first.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOOK = REPO_ROOT / "book"
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+# Matches a fenced code block's opening line, capturing the language tag (may
+# be empty) and, separately, tracks the block's start/end line numbers and
+# body. Only the three-backtick style is used anywhere in book/.
+FENCE_OPEN = re.compile(r"^```([\w-]*)\s*$")
+FENCE_CLOSE = re.compile(r"^```\s*$")
+
+
+@dataclass
+class FencedBlock:
+    lang: str  # the tag right after ``` -- "python", "text", "bash", or ""
+    body: str  # the block's source, exactly as written between the fences
+    start_line: int  # 1-based line number of the OPENING ``` fence
+
+
+def parse_fenced_blocks(text: str) -> list[FencedBlock]:
+    """Every fenced code block in a Markdown file, in document order.
+
+    Deliberately simple line-scanning rather than a full Markdown parser:
+    book/ READMEs use plain ``` fences with no nesting, and every existing
+    chapter (see ch01-ch03) fits this. A block whose opening fence is never
+    closed is silently ended at end-of-file rather than raising -- malformed
+    fencing is a content bug for a human editor to notice by reading the
+    chapter, not something this script exists to diagnose.
+    """
+    blocks: list[FencedBlock] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        match = FENCE_OPEN.match(lines[i])
+        if match is None:
+            i += 1
+            continue
+        lang = match.group(1)
+        start_line = i + 1  # 1-based
+        body_lines: list[str] = []
+        i += 1
+        while i < len(lines) and not FENCE_CLOSE.match(lines[i]):
+            body_lines.append(lines[i])
+            i += 1
+        # i now points at the closing fence (or len(lines) if unterminated)
+        blocks.append(FencedBlock(lang=lang, body="\n".join(body_lines), start_line=start_line))
+        i += 1
+    return blocks
+
+
+def normalize(text: str) -> str:
+    """Strip trailing whitespace from each line and from the whole block, so
+    a trailing-newline or trailing-space difference is not a false failure,
+    while a real content difference still is.
+    """
+    lines = [line.rstrip() for line in text.splitlines()]
+    return "\n".join(lines).strip()
+
+
+def check_chapter(readme: Path) -> tuple[int, int, list[str]]:
+    """Run one chapter's python blocks cumulatively and check its
+    python-then-text pairs. Returns (python_blocks_found, text_pairs_checked,
+    problems).
+    """
+    chapter = readme.parent.name
+    text = readme.read_text(encoding="utf-8")
+    blocks = parse_fenced_blocks(text)
+
+    problems: list[str] = []
+    namespace: dict[str, object] = {}
+    python_block_count = 0
+    pairs_checked = 0
+
+    for index, block in enumerate(blocks):
+        if block.lang != "python":
+            continue
+        python_block_count += 1
+
+        captured = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(captured):
+                exec(compile(block.body, f"{chapter}:L{block.start_line}", "exec"), namespace)
+        except Exception as error:  # noqa: BLE001 - any escape is the failure this catches
+            problems.append(
+                f"{chapter}: python block at line {block.start_line} raised "
+                f"{type(error).__name__}: {error}"
+            )
+            # Still check for a following text block would compare against a
+            # run that never finished -- skip the pair check for this block
+            # and move on to the next python block in the same chapter. The
+            # namespace already holds whatever the block managed to define
+            # before raising, matching real REPL behaviour.
+            continue
+
+        # A python-then-text pair exists only when the VERY NEXT fenced
+        # block (ignoring only non-fenced prose -- there is no such thing
+        # here since parse_fenced_blocks already skips prose) is tagged
+        # text. If the next fence is bash, another python block, or
+        # anything else, there is no pair to check -- skip silently.
+        next_block = blocks[index + 1] if index + 1 < len(blocks) else None
+        if next_block is None or next_block.lang != "text":
+            continue
+
+        pairs_checked += 1
+        expected = normalize(next_block.body)
+        actual = normalize(captured.getvalue())
+        if expected != actual:
+            problems.append(
+                f"{chapter}: python block at line {block.start_line} output does not match "
+                f"the text block at line {next_block.start_line}\n"
+                f"--- expected (text block) ---\n{expected}\n"
+                f"--- actual (captured stdout) ---\n{actual}\n"
+                f"--- end ---"
+            )
+
+    return python_block_count, pairs_checked, problems
+
+
+def main() -> int:
+    chapters = sorted(p for p in BOOK.glob("ch*") if (p / "README.md").is_file())
+    if not chapters:
+        print("BOOK SNIPPETS: no chapters found under book/ch*")
+        return 1
+
+    all_problems: list[str] = []
+    report_rows: list[str] = []
+    total_python = 0
+    total_pairs = 0
+    for chapter_dir in chapters:
+        readme = chapter_dir / "README.md"
+        python_count, pairs_checked, problems = check_chapter(readme)
+        all_problems.extend(problems)
+        total_python += python_count
+        total_pairs += pairs_checked
+        status = "FAIL" if problems else "ok"
+        report_rows.append(
+            f"  {chapter_dir.name}: {python_count} python block(s), "
+            f"{pairs_checked} text-pair(s) checked -- {status}"
+        )
+
+    for problem in all_problems:
+        print(f"BOOK SNIPPETS: {problem}")
+
+    print()
+    print("book snippet report:")
+    for row in report_rows:
+        print(row)
+
+    if all_problems:
+        print(f"\n{len(all_problems)} book snippet problem(s).")
+        return 1
+
+    print(
+        f"\nbook snippets sound: {len(chapters)} chapters, {total_python} python block(s) "
+        f"executed, {total_pairs} text-pair(s) checked, all matched"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_book_snippets_verifier.py
+++ b/tests/test_book_snippets_verifier.py
@@ -1,0 +1,364 @@
+"""Regression tests for scripts/verify_book_snippets.py's fail-closed behaviour.
+
+A Principal-level review found that the verifier's ``except Exception`` branch
+does not catch ``SystemExit`` (it inherits from ``BaseException``, not
+``Exception``): a chapter's python fence calling ``sys.exit(0)`` propagated
+straight through ``check_chapter`` and ``main``'s per-chapter loop, and
+terminated the whole process with exit code 0 -- silently, with no report,
+and with every later chapter left unchecked. The same "silently stops early
+and still looks green" family of bug existed in ``parse_fenced_blocks``: an
+unterminated fence silently ended parsing (and therefore checking) of
+everything after it in the file.
+
+These tests build a synthetic, temporary ``book/`` directory (never touching
+the real book/ch*/README.md files, which are a different party's content and
+out of scope here) and monkeypatch the verifier module's ``BOOK`` constant to
+point at it, so `check_chapter`/`main` run against fixtures instead of the
+real book.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_book_snippets.py"
+
+
+def _load_module() -> types.ModuleType:
+    """Load scripts/verify_book_snippets.py as an importable module.
+
+    scripts/ is not a package; this mirrors the importlib.util pattern
+    scripts/verify_curriculum.py itself already uses to load a chapter's
+    solution.py dynamically.
+    """
+    spec = importlib.util.spec_from_file_location("verify_book_snippets", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec_module: the script's FencedBlock is
+    # a @dataclass under `from __future__ import annotations`, and dataclass
+    # resolves its string annotations via sys.modules[cls.__module__] -- it
+    # needs the module to already be findable there while its body executes.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_cli(cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run the real CLI entry point end to end, exactly as CI/Makefile do."""
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, str(SCRIPT_PATH)], capture_output=True, text=True, cwd=cwd
+    )
+
+
+def _write_chapter(book: Path, name: str, readme_body: str) -> None:
+    chapter_dir = book / name
+    chapter_dir.mkdir(parents=True)
+    (chapter_dir / "README.md").write_text(readme_body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# B2: SystemExit must not silently terminate the whole run.
+# ---------------------------------------------------------------------------
+
+
+def test_sys_exit_in_a_snippet_is_reported_not_swallowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact defect: a python fence calling sys.exit(0) must be recorded
+    as a problem for its own chapter, and must NOT end the whole run early --
+    a later chapter in the same run must still be checked and reported.
+    """
+    book = tmp_path / "book"
+    _write_chapter(
+        book,
+        "ch01_exits_early",
+        "# Chapter 1\n\n```python\nimport sys\nsys.exit(0)\n```\n",
+    )
+    _write_chapter(
+        book,
+        "ch02_comes_after",
+        '# Chapter 2\n\n```python\nprint("still alive")\n```\n\n```text\nstill alive\n```\n',
+    )
+
+    module = _load_module()
+    monkeypatch.setattr(module, "BOOK", book)
+    monkeypatch.setattr(module, "EXPECTED_CHAPTER_COUNT", 2)
+
+    exit_code = module.main()
+
+    assert exit_code == 1, "a chapter calling sys.exit(0) must not be reported as success"
+
+    _, _, ch01_problems = module.check_chapter(book / "ch01_exits_early" / "README.md")
+    assert len(ch01_problems) == 1
+    assert "sys.exit(0)" in ch01_problems[0]
+    assert "instead of completing" in ch01_problems[0]
+
+    # The real proof execution continued: ch02, which comes AFTER the
+    # sys.exit(0) chapter, still ran its own snippet and matched its own
+    # expected output -- it was not skipped as collateral damage.
+    ch02_python_count, ch02_pairs_checked, ch02_problems = module.check_chapter(
+        book / "ch02_comes_after" / "README.md"
+    )
+    assert ch02_python_count == 1
+    assert ch02_pairs_checked == 1
+    assert ch02_problems == []
+
+
+def test_sys_exit_reproduction_via_real_cli_subprocess(tmp_path: Path) -> None:
+    """End-to-end: run the actual CLI (as CI and `make verify` do) against a
+    fixture book with a chapter that calls sys.exit(0), and confirm the
+    process itself exits 1 with a completion report -- not 0 with silence.
+
+    This is the same shape as the Principal's original repro (prepending a
+    sys.exit(0) fence to a real chapter and running the CLI), reproduced here
+    as a fixture so it runs in CI rather than needing a one-off manual check.
+    """
+    book = tmp_path / "book"
+    _write_chapter(
+        book, "ch01_exits_early", "# Chapter 1\n\n```python\nimport sys\nsys.exit(0)\n```\n"
+    )
+    _write_chapter(
+        book,
+        "ch02_comes_after",
+        '# Chapter 2\n\n```python\nprint("still alive")\n```\n\n```text\nstill alive\n```\n',
+    )
+    # The real script resolves BOOK from its own file location
+    # (REPO_ROOT / "book"), not from cwd -- so exercise the same code by
+    # copying the script next to the fixture book and running it there.
+    fixture_script_dir = tmp_path / "scripts"
+    fixture_script_dir.mkdir()
+    fixture_script = fixture_script_dir / "verify_book_snippets.py"
+    fixture_script.write_text(SCRIPT_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "src").mkdir()
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(fixture_script)], capture_output=True, text=True, cwd=tmp_path
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "sys.exit(0)" in result.stdout
+    assert "ch02_comes_after" in result.stdout
+    assert "book snippets sound" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# KeyboardInterrupt must NOT be swallowed -- it must still propagate as a
+# real Ctrl-C would.
+# ---------------------------------------------------------------------------
+
+
+def test_keyboard_interrupt_is_not_swallowed_by_the_timeout_context(tmp_path: Path) -> None:
+    """Raise KeyboardInterrupt synthetically inside code running under
+    _block_timeout (rather than needing an actual human keypress) and confirm
+    it propagates straight out uncaught -- proving the timeout's own
+    signal-handling plumbing does not accidentally absorb a real interrupt
+    either, independent of check_chapter's own except-clause ordering (which
+    test_keyboard_interrupt_escapes_check_chapter_end_to_end covers).
+    """
+    module = _load_module()
+
+    def _raises_interrupt() -> None:
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        with module._block_timeout(5):
+            _raises_interrupt()
+
+
+def test_keyboard_interrupt_escapes_check_chapter_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same proof, but through the real check_chapter()/main() path: a
+    chapter whose only python block raises KeyboardInterrupt must propagate
+    it out of check_chapter uncaught, not record it as a snippet problem.
+    """
+    book = tmp_path / "book"
+    _write_chapter(
+        book,
+        "ch01_interrupted",
+        "# Chapter 1\n\n```python\nraise KeyboardInterrupt\n```\n",
+    )
+    module = _load_module()
+    monkeypatch.setattr(module, "BOOK", book)
+
+    with pytest.raises(KeyboardInterrupt):
+        module.check_chapter(book / "ch01_interrupted" / "README.md")
+
+
+# ---------------------------------------------------------------------------
+# A hanging snippet must be caught by the timeout, not hang the verifier.
+# ---------------------------------------------------------------------------
+
+
+def test_hanging_snippet_is_caught_by_timeout_and_run_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    book = tmp_path / "book"
+    _write_chapter(
+        book,
+        "ch01_hangs",
+        "# Chapter 1\n\n```python\nwhile True:\n    pass\n```\n",
+    )
+    _write_chapter(
+        book,
+        "ch02_comes_after",
+        '# Chapter 2\n\n```python\nprint("still alive")\n```\n\n```text\nstill alive\n```\n',
+    )
+    module = _load_module()
+    monkeypatch.setattr(module, "BOOK", book)
+    monkeypatch.setattr(module, "EXPECTED_CHAPTER_COUNT", 2)
+    # Use a short timeout so this test does not itself take BLOCK_TIMEOUT_SECONDS
+    # (the production default) to run.
+    monkeypatch.setattr(module, "BLOCK_TIMEOUT_SECONDS", 2)
+
+    started = time.monotonic()
+    exit_code = module.main()
+    elapsed = time.monotonic() - started
+
+    assert exit_code == 1
+    assert elapsed < 15, "the hang must be bounded by the timeout, not run indefinitely"
+
+    _, _, ch01_problems = module.check_chapter(book / "ch01_hangs" / "README.md")
+    assert len(ch01_problems) == 1
+    assert "did not finish within" in ch01_problems[0]
+
+    ch02_python_count, ch02_pairs_checked, ch02_problems = module.check_chapter(
+        book / "ch02_comes_after" / "README.md"
+    )
+    assert ch02_python_count == 1
+    assert ch02_pairs_checked == 1
+    assert ch02_problems == []
+
+
+# ---------------------------------------------------------------------------
+# B1 (coordinator-added): an unterminated fence must raise loudly, not
+# silently truncate the rest of the chapter.
+# ---------------------------------------------------------------------------
+
+
+def test_unterminated_fence_raises_naming_chapter_and_line(tmp_path: Path) -> None:
+    module = _load_module()
+    text = (
+        "# Chapter 1\n\n"
+        "```python\n"
+        "print('before the break')\n"
+        "```\n\n"
+        "```text\n"
+        "before the break\n"
+        "```\n\n"
+        "```python\n"
+        "print('this fence is never closed')\n"
+    )
+    with pytest.raises(module.UnterminatedFenceError) as excinfo:
+        module.parse_fenced_blocks(text, chapter="ch99_broken")
+    assert "ch99_broken" in str(excinfo.value)
+    assert "line 11" in str(excinfo.value)
+
+
+def test_unterminated_fence_in_one_chapter_is_reported_and_run_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed fence in one chapter must fail loudly for THAT chapter,
+    but the run must still attempt and report every other chapter -- proving
+    this is on the same "no silent early stop" footing as the SystemExit fix.
+    """
+    book = tmp_path / "book"
+    _write_chapter(
+        book,
+        "ch01_broken_fence",
+        "# Chapter 1\n\n```python\nprint('unterminated')\n",
+    )
+    _write_chapter(
+        book,
+        "ch02_comes_after",
+        '# Chapter 2\n\n```python\nprint("still alive")\n```\n\n```text\nstill alive\n```\n',
+    )
+    module = _load_module()
+    monkeypatch.setattr(module, "BOOK", book)
+    monkeypatch.setattr(module, "EXPECTED_CHAPTER_COUNT", 2)
+
+    exit_code = module.main()
+
+    assert exit_code == 1
+    with pytest.raises(module.UnterminatedFenceError):
+        module.check_chapter(book / "ch01_broken_fence" / "README.md")
+
+    ch02_python_count, ch02_pairs_checked, ch02_problems = module.check_chapter(
+        book / "ch02_comes_after" / "README.md"
+    )
+    assert ch02_python_count == 1
+    assert ch02_pairs_checked == 1
+    assert ch02_problems == []
+
+
+def test_well_formed_real_chapters_still_parse_with_chapter_kwarg() -> None:
+    """The chapter= keyword added to parse_fenced_blocks must not disturb
+    parsing of any currently well-formed real chapter."""
+    module = _load_module()
+    for readme in sorted((REPO_ROOT / "book").glob("ch*/README.md")):
+        blocks = module.parse_fenced_blocks(
+            readme.read_text(encoding="utf-8"), chapter=readme.parent.name
+        )
+        assert isinstance(blocks, list)
+
+
+# ---------------------------------------------------------------------------
+# Completion marker: main() must refuse to report success on a partial run.
+# ---------------------------------------------------------------------------
+
+
+def test_main_fails_loudly_if_fewer_chapters_were_attempted_than_expected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    book = tmp_path / "book"
+    _write_chapter(
+        book,
+        "ch01_only_chapter",
+        '# Chapter 1\n\n```python\nprint("hi")\n```\n\n```text\nhi\n```\n',
+    )
+    module = _load_module()
+    monkeypatch.setattr(module, "BOOK", book)
+    # Simulate the book claiming to have more chapters than actually exist,
+    # standing in for the "some future escape exits the loop early" case this
+    # count exists to catch defense-in-depth against.
+    monkeypatch.setattr(module, "EXPECTED_CHAPTER_COUNT", 13)
+
+    exit_code = module.main()
+
+    assert exit_code == 1
+
+
+def test_main_succeeds_when_attempted_count_matches_expected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    book = tmp_path / "book"
+    _write_chapter(
+        book,
+        "ch01_only_chapter",
+        '# Chapter 1\n\n```python\nprint("hi")\n```\n\n```text\nhi\n```\n',
+    )
+    module = _load_module()
+    monkeypatch.setattr(module, "BOOK", book)
+    monkeypatch.setattr(module, "EXPECTED_CHAPTER_COUNT", 1)
+
+    assert module.main() == 0
+
+
+# ---------------------------------------------------------------------------
+# No regression: the real book must still verify exactly as before.
+# ---------------------------------------------------------------------------
+
+
+def test_real_book_chapters_still_pass_unchanged() -> None:
+    result = run_cli(REPO_ROOT)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "book snippets sound: 13 chapters, 81 python block(s) executed" in result.stdout
+    assert "71 text-pair(s) checked, all matched" in result.stdout

--- a/tests/test_book_snippets_verifier.py
+++ b/tests/test_book_snippets_verifier.py
@@ -360,5 +360,5 @@ def test_main_succeeds_when_attempted_count_matches_expected(
 def test_real_book_chapters_still_pass_unchanged() -> None:
     result = run_cli(REPO_ROOT)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "book snippets sound: 13 chapters, 81 python block(s) executed" in result.stdout
-    assert "71 text-pair(s) checked, all matched" in result.stdout
+    assert "book snippets sound: 13 chapters, 92 python block(s) executed" in result.stdout
+    assert "82 text-pair(s) checked, all matched" in result.stdout

--- a/tests/test_book_verifiers.py
+++ b/tests/test_book_verifiers.py
@@ -1,0 +1,227 @@
+"""Mutation regression tests for the book verifiers.
+
+Each test here is a failure class the Principal demonstrated (msg_aa4e52b8
+B3/B4) or listed as required mutation coverage: the instrument is run against
+a deliberately corrupted manifest and must fail loudly. A verifier nobody has
+tried to break is an instrument of unknown strength -- these keep every
+previously-demonstrated false-green path permanently closed.
+
+Scope: scripts/verify_book_depth.py (the depth/coverage instrument). The
+snippet verifier's own mutation coverage (SystemExit containment, timeout,
+unterminated fences, later-chapter survival) lives alongside these once its
+hardening lands -- same file, so the failure classes stay in one place.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "verify_book_depth.py"
+REAL_MANIFEST = REPO_ROOT / "book" / "coverage_manifest.json"
+
+
+def _load_depth_module():
+    spec = importlib.util.spec_from_file_location("verify_book_depth", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_with_manifest(tmp_path: Path, manifest: dict, capsys) -> tuple[int, str]:
+    """Run the depth verifier's main() against a mutated manifest copy."""
+    mutated = tmp_path / "coverage_manifest.json"
+    mutated.write_text(json.dumps(manifest), encoding="utf-8")
+    module = _load_depth_module()
+    module.MANIFEST = mutated
+    code = module.main()
+    output = capsys.readouterr().out
+    return code, output
+
+
+def real_manifest() -> dict:
+    return json.loads(REAL_MANIFEST.read_text(encoding="utf-8"))
+
+
+def first_full_chapter(manifest: dict) -> str:
+    for slug, entry in manifest["chapters"].items():
+        if entry.get("depth") == "full":
+            return slug
+    raise AssertionError("no full-depth chapter in the real manifest")
+
+
+def test_the_real_manifest_passes(capsys) -> None:
+    module = _load_depth_module()
+    code = module.main()
+    output = capsys.readouterr().out
+    assert code == 0
+    assert "BOOK-DEPTH-COMPLETE chapters=13" in output
+
+
+def test_an_empty_manifest_is_refused(tmp_path, capsys) -> None:
+    code, output = run_with_manifest(tmp_path, {"chapters": {}}, capsys)
+    assert code == 1
+    assert "empty denominator" in output
+
+
+def test_a_missing_chapter_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    removed = first_full_chapter(manifest)
+    del manifest["chapters"][removed]
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert f"missing canonical chapter {removed}" in output
+
+
+def test_an_extra_chapter_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    manifest["chapters"]["ch99_invented"] = {"depth": "pending", "concepts": []}
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "unknown chapter ch99_invented" in output
+
+
+def test_an_invalid_depth_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["depth"] = "heroic"
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "'heroic'" in output
+
+
+def test_an_empty_symbol_name_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["concepts"][0]["symbols"][0]["name"] = ""
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "empty symbol name" in output
+
+
+def test_an_absolute_symbol_path_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["concepts"][0]["symbols"][0] = {
+        "file": "/etc/hosts",
+        "name": "localhost",
+    }
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "not a file under src/ or scripts/" in output
+
+
+def test_a_traversing_symbol_path_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["concepts"][0]["symbols"][0] = {
+        "file": "src/../../etc/hosts",
+        "name": "localhost",
+    }
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "not a file under src/ or scripts/" in output
+
+
+def test_a_nonexistent_ast_symbol_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["concepts"][0]["symbols"][0]["name"] = "definitely_not_defined"
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "not a function/class/module-level assignment" in output
+
+
+def test_a_docstring_word_is_not_an_ast_symbol(tmp_path, capsys) -> None:
+    """Substring matching used to accept any word that appeared in the file."""
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    # "append-only" appears as prose in database.py but is no AST node.
+    manifest["chapters"][chapter]["concepts"][0]["symbols"][0] = {
+        "file": "src/sovereign_agent/database.py",
+        "name": "append-only",
+    }
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "not a function/class/module-level assignment" in output
+
+
+def test_an_imprecise_test_reference_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["concepts"][0]["tests"] = ["def test_"]
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "not file::function" in output
+
+
+def test_a_missing_test_function_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["concepts"][0]["tests"] = [
+        "tests/test_persistence.py::test_this_test_does_not_exist"
+    ]
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "no test function" in output
+
+
+def test_no_tests_and_no_known_gap_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    concept = manifest["chapters"][chapter]["concepts"][0]
+    concept["tests"] = []
+    concept.pop("known_gap", None)
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "neither precise tests nor an explicit known_gap" in output
+
+
+def test_an_exercise_outside_the_chapter_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["concepts"][0]["exercise"] = "scripts/verify_curriculum.py"
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "not a file under book/" in output
+
+
+def test_a_short_source_text_fragment_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["concepts"][0]["source_text"] = [
+        {"file": "src/sovereign_agent/database.py", "text": "reserv"}
+    ]
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "shorter than" in output
+
+
+def test_known_gaps_are_counted_in_the_summary(capsys) -> None:
+    module = _load_depth_module()
+    code = module.main()
+    output = capsys.readouterr().out
+    assert code == 0
+    assert "explicit known gap(s) on record" in output
+
+
+def test_canonical_chapter_sets_agree_across_verifiers() -> None:
+    """The three book instruments must never disagree on the denominator."""
+    depth = _load_depth_module()
+    curriculum_spec = importlib.util.spec_from_file_location(
+        "verify_curriculum", REPO_ROOT / "scripts" / "verify_curriculum.py"
+    )
+    assert curriculum_spec is not None and curriculum_spec.loader is not None
+    curriculum = importlib.util.module_from_spec(curriculum_spec)
+    curriculum_spec.loader.exec_module(curriculum)
+    assert set(depth.CANONICAL_CHAPTERS) == set(curriculum.REQUIRED_CHAPTERS)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_book_verifiers.py
+++ b/tests/test_book_verifiers.py
@@ -211,6 +211,53 @@ def test_known_gaps_are_counted_in_the_summary(capsys) -> None:
     assert "explicit known gap(s) on record" in output
 
 
+def test_a_tour_chapter_with_no_break_evidence_is_refused(tmp_path, capsys) -> None:
+    """'tour' is a finished chapter, not a loophole: break evidence is required."""
+    manifest = real_manifest()
+    manifest["chapters"]["ch00_first_shift"]["break_evidence"] = []
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "depth 'tour' but no break_evidence declared" in output
+
+
+def test_a_tour_chapter_with_empty_concepts_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    manifest["chapters"]["ch00_first_shift"]["concepts"] = []
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "depth 'tour' but empty concept coverage" in output
+
+
+def test_a_tour_chapter_with_no_limits_anchor_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    del manifest["chapters"]["ch00_first_shift"]["limits_anchor"]
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "depth 'tour' but no limits_anchor declared" in output
+
+
+def test_tour_does_not_require_inline_python(tmp_path, capsys) -> None:
+    """ch00 has zero python fences and depth 'tour' — that must pass, while the
+    same chapter at depth 'full' must be refused for the missing construction."""
+    manifest = real_manifest()
+    assert manifest["chapters"]["ch00_first_shift"]["depth"] == "tour"
+    code, _ = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 0
+    manifest["chapters"]["ch00_first_shift"]["depth"] = "full"
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "depth 'full' but no inline python construction" in output
+
+
+def test_a_full_book_reports_zero_pending(capsys) -> None:
+    """With every chapter at a finished depth, the summary must say 0 pending."""
+    module = _load_depth_module()
+    code = module.main()
+    output = capsys.readouterr().out
+    assert code == 0
+    assert "0 pending" in output
+
+
 def test_canonical_chapter_sets_agree_across_verifiers() -> None:
     """The three book instruments must never disagree on the denominator."""
     depth = _load_depth_module()


### PR DESCRIPTION
**Follow-up to PR #57**, opened per Operator direction. This is where the *full-depth* deepening lands — the work the Principal's review (msg_2d8bc13c) and curriculum direction call for. One reviewable chapter (or small group) at a time.

> **Stacking note:** until #57 merges, this PR's diff also shows #57's honesty/correctness pass. Once #57 lands, this PR shows only the new depth work. (#57 is the correctness/CI/honesty fixes; this PR is depth.)

## The standard this PR builds to (from the Principal)
**What was wrong** (fixed in #57, not repeated here): CI red; ch03 taught the inverse of production; several reader-facing overclaims; residual dev-leaks; the artifact called itself Raschka-depth when it wasn't.

**What the Principal wants to see** — the acceptance rubric each deep chapter must meet:
1. The learner **builds the real mechanism** in cumulative, annotated increments — no chapter passes by saying "read solution.py."
2. A **naive implementation is run and broken** before the corrected one is introduced.
3. Every reader-facing Python block is **formatted, executed, and its output compared** (a snippet gate the Master will add).
4. At least one **required rejection and its valid dual**; real atomicity/concurrency/crash/idempotency edges demonstrated, not named.
5. **Claims sit adjacent to their scope**; no proxy proves a broader property than it measures.
6. Each chapter: prerequisites, "what you'll build," a worked trace, failure-mode table, common mistakes, graded exercises with runnable solutions, summary, active recall, forward/back continuity.
7. `solution.py` is the **tested cumulative end-state** of the inline build.
8. Depth comes from the **mechanism and its failure surfaces**, not word-count padding.

## Progress
- **ch01 — done to depth.** Inline build-break-repair in throwaway SQLite: minimal schema, signed cash ledger, append-only triggers (DB-enforced), the three-write transaction, an injected crash showing atomic rollback, and an honest SQLite-durability limit. **Every inline block is executed and its output verified** (append-only UPDATE → `sqlite3.IntegrityError`; restock 10000→8500; crash leaves state unchanged). ruff format+check clean; curriculum green.
- ch02–ch12: to follow against the per-chapter map (ch03's rebuilt version already lives in #57 as the exemplar shape).

Gate on every commit: `ruff format --check book`, `ruff check book`, `verify_curriculum.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)