### PR TITLE
Add runnable companion labs for all 13 chapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: python scripts/verify_source_budget.py
       - name: Verify the curriculum is runnable
         run: python scripts/verify_curriculum.py
+      - name: Verify all companion labs from fresh roots
+        run: python scripts/verify_book_labs.py
       - name: Verify offline commands
         run: |
           sovereign-agent --help

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help:
 	@printf "  make test      Run tests\n"
 	@printf "  make lint      Run Ruff and mypy\n"
 	@printf "  make doctor    Check the offline learner environment\n"
+	@printf "  make labs      Execute every companion lab from fresh roots\n"
 
 .PHONY: install
 install:
@@ -29,10 +30,16 @@ lint:
 doctor:
 	$(UV) run --python 3.14 sovereign-agent doctor
 
+.PHONY: labs
+labs:
+	$(UV) run --python 3.14 python scripts/verify_book_labs.py
+
 .PHONY: verify
 verify: lint test
 	$(UV) run --python 3.14 python scripts/verify_runtime_dependencies.py
 	$(UV) run --python 3.14 python scripts/verify_source_budget.py
+	$(UV) run --python 3.14 python scripts/verify_curriculum.py
+	$(UV) run --python 3.14 python scripts/verify_book_labs.py
 	$(UV) run --python 3.14 sovereign-agent --help >/dev/null
 	$(UV) run --python 3.14 sovereign-agent doctor
 	$(UV) run --python 3.14 sovereign-agent demo store --mode simulated --root /tmp/sovereign-agent-demo

--- a/book/README.md
+++ b/book/README.md
@@ -6,6 +6,11 @@ package; it does not copy or fork it.
 Read them in order. Each one takes apart something the previous chapter asked
 you to take on faith.
 
+Use the [companion labs](labs/README.md) alongside the chapters. Every lab gives
+you an intentionally incomplete starter, behavioral checks, adversarial
+mutations, and a verified reference solution. The checks grade observable
+invariants rather than requiring your code to look like the reference.
+
 - [Chapter 0: Andrea's first shift](ch00_first_shift/README.md) — run one
   complete piece of work and learn that `ACCEPTED` is a proved claim
 - [Chapter 1: The organization remembers](ch01_organization_remembers/README.md) —
@@ -77,3 +82,7 @@ later, separately-authorized act outside this book's own scope. See
 
 Run `python scripts/verify_curriculum.py` to check that all of that is actually
 present and that the chapters' imports still work.
+
+Run `python scripts/verify_book_labs.py` to execute all companion reference
+solutions twice from fresh roots and compare their observations with the
+checked-in expected results.

--- a/book/labs/README.md
+++ b/book/labs/README.md
@@ -1,0 +1,94 @@
+# Companion labs
+
+These labs turn each chapter into a small, executable experiment faithfully
+reduced from the real Sovereign Agent mechanisms. They are not alternative
+implementations of the production system. Each lab maps its reduced mechanism
+to exact production symbols and tests, then asks the learner to make its
+observable invariants hold.
+
+There is one directory for every chapter, with the same directory name as the
+chapter. Every directory contains:
+
+- `README.md`: the challenge and its production connection;
+- `lab.json`: machine-readable production source and test references;
+- `starter.py`: the learner's incomplete implementation;
+- `solution.py`: the reference implementation;
+- `check.py`: behavioral assertions shared by starter and solution; and
+- `expected.json`: the deterministic observations from a correct solution.
+
+Run the complete companion-lab gate from the repository root:
+
+```console
+python scripts/verify_book_labs.py
+```
+
+The gate intentionally runs the reference solution twice, each time with a
+new temporary root. This catches examples that depend on leftover state or
+produce nondeterministic observations. It also confirms that the starter fails
+at the intended learning seam rather than accidentally behaving like another
+solution.
+
+## Author contract
+
+`starter.py` and `solution.py` must expose:
+
+```python
+def exercise(root: Path) -> dict[str, object]: ...
+```
+
+The starter sets `STUDENT_TODO = True`, and its `exercise` raises
+`NotImplementedError`. It also contains at least three distinct, numbered
+implementation seams in the exact form `# TODO(1):`, `# TODO(2):`, and so on.
+At least one top-level helper function or class besides `exercise` must give
+the learner a meaningful decomposition to complete; a blank one-function
+shell is not a lab. The solution sets `STUDENT_TODO = False`.
+
+`check.py` must expose:
+
+```python
+def check(target_module: object, root: Path) -> dict[str, object]: ...
+```
+
+The checker calls `target_module.exercise(root)`, asserts the behavior the
+student is meant to build, and returns a JSON-compatible dictionary of stable
+observations. It must not special-case the reference solution. Its result for
+the solution must equal `expected.json` exactly.
+
+Each lab README must contain these second-level headings:
+
+- `## Challenge`
+- `## Production map`
+- `## Run it`
+- `## Break it`
+- `## Explain it back`
+
+`lab.json` uses schema version 1:
+
+```json
+{
+  "schema_version": 1,
+  "chapter": "ch00_first_shift",
+  "title": "Trace the first shift",
+  "production_sources": [
+    "src/sovereign_agent/organization.py:Organization.accept"
+  ],
+  "production_tests": [
+    "tests/test_control_plane.py::test_a_named_behavior"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}
+```
+
+Every production source is a repo-relative Python file followed by a class,
+function, assignment, or qualified class member that actually exists in that
+file. Production test nodes must name an existing test function (or
+`Class::test_method`) in an existing file below `tests/`. `entrypoint` is
+exactly `exercise`, and `expected` is exactly `expected.json`. Absolute paths, `..`
+traversal, and symlink escapes are rejected. This makes every “production
+map” inspectable rather than merely a claim in prose.
+
+Keep outputs semantic and portable: report identifiers, states, counts, and
+boolean invariants, not temporary paths, timestamps, random IDs, process IDs,
+or platform-specific exception text. Use only the Python standard library in
+lab infrastructure; exercising the installed project package is expected.

--- a/book/labs/ch00_first_shift/README.md
+++ b/book/labs/ch00_first_shift/README.md
@@ -1,0 +1,28 @@
+# Lab 00 — Trace a governed result
+
+## Challenge
+
+Build a miniature execution trace in which a worker report is only a proposal. A result may become accepted only after the ledger contains an assignment, durable evidence, an independent review, and a principal acceptance. Persist the trace as JSON so you can inspect the exact data that supports the final claim.
+
+## Production map
+
+This lab compresses the control flow in `Organization.run_assignment`, `Organization.verify_outcome`, `Organization.review`, and `Organization.accept`. The real implementation has richer records and SQLite transactions; the same distinction remains: “the provider said completed” is not evidence that the governed outcome is true.
+
+## Run it
+
+Copy the starter before editing, then run this lab's checker against your copy:
+
+```bash
+cp starter.py work.py
+python -c 'from pathlib import Path; import check, work; print(check.check(work, Path(".lab-run")))'
+```
+
+Implement `exercise(root)` in `work.py`, then compare its observations with `expected.json`. Your function must be safe to run twice against the same root.
+
+## Break it
+
+Delete the evidence event while leaving the worker's `completed` report intact. Your acceptance calculation must become false. Then reorder review before evidence and make the trace reject that ordering.
+
+## Explain it back
+
+Explain which record answers each question: Who was assigned? What did the worker claim? What fact was observed? Who reviewed it? Who accepted it? Why can no one record answer all five questions honestly?

--- a/book/labs/ch00_first_shift/check.py
+++ b/book/labs/ch00_first_shift/check.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    result = target_module.exercise(root)
+    trace_path = root / "trace.json"
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    expected_digest = hashlib.sha256(
+        json.dumps(trace["observed"], sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    kinds = [event["kind"] for event in trace["events"]]
+    # The deliberately naive policy accepts the provider's self-report. The
+    # governed policy below requires the independent records as well.
+    assert result["naive_provider_claim_accepted"] is True
+    assert result["governed_trace_accepted"] is True
+    assert result["event_order"] == kinds
+    assert result["evidence_digest"] == expected_digest
+    assert kinds.index("evidence.recorded") < kinds.index("review.approved")
+    assert kinds.index("review.approved") < kinds.index("outcome.accepted")
+    actors = {
+        trace["events"][0]["actor"],
+        trace["events"][3]["actor"],
+        trace["events"][4]["actor"],
+    }
+    assert len(actors) == 3
+    return {
+        "accepted_only_with_full_trace": True,
+        "independent_actors": 3,
+        "ordered_stages": len(kinds),
+        "provider_report_is_not_proof": True,
+    }

--- a/book/labs/ch00_first_shift/expected.json
+++ b/book/labs/ch00_first_shift/expected.json
@@ -1,0 +1,6 @@
+{
+  "accepted_only_with_full_trace": true,
+  "independent_actors": 3,
+  "ordered_stages": 5,
+  "provider_report_is_not_proof": true
+}

--- a/book/labs/ch00_first_shift/lab.json
+++ b/book/labs/ch00_first_shift/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch00_first_shift",
+  "title": "Trace a governed result",
+  "production_sources": [
+    "src/sovereign_agent/organization.py:Organization.run_assignment",
+    "src/sovereign_agent/organization.py:Organization.verify_outcome",
+    "src/sovereign_agent/organization.py:Organization.review",
+    "src/sovereign_agent/organization.py:Organization.accept"
+  ],
+  "production_tests": [
+    "tests/test_acceptance_falsification.py::test_absent_provider_report_is_refused",
+    "tests/test_acceptance_falsification.py::test_refuses_when_no_review_record_exists",
+    "tests/test_acceptance_falsification.py::test_operator_cannot_accept_its_own_work"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch00_first_shift/solution.py
+++ b/book/labs/ch00_first_shift/solution.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Show why a provider report is a proposal, not an acceptance decision."""
+    root.mkdir(parents=True, exist_ok=True)
+    observed = {"sku": "SKU-TEA", "on_hand": 8, "reorder_point": 5}
+    evidence_digest = hashlib.sha256(_canonical(observed)).hexdigest()
+    events = [
+        {"kind": "assignment.created", "actor": "operator-course"},
+        {"kind": "provider.reported", "status": "completed"},
+        {"kind": "evidence.recorded", "success": True, "digest": evidence_digest},
+        {"kind": "review.approved", "actor": "sparring-course"},
+        {"kind": "outcome.accepted", "actor": "principal-human"},
+    ]
+    (root / "trace.json").write_text(
+        json.dumps({"observed": observed, "events": events}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    kinds = [str(event["kind"]) for event in events]
+    provider_only = "provider.reported" in kinds
+    required = {
+        "assignment.created",
+        "evidence.recorded",
+        "review.approved",
+        "outcome.accepted",
+    }
+    governed_actors = {
+        events[0]["actor"],
+        events[3]["actor"],
+        events[4]["actor"],
+    }
+    independent_actors = len(governed_actors) == 3
+    return {
+        "naive_provider_claim_accepted": provider_only,
+        "governed_trace_accepted": required.issubset(kinds) and independent_actors,
+        "event_order": kinds,
+        "evidence_digest": evidence_digest,
+        "trace_file": "trace.json",
+    }

--- a/book/labs/ch00_first_shift/starter.py
+++ b/book/labs/ch00_first_shift/starter.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+STUDENT_TODO = True
+REQUIRED_STAGES = (
+    "assignment.created",
+    "evidence.recorded",
+    "review.approved",
+    "outcome.accepted",
+)
+
+
+def digest_observation(observed: dict[str, object]) -> str:
+    """Return a stable digest of exactly the fact that was checked."""
+    # TODO(1): Canonicalize the observation before hashing it.
+    encoded = json.dumps(observed, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def actors_are_independent(actor_ids: list[str]) -> bool:
+    """Decide whether assignment, review, and acceptance use distinct actors."""
+    # TODO(2): Compare cardinality after deduplication; pairwise chains are insufficient.
+    return len(set(actor_ids)) == len(actor_ids)
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Create and validate a durable authority/data trace."""
+    # TODO(3): Persist an ordered trace under root and reject a provider-only claim.
+    raise NotImplementedError("Build the assignment -> evidence -> review -> acceptance trace")

--- a/book/labs/ch01_organization_remembers/README.md
+++ b/book/labs/ch01_organization_remembers/README.md
@@ -1,0 +1,28 @@
+# Lab 01 — Keep authority in the ledger
+
+## Challenge
+
+Use SQLite as the authoritative ledger and a JSON file as a disposable projection. Demonstrate three properties: a failed transaction leaves no partial fact, a pure verifier detects projection drift without repairing it, and an explicit reconciliation regenerates the projection from the ledger.
+
+## Production map
+
+`Database.transaction` owns commit and rollback. `render_outcome` computes expected bytes without writing, while `project_outcome` performs the write. That separation prevents a verifier from “checking” drift by silently erasing it.
+
+## Run it
+
+Copy the starter before editing, then run this lab's checker against your copy:
+
+```bash
+cp starter.py work.py
+python -c 'from pathlib import Path; import check, work; print(check.check(work, Path(".lab-run")))'
+```
+
+Implement `exercise(root)` in `work.py` and use only files under the supplied root. The checker runs it twice: observations must remain identical and the database must contain one authoritative outcome, not duplicates.
+
+## Break it
+
+Move projection writing inside the verifier and observe how the drift check becomes a liar. Then remove the transaction around the deliberately failing insert and inspect the orphaned row.
+
+## Explain it back
+
+Why is the Markdown or JSON projection useful but not authoritative? Describe the different jobs of rollback, pure verification, and reconciliation.

--- a/book/labs/ch01_organization_remembers/check.py
+++ b/book/labs/ch01_organization_remembers/check.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    result = target_module.exercise(root)
+    repeated = target_module.exercise(root)
+    assert result == {
+        "rollback_removed_partial_fact": True,
+        "drift_detected": True,
+        "verifier_was_pure": True,
+        "reconciled": True,
+        "ledger_rows": 1,
+        "authoritative_state": "ACTIVE",
+    }
+    assert repeated == result
+    projection = json.loads((root / "outcome.json").read_text(encoding="utf-8"))
+    with sqlite3.connect(root / "ledger.db") as connection:
+        rows = connection.execute("SELECT id, state FROM outcomes").fetchall()
+    assert rows == [("out-1", "ACTIVE")]
+    assert projection == {"id": "out-1", "state": "ACTIVE"}
+    return {
+        "drift_was_observed_before_repair": True,
+        "projection_matches_ledger_after_reconcile": True,
+        "rollback_orphans": 0,
+    }

--- a/book/labs/ch01_organization_remembers/expected.json
+++ b/book/labs/ch01_organization_remembers/expected.json
@@ -1,0 +1,5 @@
+{
+  "drift_was_observed_before_repair": true,
+  "projection_matches_ledger_after_reconcile": true,
+  "rollback_orphans": 0
+}

--- a/book/labs/ch01_organization_remembers/lab.json
+++ b/book/labs/ch01_organization_remembers/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch01_organization_remembers",
+  "title": "Keep authority in the ledger",
+  "production_sources": [
+    "src/sovereign_agent/database.py:Database.transaction",
+    "src/sovereign_agent/governance.py:render_outcome",
+    "src/sovereign_agent/governance.py:project_outcome",
+    "src/sovereign_agent/files.py:atomic_write"
+  ],
+  "production_tests": [
+    "tests/test_persistence.py::test_rollback_after_inventory_write_leaves_nothing_behind",
+    "tests/test_persistence.py::test_events_reject_update_and_delete",
+    "tests/test_verifier_scripts.py::test_projection_verification_is_pure"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch01_organization_remembers/solution.py
+++ b/book/labs/ch01_organization_remembers/solution.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+def _render(row: sqlite3.Row) -> bytes:
+    return (json.dumps({"id": row["id"], "state": row["state"]}, sort_keys=True) + "\n").encode()
+
+
+def exercise(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    database = root / "ledger.db"
+    projection = root / "outcome.json"
+    connection = sqlite3.connect(database)
+    connection.row_factory = sqlite3.Row
+    connection.execute(
+        "CREATE TABLE IF NOT EXISTS outcomes (id TEXT PRIMARY KEY, state TEXT NOT NULL)"
+    )
+
+    rolled_back = False
+    try:
+        with connection:
+            connection.execute("INSERT INTO outcomes VALUES ('out-failed', 'ACTIVE')")
+            raise RuntimeError("simulated fault between writes")
+    except RuntimeError:
+        rolled_back = (
+            connection.execute("SELECT COUNT(*) FROM outcomes WHERE id = 'out-failed'").fetchone()[
+                0
+            ]
+            == 0
+        )
+
+    with connection:
+        connection.execute("INSERT OR IGNORE INTO outcomes VALUES ('out-1', 'ACTIVE')")
+    row = connection.execute("SELECT id, state FROM outcomes WHERE id = 'out-1'").fetchone()
+    expected = _render(row)
+    projection.write_bytes(expected)
+    projection.write_text('{"id": "out-1", "state": "ACCEPTED"}\n', encoding="utf-8")
+
+    before_verify = projection.read_bytes()
+    drift_detected = before_verify != _render(row)
+    verifier_was_pure = projection.read_bytes() == before_verify
+    projection.write_bytes(_render(row))
+    reconciled = projection.read_bytes() == _render(row)
+    ledger_rows = connection.execute("SELECT COUNT(*) FROM outcomes").fetchone()[0]
+    connection.close()
+    return {
+        "rollback_removed_partial_fact": rolled_back,
+        "drift_detected": drift_detected,
+        "verifier_was_pure": verifier_was_pure,
+        "reconciled": reconciled,
+        "ledger_rows": ledger_rows,
+        "authoritative_state": "ACTIVE",
+    }

--- a/book/labs/ch01_organization_remembers/starter.py
+++ b/book/labs/ch01_organization_remembers/starter.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = True
+OUTCOME_SCHEMA = "CREATE TABLE IF NOT EXISTS outcomes (id TEXT PRIMARY KEY, state TEXT NOT NULL)"
+
+
+def render_projection(record: dict[str, str]) -> bytes:
+    """Render expected projection bytes without touching the filesystem."""
+    # TODO(1): Keep rendering deterministic so verification can compare bytes.
+    return (json.dumps(record, sort_keys=True) + "\n").encode("utf-8")
+
+
+def open_ledger(path: Path) -> sqlite3.Connection:
+    """Open the authoritative ledger with named-column access."""
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    # TODO(2): Apply OUTCOME_SCHEMA idempotently without deleting prior authority.
+    return connection
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Separate an authoritative ledger from a derived projection."""
+    # TODO(3): Prove rollback, pure drift detection, and explicit reconciliation.
+    raise NotImplementedError("Implement rollback, pure verification, and reconciliation")

--- a/book/labs/ch02_work_needs_governance/README.md
+++ b/book/labs/ch02_work_needs_governance/README.md
@@ -1,0 +1,28 @@
+# Lab 02 — Try to forge acceptance
+
+## Challenge
+
+Implement a small acceptance verifier that requires several independent layers: the outcome condition is currently true, evidence describes the current state, evidence is bound to this SOW and its execution, and that execution produced the effect the SOW declared. Run a mutation battery against stale, borrowed, and noncausal proof.
+
+## Production map
+
+The exercise mirrors the proof joins enforced by `Organization.verify_sow`, `Organization.review`, and `Organization.accept`. Production evidence carries state digests and exact SOW/execution bindings; effects show contribution rather than merely repeating that the desired condition happens to be true.
+
+## Run it
+
+Copy the starter before editing, then run this lab's checker against your copy:
+
+```bash
+cp starter.py work.py
+python -c 'from pathlib import Path; import check, work; print(check.check(work, Path(".lab-run")))'
+```
+
+Implement `exercise(root)` in `work.py`. Return deterministic verdicts for the valid proof and all three mutations. Persist the cases beneath the supplied root so you can compare the records field by field.
+
+## Break it
+
+First write the naive rule `accept = condition_true`. Watch every forged case pass. Add the checks one at a time and record which lie each layer eliminates. Finally change the order of the checks and decide which refusal gives the learner the most useful next action.
+
+## Explain it back
+
+Explain why fresh evidence can still be borrowed, correctly bound evidence can still be stale, and a true outcome can still be noncausal. What distinct claim does each layer prove?

--- a/book/labs/ch02_work_needs_governance/check.py
+++ b/book/labs/ch02_work_needs_governance/check.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    result = target_module.exercise(root)
+    expected_verdicts = {
+        "valid": "accepted",
+        "stale": "stale_evidence",
+        "borrowed": "borrowed_evidence",
+        "noncausal": "noncausal_execution",
+    }
+    assert result["layered_verdicts"] == expected_verdicts
+    assert result["naive_condition_only_accepts"] == ["borrowed", "noncausal", "stale", "valid"]
+    assert result["rejected_mutations"] == 3
+    cases = json.loads((root / "proof-cases.json").read_text(encoding="utf-8"))
+    assert cases["borrowed"]["evidence_sow"] != cases["borrowed"]["sow"]
+    assert cases["noncausal"]["condition_true"] is True
+    assert cases["stale"]["current_state"] != cases["valid"]["current_state"]
+    return {
+        "valid_proof_accepted": True,
+        "stale_proof_rejected": True,
+        "borrowed_proof_rejected": True,
+        "noncausal_proof_rejected": True,
+    }

--- a/book/labs/ch02_work_needs_governance/expected.json
+++ b/book/labs/ch02_work_needs_governance/expected.json
@@ -1,0 +1,6 @@
+{
+  "borrowed_proof_rejected": true,
+  "noncausal_proof_rejected": true,
+  "stale_proof_rejected": true,
+  "valid_proof_accepted": true
+}

--- a/book/labs/ch02_work_needs_governance/lab.json
+++ b/book/labs/ch02_work_needs_governance/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch02_work_needs_governance",
+  "title": "Try to forge acceptance",
+  "production_sources": [
+    "src/sovereign_agent/organization.py:Organization.verify_sow",
+    "src/sovereign_agent/organization.py:Organization.review",
+    "src/sovereign_agent/organization.py:Organization.accept",
+    "src/sovereign_agent/evidence.py:digest_payload"
+  ],
+  "production_tests": [
+    "tests/test_acceptance_falsification.py::test_refuses_stale_evidence_even_when_checks_still_pass",
+    "tests/test_causal_binding.py::test_one_sow_cannot_borrow_another_sows_proof",
+    "tests/test_causal_binding.py::test_condition_true_but_no_effects_exist_at_all_is_refused"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch02_work_needs_governance/solution.py
+++ b/book/labs/ch02_work_needs_governance/solution.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+def _digest(state: dict[str, int]) -> str:
+    payload = json.dumps(state, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _verify(case: dict[str, object]) -> str:
+    if not case["condition_true"]:
+        return "condition_false"
+    if case["evidence_digest"] != _digest(case["current_state"]):
+        return "stale_evidence"
+    if case["evidence_sow"] != case["sow"] or case["evidence_execution"] != case["execution"]:
+        return "borrowed_evidence"
+    if case["required_effect"] not in case["effects_by_execution"].get(case["execution"], []):
+        return "noncausal_execution"
+    return "accepted"
+
+
+def exercise(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    state = {"on_hand": 8, "reorder_point": 5}
+    valid: dict[str, object] = {
+        "condition_true": True,
+        "current_state": state,
+        "evidence_digest": _digest(state),
+        "sow": "sow-a",
+        "execution": "asg-a",
+        "evidence_sow": "sow-a",
+        "evidence_execution": "asg-a",
+        "required_effect": "replenishment",
+        "effects_by_execution": {"asg-a": ["replenishment"]},
+    }
+    cases = {
+        "valid": valid,
+        "stale": {**valid, "current_state": {"on_hand": 9, "reorder_point": 5}},
+        "borrowed": {**valid, "evidence_sow": "sow-b", "evidence_execution": "asg-b"},
+        "noncausal": {**valid, "effects_by_execution": {"asg-older": ["replenishment"]}},
+    }
+    verdicts = {name: _verify(case) for name, case in cases.items()}
+    (root / "proof-cases.json").write_text(
+        json.dumps(cases, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return {
+        "naive_condition_only_accepts": sorted(cases),
+        "layered_verdicts": verdicts,
+        "rejected_mutations": sum(verdict != "accepted" for verdict in verdicts.values()),
+    }

--- a/book/labs/ch02_work_needs_governance/starter.py
+++ b/book/labs/ch02_work_needs_governance/starter.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import NamedTuple
+
+STUDENT_TODO = True
+
+
+class ProofBinding(NamedTuple):
+    sow_id: str
+    execution_id: str
+    required_effect: str
+
+
+def digest_state(state: dict[str, int]) -> str:
+    """Digest the complete state observed by a check."""
+    # TODO(1): Use canonical JSON so insertion order cannot change the digest.
+    payload = json.dumps(state, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def verify_case(case: dict[str, object], binding: ProofBinding) -> str:
+    """Return accepted or the first actionable rejection reason."""
+    # TODO(2): Reject stale state and evidence borrowed from another binding.
+    # TODO(3): Require this execution—not an older sibling—to carry the declared effect.
+    raise NotImplementedError("Implement the layered proof joins")
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Reject stale, borrowed, and noncausal evidence independently."""
+    raise NotImplementedError("Implement the layered acceptance verifier and mutation battery")

--- a/book/labs/ch03_actor_is_not_a_model/README.md
+++ b/book/labs/ch03_actor_is_not_a_model/README.md
@@ -1,0 +1,28 @@
+# Lab 03 — Change the provider, not the actor
+
+## Challenge
+
+Use the real production `Actor`, `ROLE_AUTHORITY`, and provider capability contract. Rebind an actor's mutable `provider` field while proving that its id, role, and descriptive authority list remain unchanged. Then prove that editing that list cannot self-grant role authority and that an adapter must refuse an unproven capability.
+
+## Production map
+
+Production stores `provider` directly on `Actor`; there is no separate frozen binding object. `Organization.rebind_actor` changes that field under ruling authority. Authorization is decided by `ROLE_AUTHORITY`, while `require_proven` gates provider invocation using live probe evidence.
+
+## Run it
+
+Copy the starter before editing, then run this lab's checker against your copy:
+
+```bash
+cp starter.py work.py
+python -c 'from pathlib import Path; import check, work; print(check.check(work, Path(".lab-run")))'
+```
+
+Implement `exercise(root)` in `work.py` using the installed `sovereign_agent` package. No provider executable or credential is needed: construct `ProviderCapabilities` values as offline probe results and call the same fail-closed contract used by adapters.
+
+## Break it
+
+Append `accept` to the actor's own authority list and verify the operator still cannot accept. Next request streaming from a capability record that cannot prove streaming. Finally flip only that proven bit and observe the request pass without changing actor identity.
+
+## Explain it back
+
+Separate four nouns precisely: actor id, role, provider, and capability. Which can change during a rebind? Which grants organizational authority? Which describes what a particular CLI invocation can safely do?

--- a/book/labs/ch03_actor_is_not_a_model/check.py
+++ b/book/labs/ch03_actor_is_not_a_model/check.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    result = target_module.exercise(root)
+    assert result["actor_id"] == "operator-course"
+    assert result["provider_after_rebind"] == "claude"
+    assert result["identity_role_authority_preserved"] is True
+    assert result["self_grant_blocked"] is True
+    assert result["operator_role_actions"] == ["read", "report", "run_checks", "write_workspace"]
+    assert result["unproven_streaming_refusal"] == "capability_refusal"
+    assert result["proven_streaming_allowed"] is True
+    return {
+        "actor_identity_survived_rebind": True,
+        "authority_came_from_role_table": True,
+        "unproven_capability_refused": True,
+        "proven_capability_allowed": True,
+    }

--- a/book/labs/ch03_actor_is_not_a_model/expected.json
+++ b/book/labs/ch03_actor_is_not_a_model/expected.json
@@ -1,0 +1,6 @@
+{
+  "actor_identity_survived_rebind": true,
+  "authority_came_from_role_table": true,
+  "proven_capability_allowed": true,
+  "unproven_capability_refused": true
+}

--- a/book/labs/ch03_actor_is_not_a_model/lab.json
+++ b/book/labs/ch03_actor_is_not_a_model/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch03_actor_is_not_a_model",
+  "title": "Change the provider, not the actor",
+  "production_sources": [
+    "src/sovereign_agent/models.py:Actor",
+    "src/sovereign_agent/organization.py:Organization.rebind_actor",
+    "src/sovereign_agent/policy.py:ROLE_AUTHORITY",
+    "src/sovereign_agent/providers/base.py:require_proven"
+  ],
+  "production_tests": [
+    "tests/test_actors_and_mailbox.py::test_rebinding_the_provider_preserves_identity_and_authority",
+    "tests/test_actors_and_mailbox.py::test_an_actor_cannot_expand_its_own_authority",
+    "tests/test_providers.py::test_unproven_streaming_is_refused"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch03_actor_is_not_a_model/solution.py
+++ b/book/labs/ch03_actor_is_not_a_model/solution.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sovereign_agent.errors import Refusal
+from sovereign_agent.models import Actor, Role
+from sovereign_agent.policy import ROLE_AUTHORITY, require_authority
+from sovereign_agent.providers.base import InvocationRequest, ProviderCapabilities, require_proven
+
+STUDENT_TODO = False
+
+
+def exercise(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    actor = Actor(
+        id="operator-course",
+        role=Role.OPERATOR,
+        provider="scripted",
+        authority=["read", "write_workspace", "run_checks", "report"],
+    )
+    before = (actor.id, actor.role.value, tuple(actor.authority))
+    actor.provider = "claude"
+    after = (actor.id, actor.role.value, tuple(actor.authority))
+
+    actor.authority.append("accept")
+    self_grant_blocked = False
+    try:
+        require_authority(actor.role, "accept")
+    except Refusal:
+        self_grant_blocked = True
+
+    request = InvocationRequest(workspace=root, output=root / "report.json", prompt="restock")
+    unproven = ProviderCapabilities(available=True, print_mode=True, streaming=False)
+    capability_category = ""
+    try:
+        require_proven(
+            unproven,
+            request,
+            missing="offline-provider",
+            inspect="probe evidence",
+            next_command="choose a proven adapter",
+        )
+    except Refusal as refusal:
+        capability_category = refusal.category
+    proven = ProviderCapabilities(available=True, print_mode=True, streaming=True)
+    require_proven(
+        proven,
+        request,
+        missing="offline-provider",
+        inspect="probe evidence",
+        next_command="choose a proven adapter",
+    )
+    return {
+        "actor_id": actor.id,
+        "provider_after_rebind": actor.provider,
+        "identity_role_authority_preserved": before == after,
+        "self_grant_blocked": self_grant_blocked,
+        "operator_role_actions": sorted(ROLE_AUTHORITY[Role.OPERATOR]),
+        "unproven_streaming_refusal": capability_category,
+        "proven_streaming_allowed": True,
+    }

--- a/book/labs/ch03_actor_is_not_a_model/starter.py
+++ b/book/labs/ch03_actor_is_not_a_model/starter.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sovereign_agent.models import Actor, Role
+from sovereign_agent.providers.base import InvocationRequest, ProviderCapabilities
+
+STUDENT_TODO = True
+REQUESTED_ACTION = "accept"
+
+
+def actor_identity(actor: Actor) -> tuple[str, Role, tuple[str, ...]]:
+    """Capture the governed fields that a provider rebind must preserve."""
+    return actor.id, actor.role, tuple(actor.authority)
+
+
+def offline_request(root: Path) -> tuple[InvocationRequest, ProviderCapabilities]:
+    """Build a request and deliberately insufficient offline probe result."""
+    request = InvocationRequest(workspace=root, output=root / "report.json", prompt="restock")
+    capabilities = ProviderCapabilities(available=True, print_mode=True, streaming=False)
+    return request, capabilities
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Rebind a real Actor and gate an invocation with proven capabilities."""
+    # TODO(1): Rebind only Actor.provider and compare actor_identity before/after.
+    # TODO(2): Prove editing Actor.authority cannot expand ROLE_AUTHORITY.
+    # TODO(3): Refuse offline_request until streaming has actually been proven.
+    raise NotImplementedError("Use Actor, ROLE_AUTHORITY, and require_proven")

--- a/book/labs/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/labs/ch04_work_stays_inside_its_boundary/README.md
@@ -1,0 +1,31 @@
+## Challenge
+
+An actor may write inside its assigned workspace, but a filename is not a boundary. Build a resolved-path guard that refuses absolute paths, `..` escapes, and a symlink whose target is outside the workspace. Then write a canonical receipt plus its SHA-256 sidecar and compare before/after snapshots of the organization tree.
+
+Your result must distinguish prevention from detection. The path guard prevents a named output from escaping. The snapshot only detects changes in its declared scope; it deliberately excludes the run workspace and the SQLite ledger.
+
+## Production map
+
+- `src/sovereign_agent/workspace.py:safe_join` resolves the root and candidate before checking containment.
+- `src/sovereign_agent/workspace.py:snapshot_boundary` and `diff_boundary` report detected changes and carry their limited scope.
+- `src/sovereign_agent/execution.py:write_receipt` writes canonical evidence and a digest sidecar.
+- The tests named in `lab.json` exercise traversal, symlink, boundary-detection, and ledger-blind-spot cases.
+
+## Run it
+
+From this directory, run:
+
+```console
+cp starter.py work.py
+python check.py work.py /tmp/sa-ch04-lab
+```
+
+Fill the numbered TODO seams in `work.py` and rerun the checker. Use `python check.py solution.py /tmp/sa-ch04-lab` only after attempting the repair. The checker creates no network traffic and may be rerun against the same root.
+
+## Break it
+
+First replace the resolved-path comparison with `str(candidate).startswith(str(root))`. Observe that a sibling such as `workspace-evil` or a symlink can pass a textual prefix check. Next hash `str(receipt)` instead of canonical JSON bytes; vary key insertion order and observe that logically equal receipts acquire different digests. Finally, remove the snapshot scope from the result and explain how a clean report becomes an overclaim.
+
+## Explain it back
+
+Why must containment be checked after symlink resolution? What fact does the digest prove, and what does it not authenticate? Why is `boundary_clean: true` weaker than “the actor touched nothing outside its workspace”? Name the two deliberately invisible locations in this lab.

--- a/book/labs/ch04_work_stays_inside_its_boundary/check.py
+++ b/book/labs/ch04_work_stays_inside_its_boundary/check.py
@@ -1,0 +1,36 @@
+"""Deterministic checker for the Chapter 4 companion lab."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    observed = target_module.exercise(root)
+    assert observed["naive_accepts_traversal"] is True
+    assert observed["repaired_refusals"] == ["absolute", "symlink", "traversal"]
+    assert observed["nested_output"] == "output/report.json"
+    assert observed["receipt_digest_matches"] is True
+    assert observed["boundary_changed"] == ["policy.txt"]
+    assert observed["boundary_scope"] == "organization_root_excluding_workspace_and_ledger"
+    assert observed["ledger_change_visible"] is False
+    return observed
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_ch04", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: python check.py TARGET.py ROOT")
+    print(json.dumps(check(_load(Path(sys.argv[1])), Path(sys.argv[2])), sort_keys=True, indent=2))

--- a/book/labs/ch04_work_stays_inside_its_boundary/expected.json
+++ b/book/labs/ch04_work_stays_inside_its_boundary/expected.json
@@ -1,0 +1,15 @@
+{
+  "boundary_changed": [
+    "policy.txt"
+  ],
+  "boundary_scope": "organization_root_excluding_workspace_and_ledger",
+  "ledger_change_visible": false,
+  "naive_accepts_traversal": true,
+  "nested_output": "output/report.json",
+  "receipt_digest_matches": true,
+  "repaired_refusals": [
+    "absolute",
+    "symlink",
+    "traversal"
+  ]
+}

--- a/book/labs/ch04_work_stays_inside_its_boundary/lab.json
+++ b/book/labs/ch04_work_stays_inside_its_boundary/lab.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "chapter": "ch04_work_stays_inside_its_boundary",
+  "title": "Hostile paths, durable receipts, and an honestly scoped boundary",
+  "production_sources": [
+    "src/sovereign_agent/workspace.py:safe_join",
+    "src/sovereign_agent/workspace.py:snapshot_boundary",
+    "src/sovereign_agent/workspace.py:diff_boundary",
+    "src/sovereign_agent/execution.py:write_receipt"
+  ],
+  "production_tests": [
+    "tests/test_workspace_lifecycle.py::test_traversal_deliverable_is_refused",
+    "tests/test_workspace_lifecycle.py::test_symlinked_child_inside_a_real_output_directory_cannot_be_written_through",
+    "tests/test_workspace_lifecycle.py::test_detects_write_outside_workspace",
+    "tests/test_workspace_lifecycle.py::test_boundary_report_does_not_see_a_real_database_write"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch04_work_stays_inside_its_boundary/solution.py
+++ b/book/labs/ch04_work_stays_inside_its_boundary/solution.py
@@ -1,0 +1,108 @@
+"""Reference solution for Chapter 4: constrain paths and qualify proof."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+STUDENT_TODO = False
+
+BOUNDARY_SCOPE = "organization_root_excluding_workspace_and_ledger"
+
+
+def _fresh(path: Path) -> None:
+    if path.exists() or path.is_symlink():
+        if path.is_symlink() or path.is_file():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
+    path.mkdir(parents=True)
+
+
+def _safe_join(root: Path, relative: str) -> Path:
+    if not relative.strip() or Path(relative).is_absolute():
+        raise ValueError("path must be a non-empty relative name")
+    resolved_root = root.resolve()
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError as error:
+        raise ValueError("path escapes workspace") from error
+    return candidate
+
+
+def _snapshot(org: Path, workspace: Path, ledger: Path) -> dict[str, str]:
+    org = org.resolve()
+    workspace = workspace.resolve()
+    ledger = ledger.resolve()
+    result: dict[str, str] = {}
+    for path in sorted(org.rglob("*")):
+        if not path.is_file():
+            continue
+        if path == ledger or path == workspace or workspace in path.parents:
+            continue
+        result[str(path.relative_to(org))] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+def _diff(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    names = set(before) | set(after)
+    return sorted(name for name in names if before.get(name) != after.get(name))
+
+
+def exercise(root: Path) -> dict[str, object]:
+    lab = root / "ch04"
+    _fresh(lab)
+    org = lab / "organization"
+    workspace = org / ".sovereign" / "runs" / "run-1"
+    ledger = org / ".sovereign" / "organization.db"
+    workspace.mkdir(parents=True)
+    ledger.write_text("ledger-v1", encoding="utf-8")
+    policy = org / "policy.txt"
+    policy.write_text("approved", encoding="utf-8")
+    outside = org / "private.txt"
+    outside.write_text("do not touch", encoding="utf-8")
+
+    # The naive guard reasons about spelling, not the filesystem object reached.
+    naive_candidate = workspace / ".." / ".." / ".." / "private.txt"
+    naive_accepts_traversal = str(naive_candidate).startswith(str(workspace))
+
+    link = workspace / "shortcut"
+    link.symlink_to(outside)
+    refused: list[str] = []
+    for label, name in (
+        ("traversal", "../../../private.txt"),
+        ("absolute", str(outside.resolve())),
+        ("symlink", "shortcut"),
+    ):
+        try:
+            _safe_join(workspace, name)
+        except ValueError:
+            refused.append(label)
+    nested = _safe_join(workspace, "output/report.json")
+    nested.parent.mkdir(parents=True)
+    nested.write_text('{"status":"completed"}', encoding="utf-8")
+
+    receipt = {"assignment_id": "asg_demo", "status": "completed", "units": 3}
+    receipt_bytes = json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()
+    receipt_path = workspace / "receipt.json"
+    receipt_path.write_bytes(receipt_bytes)
+    digest = hashlib.sha256(receipt_bytes).hexdigest()
+    (workspace / "receipt.json.sha256").write_text(digest + "\n", encoding="utf-8")
+
+    before = _snapshot(org, workspace, ledger)
+    policy.write_text("tampered", encoding="utf-8")
+    ledger.write_text("ledger-v2", encoding="utf-8")
+    changed = _diff(before, _snapshot(org, workspace, ledger))
+
+    return {
+        "naive_accepts_traversal": naive_accepts_traversal,
+        "repaired_refusals": sorted(refused),
+        "nested_output": str(nested.relative_to(workspace.resolve())),
+        "receipt_digest_matches": hashlib.sha256(receipt_path.read_bytes()).hexdigest() == digest,
+        "boundary_changed": changed,
+        "boundary_scope": BOUNDARY_SCOPE,
+        "ledger_change_visible": ".sovereign/organization.db" in changed,
+    }

--- a/book/labs/ch04_work_stays_inside_its_boundary/starter.py
+++ b/book/labs/ch04_work_stays_inside_its_boundary/starter.py
@@ -1,0 +1,37 @@
+"""Starter for Chapter 4's workspace-boundary lab."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+STUDENT_TODO = True
+BOUNDARY_SCOPE = "organization_root_excluding_workspace_and_ledger"
+
+
+def safe_join(root: Path, relative: str) -> Path:
+    """Return a resolved child of root, or refuse a hostile path."""
+    # TODO(1): Refuse empty and absolute names, then prove the resolved
+    # candidate is relative to the resolved root (including through symlinks).
+    raise NotImplementedError
+
+
+def snapshot(root: Path, excluded: tuple[Path, ...]) -> dict[str, str]:
+    """Hash the visible regular files below root by relative path."""
+    # TODO(2): Walk deterministically, omit each excluded path and its children,
+    # and SHA-256 the bytes of every remaining file.
+    raise NotImplementedError
+
+
+def changed_paths(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Return sorted added, removed, or content-changed paths."""
+    # TODO(3): Compare the union of path names, not only files present in both.
+    raise NotImplementedError
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Build the hostile-path, receipt-digest, and scoped-snapshot experiment."""
+    _ = hashlib.sha256  # The receipt digest must cover canonical JSON bytes.
+    # TODO(4): Assemble the naive failure and repaired observations required by
+    # check.py, and qualify the snapshot result with BOUNDARY_SCOPE.
+    raise NotImplementedError("Implement the Chapter 4 boundary experiment")

--- a/book/labs/ch05_authority_needs_a_fence/README.md
+++ b/book/labs/ch05_authority_needs_a_fence/README.md
@@ -1,0 +1,29 @@
+## Challenge
+
+Turn a durable mailbox claim into an exclusive, leased capability. Begin by reproducing the read-then-write race: two workers read `NEW`, then both write `CLAIMED` and both believe they won. Repair it with one conditional update, mint a monotonically increasing fencing token for every real takeover, and require the current token at completion.
+
+## Production map
+
+- `src/sovereign_agent/relay.py:claim` uses compare-and-set rather than a Python read followed by an unconditional write.
+- `src/sovereign_agent/relay.py:_mint_claim_token` shares the monotonic token sequence used for process leases.
+- `src/sovereign_agent/relay.py:complete` rejects a worker that resumes with an obsolete token.
+- The tests in `lab.json` cover exclusive claims, idempotent retry, takeover after expiry, and stale-token rejection.
+
+## Run it
+
+From this directory, run:
+
+```console
+cp starter.py work.py
+python check.py work.py /tmp/sa-ch05-lab
+```
+
+Fill the numbered TODO seams in `work.py`. Use `python check.py solution.py /tmp/sa-ch05-lab` only after attempting the repair. Use only the standard library; a rerun against the same root must produce the same JSON.
+
+## Break it
+
+Move the state predicate out of the `UPDATE` and into Python. Both contenders can now decide from the same stale read. Next reuse the old token when an expired lease is reclaimed by the same actor; the paused process and the replacement become indistinguishable. Finally, complete by owner alone and show the stale process overwriting the winner.
+
+## Explain it back
+
+Why is a lease owner insufficient without a token? Why does an unexpired retry return the same token, while an expired reclaim by that same actor must mint a larger one? Identify the exact SQL predicate that decides who owns authority.

--- a/book/labs/ch05_authority_needs_a_fence/check.py
+++ b/book/labs/ch05_authority_needs_a_fence/check.py
@@ -1,0 +1,37 @@
+"""Deterministic checker for the Chapter 5 companion lab."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    observed = target_module.exercise(root)
+    assert observed["naive_winners"] == 2
+    assert observed["cas_winners_before_expiry"] == 1
+    assert observed["unexpired_retry_same_token"] is True
+    assert observed["expired_takeover_won"] is True
+    assert observed["token_increased"] is True
+    assert observed["stale_completion_accepted"] is False
+    assert observed["current_completion_accepted"] is True
+    assert observed["final_state"] == "DONE"
+    return observed
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_ch05", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: python check.py TARGET.py ROOT")
+    print(json.dumps(check(_load(Path(sys.argv[1])), Path(sys.argv[2])), sort_keys=True, indent=2))

--- a/book/labs/ch05_authority_needs_a_fence/expected.json
+++ b/book/labs/ch05_authority_needs_a_fence/expected.json
@@ -1,0 +1,10 @@
+{
+  "cas_winners_before_expiry": 1,
+  "current_completion_accepted": true,
+  "expired_takeover_won": true,
+  "final_state": "DONE",
+  "naive_winners": 2,
+  "stale_completion_accepted": false,
+  "token_increased": true,
+  "unexpired_retry_same_token": true
+}

--- a/book/labs/ch05_authority_needs_a_fence/lab.json
+++ b/book/labs/ch05_authority_needs_a_fence/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch05_authority_needs_a_fence",
+  "title": "Mailbox compare-and-set, leases, and fencing tokens",
+  "production_sources": [
+    "src/sovereign_agent/relay.py:claim",
+    "src/sovereign_agent/relay.py:_mint_claim_token",
+    "src/sovereign_agent/relay.py:complete"
+  ],
+  "production_tests": [
+    "tests/test_actors_and_mailbox.py::test_claim_lease_is_exclusive",
+    "tests/test_fencing.py::test_same_owner_unexpired_claim_is_idempotent_same_token",
+    "tests/test_fencing.py::test_same_owner_expired_claim_mints_a_fresh_token_fu4_1",
+    "tests/test_fencing.py::test_complete_with_a_stale_token_is_refused"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch05_authority_needs_a_fence/solution.py
+++ b/book/labs/ch05_authority_needs_a_fence/solution.py
@@ -1,0 +1,89 @@
+"""Reference solution for Chapter 5: authority is a current fenced lease."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+def _fresh(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True)
+
+
+def _mint(connection: sqlite3.Connection) -> int:
+    cursor = connection.execute("INSERT INTO tokens DEFAULT VALUES")
+    assert cursor.lastrowid is not None
+    return int(cursor.lastrowid)
+
+
+def _claim(connection: sqlite3.Connection, actor: str, now: int) -> tuple[bool, int]:
+    row = connection.execute(
+        "SELECT state, owner, expires_at, token FROM messages WHERE id = 'msg-1'"
+    ).fetchone()
+    assert row is not None
+    state, owner, expires_at, current_token = row
+    if state == "CLAIMED" and owner == actor and expires_at > now:
+        return True, int(current_token)
+    token = _mint(connection)
+    cursor = connection.execute(
+        "UPDATE messages SET state='CLAIMED', owner=?, expires_at=?, token=? "
+        "WHERE id='msg-1' AND (state='NEW' OR (state='CLAIMED' AND expires_at<=?))",
+        (actor, now + 10, token, now),
+    )
+    if cursor.rowcount != 1:
+        connection.rollback()
+        return False, token
+    connection.commit()
+    return True, token
+
+
+def _complete(connection: sqlite3.Connection, actor: str, token: int) -> bool:
+    cursor = connection.execute(
+        "UPDATE messages SET state='DONE' "
+        "WHERE id='msg-1' AND state='CLAIMED' AND owner=? AND token=?",
+        (actor, token),
+    )
+    connection.commit()
+    return cursor.rowcount == 1
+
+
+def exercise(root: Path) -> dict[str, object]:
+    lab = root / "ch05"
+    _fresh(lab)
+    connection = sqlite3.connect(lab / "mailbox.db")
+    connection.executescript(
+        "CREATE TABLE tokens(id INTEGER PRIMARY KEY AUTOINCREMENT);"
+        "CREATE TABLE messages(id TEXT PRIMARY KEY, state TEXT NOT NULL, owner TEXT, "
+        "expires_at INTEGER, token INTEGER);"
+        "INSERT INTO messages VALUES('msg-1', 'NEW', NULL, NULL, NULL);"
+    )
+
+    # Naive interleaving: both decisions are made from the same pre-write fact.
+    first_read = connection.execute("SELECT state FROM messages WHERE id='msg-1'").fetchone()[0]
+    second_read = connection.execute("SELECT state FROM messages WHERE id='msg-1'").fetchone()[0]
+    naive_winners = int(first_read == "NEW") + int(second_read == "NEW")
+
+    won_a, token_a = _claim(connection, "actor-a", now=0)
+    won_b, _unused = _claim(connection, "actor-b", now=0)
+    retry_won, retry_token = _claim(connection, "actor-a", now=1)
+    takeover_won, token_b = _claim(connection, "actor-b", now=11)
+    stale_completed = _complete(connection, "actor-a", token_a)
+    current_completed = _complete(connection, "actor-b", token_b)
+    final_state = connection.execute("SELECT state FROM messages WHERE id='msg-1'").fetchone()[0]
+    connection.close()
+
+    return {
+        "naive_winners": naive_winners,
+        "cas_winners_before_expiry": int(won_a) + int(won_b),
+        "unexpired_retry_same_token": retry_won and retry_token == token_a,
+        "expired_takeover_won": takeover_won,
+        "token_increased": token_b > token_a,
+        "stale_completion_accepted": stale_completed,
+        "current_completion_accepted": current_completed,
+        "final_state": final_state,
+    }

--- a/book/labs/ch05_authority_needs_a_fence/starter.py
+++ b/book/labs/ch05_authority_needs_a_fence/starter.py
@@ -1,0 +1,36 @@
+"""Starter for Chapter 5's durable mailbox and fencing lab."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = True
+LEASE_TICKS = 10
+
+
+def mint_token(connection: sqlite3.Connection) -> int:
+    """Mint the next durable, monotonically increasing authority token."""
+    # TODO(1): Insert into a sequence table and return its integer primary key.
+    raise NotImplementedError
+
+
+def claim(connection: sqlite3.Connection, actor: str, now: int) -> tuple[bool, int | None]:
+    """Claim NEW or expired work with one compare-and-set transition."""
+    # TODO(2): Preserve an unexpired same-owner token, otherwise mint inside a
+    # transaction and UPDATE only NEW or expired rows. Roll back a lost claim.
+    raise NotImplementedError
+
+
+def complete(connection: sqlite3.Connection, actor: str, token: int) -> bool:
+    """Complete only while actor and fencing token still match durable state."""
+    # TODO(3): Put state, owner, and token in the UPDATE predicate; rowcount is
+    # the authority verdict.
+    raise NotImplementedError
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Reproduce the race, then repair it with CAS and fencing."""
+    # TODO(4): Create the SQLite schema, force the naive double-read race, then
+    # report CAS winners, retry/takeover tokens, and both completion attempts.
+    raise NotImplementedError("Implement the Chapter 5 mailbox experiment")

--- a/book/labs/ch06_the_organization_recovers/README.md
+++ b/book/labs/ch06_the_organization_recovers/README.md
@@ -1,0 +1,29 @@
+## Challenge
+
+A killed worker cannot report its own death, and an output file is not proof of completion. Build a supervisor recovery transaction that records a terminal `FAILED` assignment and `worker_lost` receipt while clearing the current execution fence. Make two supervisors contend for the same abandoned attempt and prove that exactly one wins.
+
+## Production map
+
+- `src/sovereign_agent/supervisor.py:recover_abandoned_assignments` never guesses success and uses the current attempt as its compare-and-set guard.
+- `src/sovereign_agent/fencing.py:release_execution_attempt` clears the fence inside the same transaction as terminal state.
+- `src/sovereign_agent/supervisor.py:tick` is a deterministic reconciliation pass, not a work creator.
+- The tests in `lab.json` use a real hard kill, assert a failed receipt, prove idempotency, and verify terminal-before-reclaim ordering.
+
+## Run it
+
+From this directory, run:
+
+```console
+cp starter.py work.py
+python check.py work.py /tmp/sa-ch06-lab
+```
+
+Fill the numbered TODO seams in `work.py`. Use `python check.py solution.py /tmp/sa-ch06-lab` only after attempting the repair. Your experiment must inject a failure between the terminal update and receipt insert, demonstrate rollback, then perform two recovery attempts without leaving duplicate evidence.
+
+## Break it
+
+Infer `COMPLETED` from a pre-existing output file and explain which unobserved writes could still be missing. Commit the terminal state before inserting the receipt and inject a crash between them. Remove `current_attempt = ?` from the update predicate and watch both supervisors claim recovery credit. Reclaim the workspace before committing recovery and identify what evidence a second supervisor loses.
+
+## Explain it back
+
+Why is `FAILED/worker_lost` the only honest inference from an expired execution attempt? Which three facts must change atomically? How does compare-and-set make a second supervisor race an ordinary no-op rather than a second recovery?

--- a/book/labs/ch06_the_organization_recovers/check.py
+++ b/book/labs/ch06_the_organization_recovers/check.py
@@ -1,0 +1,40 @@
+"""Deterministic checker for the Chapter 6 companion lab."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    observed = target_module.exercise(root)
+    assert observed["naive_output_guess"] == "COMPLETED"
+    assert observed["injected_recovery_won"] is False
+    assert observed["rollback_state"] == "RUNNING"
+    assert observed["rollback_fence"] == "attempt-7"
+    assert observed["rollback_receipts"] == 0
+    assert observed["supervisor_winners"] == 1
+    assert observed["terminal_state"] == "FAILED"
+    assert observed["fence_released"] is True
+    assert observed["receipt_status"] == "failed"
+    assert observed["failure_category"] == "worker_lost"
+    assert observed["receipt_count"] == 1
+    return observed
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_ch06", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: python check.py TARGET.py ROOT")
+    print(json.dumps(check(_load(Path(sys.argv[1])), Path(sys.argv[2])), sort_keys=True, indent=2))

--- a/book/labs/ch06_the_organization_recovers/expected.json
+++ b/book/labs/ch06_the_organization_recovers/expected.json
@@ -1,0 +1,13 @@
+{
+  "failure_category": "worker_lost",
+  "fence_released": true,
+  "injected_recovery_won": false,
+  "naive_output_guess": "COMPLETED",
+  "receipt_count": 1,
+  "receipt_status": "failed",
+  "rollback_fence": "attempt-7",
+  "rollback_receipts": 0,
+  "rollback_state": "RUNNING",
+  "supervisor_winners": 1,
+  "terminal_state": "FAILED"
+}

--- a/book/labs/ch06_the_organization_recovers/lab.json
+++ b/book/labs/ch06_the_organization_recovers/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch06_the_organization_recovers",
+  "title": "Crash recovery without guessed success",
+  "production_sources": [
+    "src/sovereign_agent/supervisor.py:recover_abandoned_assignments",
+    "src/sovereign_agent/fencing.py:release_execution_attempt",
+    "src/sovereign_agent/supervisor.py:tick"
+  ],
+  "production_tests": [
+    "tests/test_supervisor.py::test_supervisor_recovers_a_real_sigkilled_assignment",
+    "tests/test_supervisor.py::test_never_guesses_success_recovery_receipt_is_always_failed",
+    "tests/test_supervisor.py::test_recovery_is_idempotent_a_second_tick_recovers_nothing_more",
+    "tests/test_supervisor.py::test_workspace_reclaim_applies_only_after_the_terminal_write_is_durable"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch06_the_organization_recovers/solution.py
+++ b/book/labs/ch06_the_organization_recovers/solution.py
@@ -1,0 +1,87 @@
+"""Reference solution for Chapter 6: recovery records uncertainty honestly."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+def _fresh(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True)
+
+
+def _recover(connection: sqlite3.Connection, attempt: str, *, inject_fault: bool = False) -> bool:
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        cursor = connection.execute(
+            "UPDATE assignments SET state='FAILED', current_attempt=NULL "
+            "WHERE id='asg-1' AND state='RUNNING' AND current_attempt=?",
+            (attempt,),
+        )
+        if cursor.rowcount != 1:
+            connection.rollback()
+            return False
+        if inject_fault:
+            raise RuntimeError("simulated crash before receipt")
+        connection.execute(
+            "INSERT INTO receipts(assignment_id, status, failure_category) "
+            "VALUES('asg-1', 'failed', 'worker_lost')"
+        )
+        connection.commit()
+        return True
+    except RuntimeError:
+        connection.rollback()
+        return False
+
+
+def exercise(root: Path) -> dict[str, object]:
+    lab = root / "ch06"
+    _fresh(lab)
+    (lab / "partial-output.txt").write_text("work may have started", encoding="utf-8")
+    connection = sqlite3.connect(lab / "recovery.db", isolation_level=None)
+    connection.executescript(
+        "CREATE TABLE assignments(id TEXT PRIMARY KEY, state TEXT NOT NULL, current_attempt TEXT);"
+        "CREATE TABLE receipts(assignment_id TEXT UNIQUE, status TEXT, failure_category TEXT);"
+        "INSERT INTO assignments VALUES('asg-1', 'RUNNING', 'attempt-7');"
+    )
+
+    naive_guess = "COMPLETED" if (lab / "partial-output.txt").exists() else "FAILED"
+    injected_won = _recover(connection, "attempt-7", inject_fault=True)
+    after_fault = connection.execute(
+        "SELECT state, current_attempt FROM assignments WHERE id='asg-1'"
+    ).fetchone()
+    receipts_after_fault = connection.execute("SELECT COUNT(*) FROM receipts").fetchone()[0]
+    connection.close()
+
+    supervisor_a = sqlite3.connect(lab / "recovery.db", isolation_level=None)
+    supervisor_b = sqlite3.connect(lab / "recovery.db", isolation_level=None)
+    first_won = _recover(supervisor_a, "attempt-7")
+    second_won = _recover(supervisor_b, "attempt-7")
+    final_state, final_attempt = supervisor_a.execute(
+        "SELECT state, current_attempt FROM assignments WHERE id='asg-1'"
+    ).fetchone()
+    receipt = supervisor_a.execute(
+        "SELECT status, failure_category FROM receipts WHERE assignment_id='asg-1'"
+    ).fetchone()
+    receipt_count = supervisor_a.execute("SELECT COUNT(*) FROM receipts").fetchone()[0]
+    supervisor_a.close()
+    supervisor_b.close()
+
+    return {
+        "naive_output_guess": naive_guess,
+        "injected_recovery_won": injected_won,
+        "rollback_state": after_fault[0],
+        "rollback_fence": after_fault[1],
+        "rollback_receipts": receipts_after_fault,
+        "supervisor_winners": int(first_won) + int(second_won),
+        "terminal_state": final_state,
+        "fence_released": final_attempt is None,
+        "receipt_status": receipt[0],
+        "failure_category": receipt[1],
+        "receipt_count": receipt_count,
+    }

--- a/book/labs/ch06_the_organization_recovers/starter.py
+++ b/book/labs/ch06_the_organization_recovers/starter.py
@@ -1,0 +1,40 @@
+"""Starter for Chapter 6's supervisor-recovery lab."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import NamedTuple
+
+STUDENT_TODO = True
+WORKER_LOST = "worker_lost"
+
+
+class RecoveryState(NamedTuple):
+    """The three durable facts one recovery transaction must reconcile."""
+
+    assignment_state: str
+    current_attempt: str | None
+    receipt_count: int
+
+
+def recover(connection: sqlite3.Connection, attempt_id: str, *, inject_fault: bool = False) -> bool:
+    """Try to recover one still-current abandoned attempt."""
+    # TODO(1): Begin an immediate transaction and CAS RUNNING/current_attempt.
+    # TODO(2): Write a FAILED/worker_lost receipt and clear the fence in the
+    # same transaction; injected failure must roll every fact back.
+    # TODO(3): Treat a lost CAS as an idempotent false result, not an error or
+    # second receipt.
+    raise NotImplementedError
+
+
+def read_state(connection: sqlite3.Connection) -> RecoveryState:
+    """Read the assignment/fence/receipt facts used by the assertions."""
+    raise NotImplementedError
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Recover an expired attempt atomically and reject duplicate recovery."""
+    # TODO(4): Demonstrate the naive output-file guess, inject rollback, then
+    # let two SQLite connections contend and return check.py's observations.
+    raise NotImplementedError("Implement the Chapter 6 recovery experiment")

--- a/book/labs/ch07_the_organization_wakes_itself/README.md
+++ b/book/labs/ch07_the_organization_wakes_itself/README.md
@@ -1,0 +1,58 @@
+# Chapter 7 lab: one signal, one canonical wake
+
+## Challenge
+
+Build one **manual Pulse tick** over SQLite. A durable inventory signal may
+create governed work only when the inventory condition still qualifies while
+the creation transaction holds the write lock. The same source signal must
+always resolve to the same wake decision and work item, even when two database
+connections contend.
+
+Your `exercise(root)` implementation should return the observations in
+`expected.json`. Keep identifiers deterministic so the result explains the
+mechanism instead of timing noise.
+
+## Production map
+
+- `sovereign_agent.pulse.run_pulse_once` performs one deterministic pass. It
+  does not sleep, loop, or schedule itself.
+- `Organization.create_pulse_work` owns the transaction that revalidates the
+  gate and creates the decision, SOW/assignment, event, and origin links.
+- `pulse_wake_decisions.source_signal_id` is unique, so the database chooses
+  one canonical result under contention.
+- `tests/test_pulse.py` proves current-state revalidation, provenance, replay,
+  restart, and two-connection contention.
+
+## Run it
+
+From the repository root:
+
+```bash
+cp book/labs/ch07_the_organization_wakes_itself/starter.py \
+  book/labs/ch07_the_organization_wakes_itself/work.py
+python book/labs/ch07_the_organization_wakes_itself/check.py \
+  book/labs/ch07_the_organization_wakes_itself/work.py /tmp/sa-ch07-lab
+```
+
+Fill the numbered TODO seams in `work.py`, then run the checker. Run it again
+after it passes: it should produce the same JSON. Compare with `solution.py`
+only after you have a working attempt.
+
+## Break it
+
+Try each mutation separately and predict which assertion fails:
+
+1. Check inventory before `BEGIN IMMEDIATE`, but not again inside it.
+2. Remove the unique constraint on `wake_decisions.source_signal_id`.
+3. Give each contender a randomly generated work id.
+4. Insert the work row and its origin in separate transactions.
+
+The important failure is not merely “two rows exist.” It is that there is no
+longer one durable answer to “what work did this signal cause?”
+
+## Explain it back
+
+Why does a pre-transaction gate check describe the past? Why is returning the
+winner’s identifiers stronger than merely swallowing a uniqueness error? And
+what external component would still be required to call this manual tick on a
+schedule?

--- a/book/labs/ch07_the_organization_wakes_itself/check.py
+++ b/book/labs/ch07_the_organization_wakes_itself/check.py
@@ -1,0 +1,46 @@
+"""Executable checker for the Chapter 7 lab."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    observed = target_module.exercise(root)
+    assert observed["mechanism"] == "manual_tick", "Pulse is a caller-driven tick, not a scheduler"
+    stale = observed["stale_observation"]
+    assert stale["was_low_before_restock"] is True
+    assert stale["created_after_restock"] is False, "the gate must be revalidated under lock"
+    assert stale["work_id"] is None
+    assert stale["counts"] == {"decisions": 0, "work": 0}
+    race = observed["race"]
+    assert race["created_flags"] == [False, True], "exactly one connection must create"
+    assert race["returned_work_ids"] == ["work-signal-low"], "the loser must return the winner"
+    assert race["counts"] == {"decisions": 1, "work": 1, "origins": 1}
+    assert observed["source_chain"] == {
+        "signal_id": "signal-low",
+        "source_kind": "sale.committed",
+        "decision_id": "decision-signal-low",
+        "work_id": "work-signal-low",
+        "pulse_kind": "pulse.work_created",
+    }
+    return observed
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_ch07", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    module = _load(Path(sys.argv[1]))
+    root = Path(sys.argv[2])
+    print(json.dumps(check(module, root), indent=2, sort_keys=True))

--- a/book/labs/ch07_the_organization_wakes_itself/expected.json
+++ b/book/labs/ch07_the_organization_wakes_itself/expected.json
@@ -1,0 +1,21 @@
+{
+  "mechanism": "manual_tick",
+  "race": {
+    "counts": {"decisions": 1, "origins": 1, "work": 1},
+    "created_flags": [false, true],
+    "returned_work_ids": ["work-signal-low"]
+  },
+  "source_chain": {
+    "decision_id": "decision-signal-low",
+    "pulse_kind": "pulse.work_created",
+    "signal_id": "signal-low",
+    "source_kind": "sale.committed",
+    "work_id": "work-signal-low"
+  },
+  "stale_observation": {
+    "counts": {"decisions": 0, "work": 0},
+    "created_after_restock": false,
+    "was_low_before_restock": true,
+    "work_id": null
+  }
+}

--- a/book/labs/ch07_the_organization_wakes_itself/lab.json
+++ b/book/labs/ch07_the_organization_wakes_itself/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch07_the_organization_wakes_itself",
+  "title": "One signal, one canonical manual Pulse tick",
+  "production_sources": [
+    "src/sovereign_agent/pulse.py:run_pulse_once",
+    "src/sovereign_agent/organization.py:Organization.create_pulse_work",
+    "src/reference_organizations/store/pulse_gate.py:store_wake_gate"
+  ],
+  "production_tests": [
+    "tests/test_pulse.py::test_a_formerly_qualifying_signal_does_not_fire_after_the_condition_resolves",
+    "tests/test_pulse.py::test_attribution_walks_source_event_to_signal_to_decision_to_pulse_event_to_sow_to_assignment",
+    "tests/test_pulse.py::test_create_pulse_work_called_twice_for_the_same_signal_returns_the_same_identifiers",
+    "tests/test_pulse.py::test_two_real_processes_evaluating_the_same_signal_create_one_canonical_sow"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch07_the_organization_wakes_itself/solution.py
+++ b/book/labs/ch07_the_organization_wakes_itself/solution.py
@@ -1,0 +1,192 @@
+"""Reference solution for Chapter 7's manual Pulse transaction lab."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+SCHEMA = """
+PRAGMA journal_mode = WAL;
+CREATE TABLE inventory (
+    sku TEXT PRIMARY KEY,
+    on_hand INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    reorder_point INTEGER NOT NULL
+);
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE TABLE signals (
+    id TEXT PRIMARY KEY,
+    source_event_id TEXT NOT NULL REFERENCES events(id),
+    sku TEXT NOT NULL
+);
+CREATE TABLE wake_decisions (
+    id TEXT PRIMARY KEY,
+    source_signal_id TEXT NOT NULL UNIQUE REFERENCES signals(id),
+    source_event_id TEXT NOT NULL REFERENCES events(id)
+);
+CREATE TABLE work (
+    id TEXT PRIMARY KEY,
+    decision_id TEXT NOT NULL UNIQUE REFERENCES wake_decisions(id),
+    sku TEXT NOT NULL
+);
+CREATE TABLE origins (
+    work_id TEXT PRIMARY KEY REFERENCES work(id),
+    decision_id TEXT NOT NULL REFERENCES wake_decisions(id),
+    pulse_event_id TEXT NOT NULL UNIQUE REFERENCES events(id)
+);
+"""
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path, timeout=5.0, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def _fresh_database(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+    connection = _connect(path)
+    connection.executescript(SCHEMA)
+    connection.execute("INSERT INTO inventory VALUES ('SKU-TEA', 2, 0, 3)")
+    connection.execute(
+        "INSERT INTO events VALUES ('event-sale', 'sale.committed', ?)",
+        (json.dumps({"signal_id": "signal-low", "sku": "SKU-TEA"}, sort_keys=True),),
+    )
+    connection.execute("INSERT INTO signals VALUES ('signal-low', 'event-sale', 'SKU-TEA')")
+    connection.close()
+
+
+def _manual_tick(connection: sqlite3.Connection, signal_id: str) -> tuple[str | None, bool]:
+    """Create or return one canonical work item for a signal.
+
+    The gate is deliberately re-read only after BEGIN IMMEDIATE holds the
+    write lock. A caller may have observed an old low-stock state, but that
+    observation grants no authority to create work.
+    """
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        existing = connection.execute(
+            "SELECT w.id FROM wake_decisions d JOIN work w ON w.decision_id = d.id "
+            "WHERE d.source_signal_id = ?",
+            (signal_id,),
+        ).fetchone()
+        if existing is not None:
+            connection.commit()
+            return str(existing["id"]), False
+
+        row = connection.execute(
+            "SELECT s.sku, s.source_event_id, i.on_hand, i.reserved, i.reorder_point "
+            "FROM signals s JOIN inventory i ON i.sku = s.sku WHERE s.id = ?",
+            (signal_id,),
+        ).fetchone()
+        if row is None or int(row["on_hand"]) - int(row["reserved"]) > int(row["reorder_point"]):
+            connection.commit()
+            return None, False
+
+        decision_id = f"decision-{signal_id}"
+        work_id = f"work-{signal_id}"
+        pulse_event_id = f"event-pulse-{signal_id}"
+        connection.execute(
+            "INSERT INTO wake_decisions VALUES (?, ?, ?)",
+            (decision_id, signal_id, row["source_event_id"]),
+        )
+        connection.execute("INSERT INTO work VALUES (?, ?, ?)", (work_id, decision_id, row["sku"]))
+        connection.execute(
+            "INSERT INTO events VALUES (?, 'pulse.work_created', ?)",
+            (pulse_event_id, json.dumps({"work_id": work_id}, sort_keys=True)),
+        )
+        connection.execute(
+            "INSERT INTO origins VALUES (?, ?, ?)",
+            (work_id, decision_id, pulse_event_id),
+        )
+        connection.commit()
+        return work_id, True
+    except BaseException:
+        connection.rollback()
+        raise
+
+
+def exercise(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "pulse.sqlite3"
+    _fresh_database(path)
+
+    # A stale outside observation said "low". The shelf is then replenished;
+    # the transaction-time read must refuse creation.
+    observer = _connect(path)
+    was_low = bool(
+        observer.execute(
+            "SELECT on_hand - reserved <= reorder_point AS low FROM inventory WHERE sku='SKU-TEA'"
+        ).fetchone()["low"]
+    )
+    observer.execute("UPDATE inventory SET on_hand = 9 WHERE sku='SKU-TEA'")
+    stale_work, stale_created = _manual_tick(observer, "signal-low")
+    stale_counts = {
+        "decisions": observer.execute("SELECT COUNT(*) FROM wake_decisions").fetchone()[0],
+        "work": observer.execute("SELECT COUNT(*) FROM work").fetchone()[0],
+    }
+    observer.execute("UPDATE inventory SET on_hand = 2 WHERE sku='SKU-TEA'")
+    observer.close()
+
+    barrier = threading.Barrier(2)
+    results: list[tuple[str | None, bool]] = []
+    result_lock = threading.Lock()
+
+    def contend() -> None:
+        connection = _connect(path)
+        barrier.wait()
+        result = _manual_tick(connection, "signal-low")
+        with result_lock:
+            results.append(result)
+        connection.close()
+
+    contenders = [threading.Thread(target=contend), threading.Thread(target=contend)]
+    for contender in contenders:
+        contender.start()
+    for contender in contenders:
+        contender.join()
+
+    inspector = _connect(path)
+    chain = inspector.execute(
+        "SELECT s.id AS signal_id, e.kind AS source_kind, d.id AS decision_id, "
+        "w.id AS work_id, pe.kind AS pulse_kind "
+        "FROM signals s JOIN events e ON e.id=s.source_event_id "
+        "JOIN wake_decisions d ON d.source_signal_id=s.id "
+        "JOIN work w ON w.decision_id=d.id "
+        "JOIN origins o ON o.work_id=w.id "
+        "JOIN events pe ON pe.id=o.pulse_event_id"
+    ).fetchone()
+    counts = {
+        "decisions": inspector.execute("SELECT COUNT(*) FROM wake_decisions").fetchone()[0],
+        "work": inspector.execute("SELECT COUNT(*) FROM work").fetchone()[0],
+        "origins": inspector.execute("SELECT COUNT(*) FROM origins").fetchone()[0],
+    }
+    inspector.close()
+
+    return {
+        "mechanism": "manual_tick",
+        "stale_observation": {
+            "was_low_before_restock": was_low,
+            "created_after_restock": stale_created,
+            "work_id": stale_work,
+            "counts": stale_counts,
+        },
+        "race": {
+            "created_flags": sorted(created for _work_id, created in results),
+            "returned_work_ids": sorted({work_id for work_id, _created in results}),
+            "counts": counts,
+        },
+        "source_chain": dict(chain) if chain is not None else {},
+    }

--- a/book/labs/ch07_the_organization_wakes_itself/starter.py
+++ b/book/labs/ch07_the_organization_wakes_itself/starter.py
@@ -1,0 +1,57 @@
+"""Starter for Chapter 7's manual Pulse transaction lab."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = True
+
+# TODO(1): Add wake_decisions, work, and origins to SCHEMA. Which source
+# identifier needs a UNIQUE constraint to make one decision canonical?
+
+SCHEMA = """
+CREATE TABLE inventory (
+    sku TEXT PRIMARY KEY,
+    on_hand INTEGER NOT NULL,
+    reserved INTEGER NOT NULL,
+    reorder_point INTEGER NOT NULL
+);
+CREATE TABLE events (id TEXT PRIMARY KEY, kind TEXT NOT NULL, payload TEXT NOT NULL);
+CREATE TABLE signals (
+    id TEXT PRIMARY KEY,
+    source_event_id TEXT NOT NULL REFERENCES events(id),
+    sku TEXT NOT NULL
+);
+"""
+
+
+def connect(path: Path) -> sqlite3.Connection:
+    """Open one contender's independent connection."""
+    connection = sqlite3.connect(path, timeout=5.0, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def manual_tick(connection: sqlite3.Connection, signal_id: str) -> tuple[str | None, bool]:
+    """Return (canonical_work_id, created_by_this_call)."""
+    # TODO(2): Acquire the write lock before re-reading available inventory.
+    # A gate result observed before this transaction is only historical data.
+    # TODO(3): Create decision, work, Pulse event, and origin in one transaction.
+    # On replay or a lost race, return the already-canonical work id with False.
+    raise NotImplementedError("implement one canonical manual Pulse tick")
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Build and probe a revalidated, canonical manual Pulse tick.
+
+    Required observations are documented in README.md and expected.json.
+    Use two independent SQLite connections for the contention experiment.
+    """
+    # TODO(4): Seed a formerly qualifying signal, resolve its condition, and
+    # prove transaction-time revalidation creates no work.
+    # TODO(5): Race two threads using separate connections, then query the
+    # complete signal -> event -> decision -> work -> Pulse-event chain.
+    raise NotImplementedError("assemble the Chapter 7 experiments")

--- a/book/labs/ch08_the_store_becomes_a_catalog/README.md
+++ b/book/labs/ch08_the_store_becomes_a_catalog/README.md
@@ -1,0 +1,56 @@
+# Chapter 8 lab: migrate a populated catalog safely
+
+## Challenge
+
+Turn a populated, denormalized `catalog_v1` table into separate `products` and
+`inventory` tables. Preserve every product, introduce database-enforced
+inventory constraints, and prove that malformed legacy data rolls the entire
+migration back instead of leaving a half-created schema.
+
+Implement `exercise(root)` so it runs both a successful migration and a
+duplicate-SKU failure experiment. Its deterministic observations must match
+`expected.json`.
+
+## Production map
+
+- `sovereign_agent.database.MIGRATIONS` applies forward-only schema changes in
+  transactions and records their versions.
+- `reference_organizations.store.seed_catalog` treats SKU identity, stock, and
+  reorder points as per-product facts.
+- Persistence tests exercise upgrades with populated state, malformed
+  migrations, rollback, and schema constraints.
+
+This compact lab uses a new-table/copy/swap shape without hiding migration
+failure behind `INSERT OR REPLACE`.
+
+## Run it
+
+```bash
+cp book/labs/ch08_the_store_becomes_a_catalog/starter.py \
+  book/labs/ch08_the_store_becomes_a_catalog/work.py
+python book/labs/ch08_the_store_becomes_a_catalog/check.py \
+  book/labs/ch08_the_store_becomes_a_catalog/work.py /tmp/sa-ch08-lab
+```
+
+Fill the numbered TODO seams in `work.py`. Once it passes, run it twice to
+confirm the harness starts from the same known legacy state and produces the
+same result. Use `solution.py` as a final comparison, not the starting point.
+
+## Break it
+
+Try these mutations one at a time:
+
+1. Commit after creating `products` but before copying `inventory`.
+2. Replace plain `INSERT` with `INSERT OR REPLACE` during the copy.
+3. Remove `CHECK (reserved <= on_hand)`.
+4. Disable foreign keys and insert inventory for an unknown SKU.
+5. Drop `catalog_v1` before the copy has proved successful.
+
+Observe which mutations destroy information and which merely postpone the
+failure until later application code.
+
+## Explain it back
+
+Why must a migration be tested with existing rows rather than an empty test
+database? Why is a duplicate a reason to stop instead of a reason to choose one
+row? Which invariants belong in SQLite even if Python also validates them?

--- a/book/labs/ch08_the_store_becomes_a_catalog/check.py
+++ b/book/labs/ch08_the_store_becomes_a_catalog/check.py
@@ -1,0 +1,46 @@
+"""Executable checker for the Chapter 8 lab."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    observed = target_module.exercise(root)
+    success = observed["successful_migration"]
+    assert success["rows_before"] == success["rows_after"] == 2
+    assert success["tables"] == ["inventory", "products", "schema_migrations"]
+    assert [row["sku"] for row in success["products"]] == ["SKU-COFFEE", "SKU-TEA"]
+    assert success["products"][0]["reorder_point"] == 6
+    assert success["products"][1]["reorder_point"] == 3
+    assert success["constraints"] == {
+        "negative_stock": "refused",
+        "reserved_above_stock": "refused",
+        "orphan_inventory": "refused",
+    }
+    assert success["tea_after_refusals"] == {"on_hand": 4, "reserved": 0}
+    duplicate = observed["duplicate_migration"]
+    assert duplicate == {
+        "result": "duplicate_sku_refused",
+        "legacy_rows_preserved": 3,
+        "tables_after_rollback": ["catalog_v1"],
+    }, "a failed copy must leave the legacy schema and all rows intact"
+    return observed
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_ch08", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    module = _load(Path(sys.argv[1]))
+    print(json.dumps(check(module, Path(sys.argv[2])), indent=2, sort_keys=True))

--- a/book/labs/ch08_the_store_becomes_a_catalog/expected.json
+++ b/book/labs/ch08_the_store_becomes_a_catalog/expected.json
@@ -1,0 +1,36 @@
+{
+  "duplicate_migration": {
+    "legacy_rows_preserved": 3,
+    "result": "duplicate_sku_refused",
+    "tables_after_rollback": ["catalog_v1"]
+  },
+  "successful_migration": {
+    "constraints": {
+      "negative_stock": "refused",
+      "orphan_inventory": "refused",
+      "reserved_above_stock": "refused"
+    },
+    "products": [
+      {
+        "name": "Kenyan coffee",
+        "on_hand": 10,
+        "price_cents": 650,
+        "reorder_point": 6,
+        "reserved": 0,
+        "sku": "SKU-COFFEE"
+      },
+      {
+        "name": "Assam tea",
+        "on_hand": 4,
+        "price_cents": 400,
+        "reorder_point": 3,
+        "reserved": 0,
+        "sku": "SKU-TEA"
+      }
+    ],
+    "rows_after": 2,
+    "rows_before": 2,
+    "tables": ["inventory", "products", "schema_migrations"],
+    "tea_after_refusals": {"on_hand": 4, "reserved": 0}
+  }
+}

--- a/book/labs/ch08_the_store_becomes_a_catalog/lab.json
+++ b/book/labs/ch08_the_store_becomes_a_catalog/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch08_the_store_becomes_a_catalog",
+  "title": "Migrate a populated catalog without losing rows",
+  "production_sources": [
+    "src/sovereign_agent/database.py:Database.migrate",
+    "src/sovereign_agent/database.py:MIGRATIONS",
+    "src/reference_organizations/store/__init__.py:seed_catalog"
+  ],
+  "production_tests": [
+    "tests/test_persistence.py::test_upgrade_from_prior_schema_preserves_data",
+    "tests/test_persistence.py::test_a_failed_migration_rolls_back_schema_and_stamp",
+    "tests/test_persistence.py::test_migrations_are_forward_only_and_ordered",
+    "tests/test_store_multi_sku.py::test_a_sale_of_one_sku_does_not_change_another_skus_inventory"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch08_the_store_becomes_a_catalog/solution.py
+++ b/book/labs/ch08_the_store_becomes_a_catalog/solution.py
@@ -1,0 +1,154 @@
+"""Reference solution for Chapter 8's populated catalog migration lab."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+LEGACY_SCHEMA = """
+CREATE TABLE catalog_v1 (
+    sku TEXT NOT NULL,
+    name TEXT NOT NULL,
+    price_cents INTEGER NOT NULL,
+    on_hand INTEGER NOT NULL,
+    reorder_point INTEGER NOT NULL
+);
+"""
+
+MIGRATION = """
+CREATE TABLE products (
+    sku TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    price_cents INTEGER NOT NULL CHECK (price_cents > 0)
+);
+CREATE TABLE inventory (
+    sku TEXT PRIMARY KEY REFERENCES products(sku),
+    on_hand INTEGER NOT NULL CHECK (on_hand >= 0),
+    reserved INTEGER NOT NULL DEFAULT 0 CHECK (reserved >= 0 AND reserved <= on_hand),
+    reorder_point INTEGER NOT NULL CHECK (reorder_point >= 0)
+);
+INSERT INTO products(sku, name, price_cents)
+    SELECT sku, name, price_cents FROM catalog_v1;
+INSERT INTO inventory(sku, on_hand, reserved, reorder_point)
+    SELECT sku, on_hand, 0, reorder_point FROM catalog_v1;
+DROP TABLE catalog_v1;
+CREATE TABLE schema_migrations (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+INSERT INTO schema_migrations VALUES (2, '2026-09-01T00:00:00Z');
+"""
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def _seed_legacy(path: Path, *, duplicate: bool) -> None:
+    if path.exists():
+        path.unlink()
+    connection = _connect(path)
+    connection.executescript(LEGACY_SCHEMA)
+    connection.executemany(
+        "INSERT INTO catalog_v1 VALUES (?, ?, ?, ?, ?)",
+        [
+            ("SKU-TEA", "Assam tea", 400, 4, 3),
+            ("SKU-COFFEE", "Kenyan coffee", 650, 10, 6),
+        ],
+    )
+    if duplicate:
+        connection.execute(
+            "INSERT INTO catalog_v1 VALUES ('SKU-TEA', 'Conflicting tea', 999, 99, 9)"
+        )
+    connection.close()
+
+
+def _migrate(connection: sqlite3.Connection) -> None:
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        # executescript would commit an open transaction implicitly. Execute
+        # the known statements one by one so rollback covers the whole copy.
+        statements = [statement.strip() for statement in MIGRATION.split(";") if statement.strip()]
+        for statement in statements:
+            connection.execute(statement)
+        connection.commit()
+    except BaseException:
+        connection.rollback()
+        raise
+
+
+def _tables(connection: sqlite3.Connection) -> list[str]:
+    rows = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).fetchall()
+    return [str(row["name"]) for row in rows]
+
+
+def exercise(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    valid_path = root / "catalog-valid.sqlite3"
+    invalid_path = root / "catalog-duplicate.sqlite3"
+
+    _seed_legacy(valid_path, duplicate=False)
+    valid = _connect(valid_path)
+    before = valid.execute("SELECT COUNT(*) FROM catalog_v1").fetchone()[0]
+    _migrate(valid)
+    products = [
+        dict(row)
+        for row in valid.execute(
+            "SELECT p.sku, p.name, p.price_cents, i.on_hand, i.reserved, i.reorder_point "
+            "FROM products p JOIN inventory i USING (sku) ORDER BY p.sku"
+        ).fetchall()
+    ]
+
+    constraint_results: dict[str, str] = {}
+    for name, statement in {
+        "negative_stock": "UPDATE inventory SET on_hand=-1 WHERE sku='SKU-TEA'",
+        "reserved_above_stock": "UPDATE inventory SET reserved=5 WHERE sku='SKU-TEA'",
+        "orphan_inventory": "INSERT INTO inventory VALUES ('SKU-MISSING', 1, 0, 0)",
+    }.items():
+        try:
+            valid.execute(statement)
+        except sqlite3.IntegrityError:
+            constraint_results[name] = "refused"
+        else:
+            constraint_results[name] = "accepted"
+    valid_after = valid.execute(
+        "SELECT on_hand, reserved FROM inventory WHERE sku='SKU-TEA'"
+    ).fetchone()
+    valid_tables = _tables(valid)
+    valid.close()
+
+    _seed_legacy(invalid_path, duplicate=True)
+    invalid = _connect(invalid_path)
+    failure = "none"
+    try:
+        _migrate(invalid)
+    except sqlite3.IntegrityError:
+        failure = "duplicate_sku_refused"
+    duplicate_rows = invalid.execute("SELECT COUNT(*) FROM catalog_v1").fetchone()[0]
+    invalid_tables = _tables(invalid)
+    invalid.close()
+
+    return {
+        "successful_migration": {
+            "rows_before": before,
+            "rows_after": len(products),
+            "tables": valid_tables,
+            "products": products,
+            "constraints": constraint_results,
+            "tea_after_refusals": dict(valid_after),
+        },
+        "duplicate_migration": {
+            "result": failure,
+            "legacy_rows_preserved": duplicate_rows,
+            "tables_after_rollback": invalid_tables,
+        },
+    }

--- a/book/labs/ch08_the_store_becomes_a_catalog/starter.py
+++ b/book/labs/ch08_the_store_becomes_a_catalog/starter.py
@@ -1,0 +1,43 @@
+"""Starter for Chapter 8's populated catalog migration lab."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = True
+
+LEGACY_SCHEMA = """
+CREATE TABLE catalog_v1 (
+    sku TEXT NOT NULL,
+    name TEXT NOT NULL,
+    price_cents INTEGER NOT NULL,
+    on_hand INTEGER NOT NULL,
+    reorder_point INTEGER NOT NULL
+);
+"""
+
+VALID_ROWS: tuple[tuple[str, str, int, int, int], ...] = (
+    ("SKU-TEA", "Assam tea", 400, 4, 3),
+    ("SKU-COFFEE", "Kenyan coffee", 650, 10, 6),
+)
+
+
+def migrate(connection: sqlite3.Connection) -> None:
+    """Normalize catalog_v1 without losing its populated rows."""
+    # TODO(1): Begin one IMMEDIATE transaction and create products/inventory.
+    # Put positive-price, nonnegative-stock, reservation, and foreign-key
+    # invariants in the schema rather than relying only on Python checks.
+    # TODO(2): Copy with plain INSERT so duplicate identity fails closed. Do
+    # not use executescript: it can commit before the migration is complete.
+    # TODO(3): Drop catalog_v1 and stamp the migration only after both copies
+    # succeed; roll back every DDL and DML statement on any exception.
+    raise NotImplementedError("implement the populated catalog migration")
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Migrate valid legacy rows and prove duplicate input rolls back."""
+    # TODO(4): Run a valid populated upgrade and probe all three constraints.
+    # TODO(5): Run a duplicate-SKU upgrade in another database, then prove the
+    # legacy table and all three original rows survived the rollback.
+    raise NotImplementedError("assemble the Chapter 8 migration experiments")

--- a/book/labs/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/labs/ch09_each_product_has_its_own_threshold/README.md
@@ -1,0 +1,56 @@
+# Chapter 9 lab: make a sale one indivisible fact
+
+## Challenge
+
+Implement a sale whose stock read, inventory decrement, cash movement, and
+event append happen in one immediate transaction. This lab strengthens the
+boundary by reading price from the catalog rather than accepting it from the
+caller. Availability is `on_hand - reserved`, not `on_hand`.
+
+The exercise must also inject a failure after the cash insert and race two
+independent SQLite connections that each want more than half the remaining
+stock. The database should commit one complete sale and refuse the other.
+
+## Production map
+
+- `reference_organizations.store.record_sale` reads stock under
+  `BEGIN IMMEDIATE`, rejects negative inventory, computes cash as quantity
+  times the supplied unit price, and commits the signal/event beside the state
+  changes. Compare that production boundary with this lab's catalog lookup.
+- `checks.inventory_at_or_above_reorder_point` reasons over available stock,
+  `on_hand - reserved`.
+- Store tests cover multiple SKU isolation and genuine two-connection
+  oversell contention.
+
+## Run it
+
+```bash
+cp book/labs/ch09_each_product_has_its_own_threshold/starter.py \
+  book/labs/ch09_each_product_has_its_own_threshold/work.py
+python book/labs/ch09_each_product_has_its_own_threshold/check.py \
+  book/labs/ch09_each_product_has_its_own_threshold/work.py /tmp/sa-ch09-lab
+```
+
+Fill the numbered TODO seams in `work.py`. The passing output is
+timing-independent: it records one winner and one refusal, not which thread
+happened to acquire the lock first. Consult `solution.py` after your attempt.
+
+## Break it
+
+Try each mutation and inspect all four ledgers afterward:
+
+1. Read `on_hand` before opening the immediate transaction.
+2. Ignore `reserved` when computing availability.
+3. Accept `unit_price_cents` from the caller instead of reading the product.
+4. Commit inventory before inserting cash and the event.
+5. Catch an exception after the cash insert but forget to roll back.
+
+For each break, ask whether the database now tells one coherent story or
+several incompatible stories.
+
+## Explain it back
+
+Why is `quantity * catalog price` part of the invariant rather than a display
+calculation? Why does reservation reduce sellable stock without reducing
+on-hand stock? What property does `BEGIN IMMEDIATE` add that a Python lock does
+not provide to another process?

--- a/book/labs/ch09_each_product_has_its_own_threshold/check.py
+++ b/book/labs/ch09_each_product_has_its_own_threshold/check.py
@@ -1,0 +1,68 @@
+"""Executable checker for the Chapter 9 lab."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    observed = target_module.exercise(root)
+    reservation = observed["reservation"]
+    assert reservation["result"] == "requested 4, available 3"
+    assert reservation["state"] == {
+        "on_hand": 5,
+        "reserved": 2,
+        "available": 3,
+        "cash_total": 0,
+        "cash_rows": 0,
+        "event_rows": 0,
+    }
+    committed = observed["committed_sale"]
+    assert committed["receipt"] == {"sale_id": "sale-one", "quantity": 2, "amount_cents": 850}
+    assert committed["event_payload"] == {
+        "amount_cents": 850,
+        "qty": 2,
+        "sale_id": "sale-one",
+        "sku": "SKU-GELATO",
+    }
+    assert committed["state"] == {
+        "on_hand": 3,
+        "reserved": 2,
+        "available": 1,
+        "cash_total": 850,
+        "cash_rows": 1,
+        "event_rows": 1,
+    }
+    fault = observed["fault_injection"]
+    assert fault["result"] == "injected failure after cash"
+    assert fault["state_unchanged"] is True, "inventory, cash, and event must roll back together"
+    assert fault["state"] == committed["state"]
+    contention = observed["contention"]
+    assert contention["statuses"] == ["committed", "refused"]
+    assert contention["state"] == {
+        "on_hand": 1,
+        "reserved": 0,
+        "available": 1,
+        "cash_total": 850,
+        "cash_rows": 1,
+        "event_rows": 1,
+    }
+    return observed
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_ch09", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    module = _load(Path(sys.argv[1]))
+    print(json.dumps(check(module, Path(sys.argv[2])), indent=2, sort_keys=True))

--- a/book/labs/ch09_each_product_has_its_own_threshold/expected.json
+++ b/book/labs/ch09_each_product_has_its_own_threshold/expected.json
@@ -1,0 +1,53 @@
+{
+  "committed_sale": {
+    "event_payload": {
+      "amount_cents": 850,
+      "qty": 2,
+      "sale_id": "sale-one",
+      "sku": "SKU-GELATO"
+    },
+    "receipt": {"amount_cents": 850, "quantity": 2, "sale_id": "sale-one"},
+    "state": {
+      "available": 1,
+      "cash_rows": 1,
+      "cash_total": 850,
+      "event_rows": 1,
+      "on_hand": 3,
+      "reserved": 2
+    }
+  },
+  "contention": {
+    "state": {
+      "available": 1,
+      "cash_rows": 1,
+      "cash_total": 850,
+      "event_rows": 1,
+      "on_hand": 1,
+      "reserved": 0
+    },
+    "statuses": ["committed", "refused"]
+  },
+  "fault_injection": {
+    "result": "injected failure after cash",
+    "state": {
+      "available": 1,
+      "cash_rows": 1,
+      "cash_total": 850,
+      "event_rows": 1,
+      "on_hand": 3,
+      "reserved": 2
+    },
+    "state_unchanged": true
+  },
+  "reservation": {
+    "result": "requested 4, available 3",
+    "state": {
+      "available": 3,
+      "cash_rows": 0,
+      "cash_total": 0,
+      "event_rows": 0,
+      "on_hand": 5,
+      "reserved": 2
+    }
+  }
+}

--- a/book/labs/ch09_each_product_has_its_own_threshold/lab.json
+++ b/book/labs/ch09_each_product_has_its_own_threshold/lab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "chapter": "ch09_each_product_has_its_own_threshold",
+  "title": "Commit inventory, cash, and event as one sale",
+  "production_sources": [
+    "src/reference_organizations/store/__init__.py:record_sale",
+    "src/sovereign_agent/checks.py:inventory_at_or_above_reorder_point",
+    "src/sovereign_agent/database.py:Database.immediate"
+  ],
+  "production_tests": [
+    "tests/test_store_multi_sku.py::test_a_sale_of_one_sku_does_not_change_another_skus_inventory",
+    "tests/test_concurrency.py::test_concurrent_sales_cannot_oversell",
+    "tests/test_acceptance_falsification.py::test_reserved_stock_is_not_available_stock",
+    "tests/test_persistence.py::test_inventory_never_goes_negative"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch09_each_product_has_its_own_threshold/solution.py
+++ b/book/labs/ch09_each_product_has_its_own_threshold/solution.py
@@ -1,0 +1,208 @@
+"""Reference solution for Chapter 9's invariant-preserving sale lab."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+SCHEMA = """
+PRAGMA journal_mode = WAL;
+CREATE TABLE products (
+    sku TEXT PRIMARY KEY,
+    price_cents INTEGER NOT NULL CHECK (price_cents > 0)
+);
+CREATE TABLE inventory (
+    sku TEXT PRIMARY KEY REFERENCES products(sku),
+    on_hand INTEGER NOT NULL CHECK (on_hand >= 0),
+    reserved INTEGER NOT NULL CHECK (reserved >= 0 AND reserved <= on_hand),
+    reorder_point INTEGER NOT NULL CHECK (reorder_point >= 0)
+);
+CREATE TABLE cash_entries (
+    sale_id TEXT PRIMARY KEY,
+    amount_cents INTEGER NOT NULL CHECK (amount_cents > 0)
+);
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL
+);
+"""
+
+
+class SaleError(RuntimeError):
+    pass
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path, timeout=5.0, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def _fresh_database(path: Path, *, on_hand: int, reserved: int) -> None:
+    if path.exists():
+        path.unlink()
+    connection = _connect(path)
+    connection.executescript(SCHEMA)
+    connection.execute("INSERT INTO products VALUES ('SKU-GELATO', 425)")
+    connection.execute(
+        "INSERT INTO inventory VALUES ('SKU-GELATO', ?, ?, 2)",
+        (on_hand, reserved),
+    )
+    connection.close()
+
+
+def _record_sale(
+    connection: sqlite3.Connection,
+    sale_id: str,
+    sku: str,
+    quantity: int,
+    *,
+    fail_after_cash: bool = False,
+) -> dict[str, int | str]:
+    if quantity <= 0:
+        raise SaleError("quantity must be positive")
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        row = connection.execute(
+            "SELECT i.on_hand, i.reserved, p.price_cents "
+            "FROM inventory i JOIN products p USING (sku) WHERE i.sku = ?",
+            (sku,),
+        ).fetchone()
+        if row is None:
+            raise SaleError("unknown SKU")
+        available = int(row["on_hand"]) - int(row["reserved"])
+        if quantity > available:
+            raise SaleError(f"requested {quantity}, available {available}")
+        amount = quantity * int(row["price_cents"])
+        new_on_hand = int(row["on_hand"]) - quantity
+        connection.execute("UPDATE inventory SET on_hand=? WHERE sku=?", (new_on_hand, sku))
+        connection.execute("INSERT INTO cash_entries VALUES (?, ?)", (sale_id, amount))
+        if fail_after_cash:
+            raise RuntimeError("injected failure after cash")
+        connection.execute(
+            "INSERT INTO events VALUES (?, 'sale.committed', ?)",
+            (
+                f"event-{sale_id}",
+                json.dumps(
+                    {"amount_cents": amount, "qty": quantity, "sale_id": sale_id, "sku": sku},
+                    sort_keys=True,
+                ),
+            ),
+        )
+        connection.commit()
+        return {"sale_id": sale_id, "quantity": quantity, "amount_cents": amount}
+    except BaseException:
+        connection.rollback()
+        raise
+
+
+def _snapshot(connection: sqlite3.Connection) -> dict[str, int]:
+    inventory = connection.execute(
+        "SELECT on_hand, reserved FROM inventory WHERE sku='SKU-GELATO'"
+    ).fetchone()
+    return {
+        "on_hand": int(inventory["on_hand"]),
+        "reserved": int(inventory["reserved"]),
+        "available": int(inventory["on_hand"]) - int(inventory["reserved"]),
+        "cash_total": int(
+            connection.execute(
+                "SELECT COALESCE(SUM(amount_cents), 0) FROM cash_entries"
+            ).fetchone()[0]
+        ),
+        "cash_rows": int(connection.execute("SELECT COUNT(*) FROM cash_entries").fetchone()[0]),
+        "event_rows": int(connection.execute("SELECT COUNT(*) FROM events").fetchone()[0]),
+    }
+
+
+def exercise(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "sale.sqlite3"
+    _fresh_database(path, on_hand=5, reserved=2)
+    connection = _connect(path)
+
+    reservation_refusal = "not_refused"
+    try:
+        _record_sale(connection, "reserved-sale", "SKU-GELATO", 4)
+    except SaleError as error:
+        reservation_refusal = str(error)
+    after_reservation_refusal = _snapshot(connection)
+
+    committed = _record_sale(connection, "sale-one", "SKU-GELATO", 2)
+    event_payload = json.loads(
+        connection.execute("SELECT payload FROM events WHERE id='event-sale-one'").fetchone()[0]
+    )
+    after_commit = _snapshot(connection)
+
+    injected_failure = "not_raised"
+    before_failure = _snapshot(connection)
+    try:
+        _record_sale(
+            connection,
+            "sale-fault",
+            "SKU-GELATO",
+            1,
+            fail_after_cash=True,
+        )
+    except RuntimeError as error:
+        injected_failure = str(error)
+    after_failure = _snapshot(connection)
+    connection.close()
+
+    race_path = root / "sale-race.sqlite3"
+    _fresh_database(race_path, on_hand=3, reserved=0)
+    barrier = threading.Barrier(2)
+    statuses: list[str] = []
+    statuses_lock = threading.Lock()
+
+    def contend(sale_id: str) -> None:
+        contender = _connect(race_path)
+        barrier.wait()
+        try:
+            _record_sale(contender, sale_id, "SKU-GELATO", 2)
+            status = "committed"
+        except SaleError:
+            status = "refused"
+        with statuses_lock:
+            statuses.append(status)
+        contender.close()
+
+    threads = [
+        threading.Thread(target=contend, args=("race-a",)),
+        threading.Thread(target=contend, args=("race-b",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    race_inspector = _connect(race_path)
+    race_snapshot = _snapshot(race_inspector)
+    race_inspector.close()
+
+    return {
+        "reservation": {
+            "result": reservation_refusal,
+            "state": after_reservation_refusal,
+        },
+        "committed_sale": {
+            "receipt": committed,
+            "event_payload": event_payload,
+            "state": after_commit,
+        },
+        "fault_injection": {
+            "result": injected_failure,
+            "state_unchanged": before_failure == after_failure,
+            "state": after_failure,
+        },
+        "contention": {
+            "statuses": sorted(statuses),
+            "state": race_snapshot,
+        },
+    }

--- a/book/labs/ch09_each_product_has_its_own_threshold/starter.py
+++ b/book/labs/ch09_each_product_has_its_own_threshold/starter.py
@@ -1,0 +1,53 @@
+"""Starter for Chapter 9's invariant-preserving sale lab."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = True
+
+SCHEMA = """
+CREATE TABLE products (
+    sku TEXT PRIMARY KEY,
+    price_cents INTEGER NOT NULL CHECK (price_cents > 0)
+);
+CREATE TABLE inventory (
+    sku TEXT PRIMARY KEY REFERENCES products(sku),
+    on_hand INTEGER NOT NULL CHECK (on_hand >= 0),
+    reserved INTEGER NOT NULL CHECK (reserved >= 0 AND reserved <= on_hand),
+    reorder_point INTEGER NOT NULL CHECK (reorder_point >= 0)
+);
+CREATE TABLE cash_entries (sale_id TEXT PRIMARY KEY, amount_cents INTEGER NOT NULL);
+CREATE TABLE events (id TEXT PRIMARY KEY, kind TEXT NOT NULL, payload TEXT NOT NULL);
+"""
+
+
+class SaleError(RuntimeError):
+    """A domain refusal that should leave every sale table unchanged."""
+
+
+def record_sale(
+    connection: sqlite3.Connection,
+    sale_id: str,
+    sku: str,
+    quantity: int,
+    *,
+    fail_after_cash: bool = False,
+) -> dict[str, int | str]:
+    """Commit inventory, cash, and event as one fact."""
+    # TODO(1): BEGIN IMMEDIATE before reading the product and inventory rows.
+    # TODO(2): Refuse quantity > on_hand - reserved, then calculate the cash
+    # amount from quantity * the catalog's price_cents.
+    # TODO(3): Update inventory and insert cash plus event in the same
+    # transaction. Use fail_after_cash to prove an exception rolls all back.
+    raise NotImplementedError("implement an invariant-preserving sale")
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Prove price, reservation, rollback, and contention invariants."""
+    # TODO(4): Observe a reservation refusal, one successful two-unit sale,
+    # and the state before/after the injected failure.
+    # TODO(5): Race two independent connections selling two of three units;
+    # report statuses without exposing the nondeterministic winner identity.
+    raise NotImplementedError("assemble the Chapter 9 sale experiments")

--- a/book/labs/ch10_one_signal_wakes_one_need/README.md
+++ b/book/labs/ch10_one_signal_wakes_one_need/README.md
@@ -1,0 +1,50 @@
+# Chapter 10 lab: prove the path, not merely the condition
+
+## Challenge
+
+An inventory check says tea is low, and a later observation says stock rose.
+That is useful corroboration, but it does not prove which assignment caused the
+rise. Implement `exercise(root)` so acceptance requires an unbroken graph from
+the intended outcome to its SOW, completed execution, effect, and exact SKU.
+Make sibling proof, an old execution, and a different subject fail separately.
+
+## Production map
+
+Read `Organization.verify_sow` and `Organization.accept`, then descend into
+`apply_restock`. The corresponding falsification tests are named in
+`lab.json`. Notice that the world-condition check and the contribution proof
+answer different questions; neither can substitute for the other.
+
+## Run it
+
+```bash
+python book/labs/ch10_one_signal_wakes_one_need/check.py \
+  book/labs/ch10_one_signal_wakes_one_need/solution.py /tmp/sa-ch10-lab
+```
+
+Copy `starter.py` to `work.py`, implement its seams, and point the checker at
+your copy:
+
+```bash
+cp book/labs/ch10_one_signal_wakes_one_need/starter.py \
+  book/labs/ch10_one_signal_wakes_one_need/work.py
+python book/labs/ch10_one_signal_wakes_one_need/check.py \
+  book/labs/ch10_one_signal_wakes_one_need/work.py /tmp/sa-ch10-work
+```
+
+No network access or credentials are needed.
+
+## Break it
+
+Remove one comparison at a time from your validator. Confirm that the checker
+catches wrong outcome and wrong effect kind. Then invent an attack where the
+right execution produces an effect for the right subject but for a sibling
+outcome. Add the smallest assertion that rejects it without rejecting the
+repaired graph.
+
+## Explain it back
+
+Why can two consistent observations detect a contradiction without
+authenticating an actor? Draw the minimum proof graph and explain which edge
+rejects a sibling SOW, which rejects replayed old work, and which prevents a
+valid tea restock from being presented as proof about cones.

--- a/book/labs/ch10_one_signal_wakes_one_need/check.py
+++ b/book/labs/ch10_one_signal_wakes_one_need/check.py
@@ -1,0 +1,52 @@
+"""Behavioral checker for the Chapter 10 lab."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    if getattr(target_module, "STUDENT_TODO", True):
+        raise AssertionError("complete the starter and set STUDENT_TODO = False")
+    first = target_module.exercise(root)
+    second = target_module.exercise(root)
+    assert first == second, "the exercise must be idempotent"
+    assert first["repaired"] == "ACCEPTED"
+    assert first["attacks"] == {
+        "world_only": "missing_causal_effect",
+        "sibling_proof": "sibling_proof",
+        "wrong_execution": "wrong_execution",
+        "wrong_subject": "wrong_subject",
+    }
+    saved = json.loads((root / "proof-graph.json").read_text(encoding="utf-8"))
+    assert target_module.validate_proof(saved) == "ACCEPTED"
+    assert saved["corroboration"][0]["on_hand"] < saved["world"]["reorder_at"]
+    assert saved["world"]["on_hand"] >= saved["world"]["reorder_at"], (
+        "a successful restock proof must end in a healthy current observation"
+    )
+
+    mutant = json.loads(json.dumps(saved))
+    mutant["effect"]["outcome_id"] = "outcome-cones"
+    assert target_module.validate_proof(mutant) == "wrong_outcome"
+    mutant = json.loads(json.dumps(saved))
+    mutant["effect"]["kind"] = "inventory.observed"
+    assert target_module.validate_proof(mutant) == "wrong_effect_kind"
+    return first
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_lab", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    observation = check(_load(Path(sys.argv[1])), Path(sys.argv[2]))
+    print(json.dumps(observation, indent=2, sort_keys=True))

--- a/book/labs/ch10_one_signal_wakes_one_need/expected.json
+++ b/book/labs/ch10_one_signal_wakes_one_need/expected.json
@@ -1,0 +1,16 @@
+{
+  "attacks": {
+    "sibling_proof": "sibling_proof",
+    "world_only": "missing_causal_effect",
+    "wrong_execution": "wrong_execution",
+    "wrong_subject": "wrong_subject"
+  },
+  "principle": "corroboration_is_not_causal_binding",
+  "proof_edges": [
+    "outcome->sow",
+    "sow->execution",
+    "execution->effect",
+    "effect->subject"
+  ],
+  "repaired": "ACCEPTED"
+}

--- a/book/labs/ch10_one_signal_wakes_one_need/lab.json
+++ b/book/labs/ch10_one_signal_wakes_one_need/lab.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "chapter": "ch10_one_signal_wakes_one_need",
+  "title": "One signal wakes one need: prove causation, not coincidence",
+  "production_sources": [
+    "src/sovereign_agent/organization.py:Organization.accept",
+    "src/sovereign_agent/organization.py:Organization.verify_sow",
+    "src/reference_organizations/store/__init__.py:apply_restock"
+  ],
+  "production_tests": [
+    "tests/test_causal_binding.py::test_condition_true_but_another_execution_contributed_is_refused",
+    "tests/test_causal_binding.py::test_one_sow_cannot_borrow_another_sows_proof",
+    "tests/test_causal_binding.py::test_corroboration_detects_inconsistency_but_does_not_authenticate"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch10_one_signal_wakes_one_need/solution.py
+++ b/book/labs/ch10_one_signal_wakes_one_need/solution.py
@@ -1,0 +1,108 @@
+"""A small executable model of exact causal binding.
+
+This does not imitate the production database.  It isolates the acceptance
+invariant so each edge can be attacked independently.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+STUDENT_TODO = False
+
+
+def validate_proof(graph: dict[str, Any]) -> str:
+    """Return ACCEPTED or the first deterministic refusal category."""
+    expected = graph["expected"]
+    if not graph["world"]["condition_true"]:
+        return "world_condition_false"
+
+    # Signals and observations corroborate the world condition.  They cannot
+    # identify which execution caused the change.
+    if not graph["corroboration"]:
+        return "missing_corroboration"
+
+    execution = graph["execution"]
+    if execution["sow_id"] != expected["sow_id"]:
+        return "sibling_proof"
+    if execution["outcome_id"] != expected["outcome_id"]:
+        return "wrong_outcome"
+    if execution["status"] != "completed":
+        return "execution_incomplete"
+
+    effect = graph.get("effect")
+    if effect is None:
+        return "missing_causal_effect"
+    if effect["execution_id"] != execution["id"]:
+        return "wrong_execution"
+    if effect["outcome_id"] != expected["outcome_id"]:
+        return "wrong_outcome"
+    if effect["subject"] != expected["subject"]:
+        return "wrong_subject"
+    if effect["kind"] != expected["effect_kind"]:
+        return "wrong_effect_kind"
+    return "ACCEPTED"
+
+
+def _base_graph() -> dict[str, Any]:
+    return {
+        "world": {"condition_true": True, "on_hand": 14, "reorder_at": 10},
+        "corroboration": [
+            {"kind": "inventory.low", "subject": "SKU-TEA", "on_hand": 8},
+            {"kind": "inventory.observed", "subject": "SKU-TEA", "on_hand": 14},
+        ],
+        "expected": {
+            "outcome_id": "outcome-tea",
+            "sow_id": "sow-restock-tea",
+            "subject": "SKU-TEA",
+            "effect_kind": "inventory.restocked",
+        },
+        "execution": {
+            "id": "exec-restock-tea",
+            "sow_id": "sow-restock-tea",
+            "outcome_id": "outcome-tea",
+            "status": "completed",
+        },
+        "effect": {
+            "execution_id": "exec-restock-tea",
+            "outcome_id": "outcome-tea",
+            "subject": "SKU-TEA",
+            "kind": "inventory.restocked",
+        },
+    }
+
+
+def exercise(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    repaired = _base_graph()
+    attacks: dict[str, dict[str, Any]] = {}
+
+    attacks["world_only"] = json.loads(json.dumps(repaired))
+    attacks["world_only"]["effect"] = None
+
+    attacks["sibling_proof"] = json.loads(json.dumps(repaired))
+    attacks["sibling_proof"]["execution"]["sow_id"] = "sow-audit-sibling"
+
+    attacks["wrong_execution"] = json.loads(json.dumps(repaired))
+    attacks["wrong_execution"]["effect"]["execution_id"] = "exec-older-replenishment"
+
+    attacks["wrong_subject"] = json.loads(json.dumps(repaired))
+    attacks["wrong_subject"]["effect"]["subject"] = "SKU-CONE"
+
+    result: dict[str, object] = {
+        "principle": "corroboration_is_not_causal_binding",
+        "attacks": {name: validate_proof(graph) for name, graph in attacks.items()},
+        "repaired": validate_proof(repaired),
+        "proof_edges": [
+            "outcome->sow",
+            "sow->execution",
+            "execution->effect",
+            "effect->subject",
+        ],
+    }
+    (root / "proof-graph.json").write_text(
+        json.dumps(repaired, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return result

--- a/book/labs/ch10_one_signal_wakes_one_need/starter.py
+++ b/book/labs/ch10_one_signal_wakes_one_need/starter.py
@@ -1,0 +1,27 @@
+"""Starter for Chapter 10's causal-binding lab."""
+
+from pathlib import Path
+from typing import Any
+
+STUDENT_TODO = True
+Graph = dict[str, Any]
+
+
+def build_repaired_graph() -> Graph:
+    """Return the intended outcome -> SOW -> execution -> effect graph."""
+    # TODO(1): Model a historical low-stock signal and a healthy current observation.
+    raise NotImplementedError
+
+
+def validate_proof(graph: Graph) -> str:
+    """Return ACCEPTED or one stable refusal category."""
+    # TODO(2): Check every causal edge, not merely the final world condition.
+    raise NotImplementedError
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Build attacks and a repaired proof graph, then report the verdicts."""
+    # TODO(3): Mutate one edge per attack and persist the repaired graph below root.
+    raise NotImplementedError(
+        "Bind outcome, SOW, execution, effect, and subject; a true condition is not proof."
+    )

--- a/book/labs/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/labs/ch11_replenishment_scales_without_losing_governance/README.md
@@ -1,0 +1,53 @@
+# Chapter 11 lab: scale the effect, keep the authority
+
+## Challenge
+
+Implement a restock operation that survives two callers racing on the same
+request. Exactly one caller changes inventory and cash; the other observes an
+idempotent replay. A reused key with different content is a conflict, not a
+replay. An unauthorized assignment must fail even when its effect key is new.
+Inventory, cash, and the durable effect must commit or roll back together.
+
+## Production map
+
+Compare your transaction with `apply_restock`, the database transaction
+wrapper, and the causal contribution checks in `Organization.accept`. Follow
+the exact tests in `lab.json`. The teaching model is intentionally smaller,
+but retains the production distinctions between authority, identity,
+idempotency, and atomicity.
+
+## Run it
+
+```bash
+python book/labs/ch11_replenishment_scales_without_losing_governance/check.py \
+  book/labs/ch11_replenishment_scales_without_losing_governance/solution.py \
+  /tmp/sa-ch11-lab
+```
+
+The checker uses two threads with separate SQLite connections; it does not
+simulate concurrency by calling the function twice in sequence.
+
+Copy the scaffold and check your implementation directly:
+
+```bash
+cp book/labs/ch11_replenishment_scales_without_losing_governance/starter.py \
+  book/labs/ch11_replenishment_scales_without_losing_governance/work.py
+python book/labs/ch11_replenishment_scales_without_losing_governance/check.py \
+  book/labs/ch11_replenishment_scales_without_losing_governance/work.py \
+  /tmp/sa-ch11-work
+```
+
+## Break it
+
+Move the effect lookup outside `BEGIN IMMEDIATE`, or replace the primary key
+with a read-then-write boolean. Run the race repeatedly. Next, catch the
+injected fault and commit anyway: inventory will diverge from cash and the
+effect ledger. Finally, skip the payload comparison on replay and observe how
+one key can silently change meaning.
+
+## Explain it back
+
+Why are “authorized,” “idempotent,” and “atomic” three independent claims?
+Explain what the unique effect key proves, what it cannot prove, why exact
+request identity matters, and which transaction boundary prevents partial
+world changes after a crash.

--- a/book/labs/ch11_replenishment_scales_without_losing_governance/check.py
+++ b/book/labs/ch11_replenishment_scales_without_losing_governance/check.py
@@ -1,0 +1,78 @@
+"""Behavioral checker for Chapter 11, including a real two-connection race."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    if getattr(target_module, "STUDENT_TODO", True):
+        raise AssertionError("complete the starter and set STUDENT_TODO = False")
+    first = target_module.exercise(root)
+    second = target_module.exercise(root)
+    assert first == second, "reopening and replaying must preserve the same observation"
+    assert first["state"] == {"tea_on_hand": 10, "cash_cents": 8200, "effect_count": 1}
+    assert first["replay"] == "replay"
+    assert first["unauthorized"] == "unauthorized"
+    assert first["rollback_preserved_state"] is True
+
+    race_db = root / "race.sqlite3"
+    target_module.initialize(race_db)
+    request = target_module.Restock(
+        "restock:race", "assignment-tea", "signal-tea-low", "SKU-TEA", 6, 300
+    )
+    barrier = threading.Barrier(2)
+    outcomes: list[str] = []
+    failures: list[str] = []
+
+    def contender() -> None:
+        try:
+            barrier.wait(timeout=5)
+            outcomes.append(target_module.apply_restock(race_db, request))
+        except BaseException as exc:  # checker must report thread failures
+            failures.append(repr(exc))
+
+    threads = [threading.Thread(target=contender) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15)
+    assert not failures, failures
+    assert not any(thread.is_alive() for thread in threads)
+    assert sorted(outcomes) == ["applied", "replay"]
+    assert target_module.snapshot(race_db) == {
+        "tea_on_hand": 10,
+        "cash_cents": 8200,
+        "effect_count": 1,
+    }
+
+    conflict = target_module.Restock(
+        "restock:race", "assignment-tea", "signal-tea-low", "SKU-TEA", 7, 300
+    )
+    try:
+        target_module.apply_restock(race_db, conflict)
+    except ValueError as exc:
+        assert str(exc) == "effect_identity_conflict"
+    else:
+        raise AssertionError("same key with different payload was misclassified as replay")
+    return first
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_lab", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    observation = check(_load(Path(sys.argv[1])), Path(sys.argv[2]))
+    print(json.dumps(observation, indent=2, sort_keys=True))

--- a/book/labs/ch11_replenishment_scales_without_losing_governance/expected.json
+++ b/book/labs/ch11_replenishment_scales_without_losing_governance/expected.json
@@ -1,0 +1,12 @@
+{
+  "fault": "injected_after_inventory",
+  "lesson": "idempotency_does_not_grant_authority",
+  "replay": "replay",
+  "rollback_preserved_state": true,
+  "state": {
+    "cash_cents": 8200,
+    "effect_count": 1,
+    "tea_on_hand": 10
+  },
+  "unauthorized": "unauthorized"
+}

--- a/book/labs/ch11_replenishment_scales_without_losing_governance/lab.json
+++ b/book/labs/ch11_replenishment_scales_without_losing_governance/lab.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "chapter": "ch11_replenishment_scales_without_losing_governance",
+  "title": "Replenishment scales without losing governance",
+  "production_sources": [
+    "src/reference_organizations/store/__init__.py:apply_restock",
+    "src/sovereign_agent/database.py:Database.transaction",
+    "src/sovereign_agent/organization.py:Organization.accept"
+  ],
+  "production_tests": [
+    "tests/test_causal_binding.py::test_condition_true_contribution_true_accepts",
+    "tests/test_store_multi_sku.py::test_replenishment_effect_for_one_sku_never_touches_another_skus_inventory",
+    "tests/test_store_multi_sku.py::test_two_real_connections_racing_two_different_skus_create_two_canonical_sows"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch11_replenishment_scales_without_losing_governance/solution.py
+++ b/book/labs/ch11_replenishment_scales_without_losing_governance/solution.py
@@ -1,0 +1,186 @@
+"""SQLite exercise: authorization, idempotency, and atomicity are distinct."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+STUDENT_TODO = False
+
+
+class Restock:
+    def __init__(
+        self,
+        effect_key: str,
+        assignment_id: str,
+        signal_id: str,
+        sku: str,
+        quantity: int,
+        unit_cost_cents: int,
+    ) -> None:
+        self.effect_key = effect_key
+        self.assignment_id = assignment_id
+        self.signal_id = signal_id
+        self.sku = sku
+        self.quantity = quantity
+        self.unit_cost_cents = unit_cost_cents
+
+
+def initialize(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.executescript(
+            """
+            PRAGMA journal_mode = WAL;
+            CREATE TABLE IF NOT EXISTS inventory (
+                sku TEXT PRIMARY KEY,
+                on_hand INTEGER NOT NULL CHECK (on_hand >= 0)
+            );
+            CREATE TABLE IF NOT EXISTS cash (
+                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                cents INTEGER NOT NULL CHECK (cents >= 0)
+            );
+            CREATE TABLE IF NOT EXISTS authorizations (
+                assignment_id TEXT PRIMARY KEY,
+                signal_id TEXT NOT NULL,
+                subject TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS effects (
+                effect_key TEXT PRIMARY KEY,
+                assignment_id TEXT NOT NULL,
+                signal_id TEXT NOT NULL,
+                subject TEXT NOT NULL,
+                quantity INTEGER NOT NULL,
+                unit_cost_cents INTEGER NOT NULL
+            );
+            INSERT OR IGNORE INTO inventory(sku, on_hand) VALUES ('SKU-TEA', 4);
+            INSERT OR IGNORE INTO cash(singleton, cents) VALUES (1, 10000);
+            INSERT OR IGNORE INTO authorizations(assignment_id, signal_id, subject)
+                VALUES ('assignment-tea', 'signal-tea-low', 'SKU-TEA');
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def apply_restock(db_path: Path, request: Restock, *, fault: str | None = None) -> str:
+    """Return applied/replay; refuse unauthorized or colliding requests."""
+    connection = sqlite3.connect(db_path, timeout=10)
+    connection.row_factory = sqlite3.Row
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        authorization = connection.execute(
+            "SELECT signal_id, subject FROM authorizations WHERE assignment_id = ?",
+            (request.assignment_id,),
+        ).fetchone()
+        if authorization is None or (authorization["signal_id"], authorization["subject"]) != (
+            request.signal_id,
+            request.sku,
+        ):
+            raise ValueError("unauthorized")
+
+        existing = connection.execute(
+            "SELECT assignment_id, signal_id, subject, quantity, unit_cost_cents "
+            "FROM effects WHERE effect_key = ?",
+            (request.effect_key,),
+        ).fetchone()
+        identity = (
+            request.assignment_id,
+            request.signal_id,
+            request.sku,
+            request.quantity,
+            request.unit_cost_cents,
+        )
+        if existing is not None:
+            durable = tuple(existing)
+            if durable != identity:
+                raise ValueError("effect_identity_conflict")
+            connection.commit()
+            return "replay"
+
+        if request.quantity <= 0 or request.unit_cost_cents < 0:
+            raise ValueError("invalid_restock")
+        cost = request.quantity * request.unit_cost_cents
+        cash = connection.execute("SELECT cents FROM cash WHERE singleton = 1").fetchone()["cents"]
+        if cash < cost:
+            raise ValueError("insufficient_cash")
+
+        updated = connection.execute(
+            "UPDATE inventory SET on_hand = on_hand + ? WHERE sku = ?",
+            (request.quantity, request.sku),
+        )
+        if updated.rowcount != 1:
+            raise ValueError("unknown_sku")
+        if fault == "after_inventory":
+            raise RuntimeError("injected_after_inventory")
+        connection.execute("UPDATE cash SET cents = cents - ? WHERE singleton = 1", (cost,))
+        connection.execute(
+            "INSERT INTO effects VALUES (?, ?, ?, ?, ?, ?)",
+            (request.effect_key, *identity),
+        )
+        connection.commit()
+        return "applied"
+    except BaseException:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def snapshot(db_path: Path) -> dict[str, int]:
+    connection = sqlite3.connect(db_path)
+    try:
+        on_hand = connection.execute(
+            "SELECT on_hand FROM inventory WHERE sku = 'SKU-TEA'"
+        ).fetchone()[0]
+        cash = connection.execute("SELECT cents FROM cash WHERE singleton = 1").fetchone()[0]
+        effects = connection.execute("SELECT COUNT(*) FROM effects").fetchone()[0]
+        return {"tea_on_hand": on_hand, "cash_cents": cash, "effect_count": effects}
+    finally:
+        connection.close()
+
+
+def exercise(root: Path) -> dict[str, object]:
+    db_path = root / "restock.sqlite3"
+    initialize(db_path)
+    canonical = Restock(
+        "restock:signal-tea-low",
+        "assignment-tea",
+        "signal-tea-low",
+        "SKU-TEA",
+        6,
+        300,
+    )
+    apply_restock(db_path, canonical)
+    replay = apply_restock(db_path, canonical)
+
+    unauthorized = "not_tested"
+    try:
+        apply_restock(
+            db_path,
+            Restock("restock:intruder", "assignment-intruder", "signal-tea-low", "SKU-TEA", 2, 300),
+        )
+    except ValueError as exc:
+        unauthorized = str(exc)
+
+    before_fault = snapshot(db_path)
+    rollback = "not_tested"
+    try:
+        apply_restock(
+            db_path,
+            Restock("restock:fault", "assignment-tea", "signal-tea-low", "SKU-TEA", 2, 300),
+            fault="after_inventory",
+        )
+    except RuntimeError as exc:
+        rollback = str(exc)
+
+    return {
+        "state": snapshot(db_path),
+        "replay": replay,
+        "unauthorized": unauthorized,
+        "fault": rollback,
+        "rollback_preserved_state": before_fault == snapshot(db_path),
+        "lesson": "idempotency_does_not_grant_authority",
+    }

--- a/book/labs/ch11_replenishment_scales_without_losing_governance/starter.py
+++ b/book/labs/ch11_replenishment_scales_without_losing_governance/starter.py
@@ -1,0 +1,45 @@
+"""Starter for Chapter 11's transactional restock lab."""
+
+from pathlib import Path
+
+STUDENT_TODO = True
+
+
+class Restock:
+    """Exact identity of one requested replenishment effect."""
+
+    def __init__(
+        self,
+        effect_key: str,
+        assignment_id: str,
+        signal_id: str,
+        sku: str,
+        quantity: int,
+        unit_cost_cents: int,
+    ) -> None:
+        self.effect_key = effect_key
+        self.assignment_id = assignment_id
+        self.signal_id = signal_id
+        self.sku = sku
+        self.quantity = quantity
+        self.unit_cost_cents = unit_cost_cents
+
+
+def initialize(db_path: Path) -> None:
+    """Create inventory, cash, authority, and effect-key tables."""
+    # TODO(1): Add constraints and seed one authorized tea assignment.
+    raise NotImplementedError
+
+
+def apply_restock(db_path: Path, request: Restock, *, fault: str | None = None) -> str:
+    """Apply once or return replay for an exact durable identity."""
+    # TODO(2): Put authority, replay, inventory, cash, and effect writes in one transaction.
+    raise NotImplementedError
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Apply one authorized effect exactly once and prove rollback safety."""
+    # TODO(3): Demonstrate exact replay, unauthorized refusal, and injected rollback.
+    raise NotImplementedError(
+        "Use a durable effect key, exact request identity, and one SQLite transaction."
+    )

--- a/book/labs/ch12_the_pilot_begins_with_a_receipt/README.md
+++ b/book/labs/ch12_the_pilot_begins_with_a_receipt/README.md
@@ -1,0 +1,51 @@
+# Chapter 12 lab: begin with a durable, honest receipt
+
+## Challenge
+
+Build a replayable pilot-start transaction and a small proof-pack verifier.
+The same complete pilot identity must replay without another row or event. The
+same ID with changed identity must conflict, a different active pilot must be
+refused, and an injected fault must leave no orphan. Evidence paths must remain
+inside the root, digests must match bytes, and NOT_RUN prose must not claim a
+success that never occurred.
+
+## Production map
+
+Read `start_pilot`, `active_pilot_id`, and `verify_proof_pack.verify`, then run
+the exact regression tests named in `lab.json`. The local model keeps the
+essential production invariants while avoiding credentials, live providers,
+and any named real pilot organization.
+
+## Run it
+
+```bash
+python book/labs/ch12_the_pilot_begins_with_a_receipt/check.py \
+  book/labs/ch12_the_pilot_begins_with_a_receipt/solution.py /tmp/sa-ch12-lab
+```
+
+Run the same command twice. The second run must describe the same one pilot,
+one active slot, and one start event.
+
+Copy the scaffold to a working file before implementing it:
+
+```bash
+cp book/labs/ch12_the_pilot_begins_with_a_receipt/starter.py \
+  book/labs/ch12_the_pilot_begins_with_a_receipt/work.py
+python book/labs/ch12_the_pilot_begins_with_a_receipt/check.py \
+  book/labs/ch12_the_pilot_begins_with_a_receipt/work.py /tmp/sa-ch12-work
+```
+
+## Break it
+
+Treat every matching `pilot_id` as a replay without comparing the other three
+identity fields. Commit the pilot row before reserving the singleton active
+slot. Replace resolved-path containment with a string-prefix test. Finally,
+change the NOT_RUN note to “passed” and remove the lie scan. Each mutation
+should create a specific checker failure.
+
+## Explain it back
+
+Why is a replay an exact identity claim rather than merely a duplicate-key
+case? Why must the row, active slot, and event share one transaction? Explain
+how a digest detects changed bytes yet cannot prove who produced them, and why
+an internally consistent proof pack can honestly report `authenticated: false`.

--- a/book/labs/ch12_the_pilot_begins_with_a_receipt/check.py
+++ b/book/labs/ch12_the_pilot_begins_with_a_receipt/check.py
@@ -1,0 +1,88 @@
+"""Behavioral checker for the Chapter 12 pilot and evidence lab."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def check(target_module: ModuleType, root: Path) -> dict[str, object]:
+    if getattr(target_module, "STUDENT_TODO", True):
+        raise AssertionError("complete the starter and set STUDENT_TODO = False")
+    first = target_module.exercise(root)
+    second = target_module.exercise(root)
+    assert first == second, "pilot replay across invocations must be stable"
+    assert first["pilot"] == {
+        "pilots": ["pilot-lucy-01"],
+        "active": "pilot-lucy-01",
+        "started_events": 1,
+    }
+    assert first["replay"] == "replay"
+    assert first["no_orphan_after_fault"] is True
+    proof = first["proof_pack"]
+    assert proof["valid_failures"] == []
+    assert proof["attacks"] == {
+        "path_escape": ["path_escape"],
+        "digest_mismatch": ["digest_mismatch"],
+        "not_run_lie": ["not_run_success_claim"],
+    }
+    assert proof["internally_consistent"] is True
+    assert proof["authenticated"] is False
+
+    isolated = root / "fault-only.sqlite3"
+    target_module.initialize(isolated)
+    request = target_module.PilotStart("pilot-fault", "store", "profile", "ns")
+    try:
+        target_module.start_pilot(isolated, request, fault="after_pilot")
+    except RuntimeError as exc:
+        assert str(exc) == "injected_after_pilot"
+    else:
+        raise AssertionError("fault injection did not interrupt pilot start")
+    assert target_module.pilot_snapshot(isolated) == {
+        "pilots": [],
+        "active": None,
+        "started_events": 0,
+    }
+
+    conflict = target_module.PilotStart(
+        "pilot-lucy-01", "store-lucy", "profile-changed", "evidence/lucy-01"
+    )
+    try:
+        target_module.start_pilot(root / "pilot.sqlite3", conflict)
+    except ValueError as exc:
+        assert str(exc) == "pilot_identity_conflict"
+    else:
+        raise AssertionError("same pilot id with changed identity was accepted as replay")
+
+    before_other = target_module.pilot_snapshot(root / "pilot.sqlite3")
+    other = target_module.PilotStart(
+        "pilot-lucy-02", "store-lucy", "profile-safe", "evidence/lucy-02"
+    )
+    try:
+        target_module.start_pilot(root / "pilot.sqlite3", other)
+    except ValueError as exc:
+        assert str(exc) == "pilot_already_active"
+    else:
+        raise AssertionError("a different pilot occupied an already active singleton slot")
+    assert target_module.pilot_snapshot(root / "pilot.sqlite3") == before_other, (
+        "refusing a different active pilot must roll back its inserted row"
+    )
+    return first
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("student_lab", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    observation = check(_load(Path(sys.argv[1])), Path(sys.argv[2]))
+    print(json.dumps(observation, indent=2, sort_keys=True))

--- a/book/labs/ch12_the_pilot_begins_with_a_receipt/expected.json
+++ b/book/labs/ch12_the_pilot_begins_with_a_receipt/expected.json
@@ -1,0 +1,28 @@
+{
+  "fault": "injected_after_pilot",
+  "no_orphan_after_fault": true,
+  "pilot": {
+    "active": "pilot-lucy-01",
+    "pilots": [
+      "pilot-lucy-01"
+    ],
+    "started_events": 1
+  },
+  "proof_pack": {
+    "attacks": {
+      "digest_mismatch": [
+        "digest_mismatch"
+      ],
+      "not_run_lie": [
+        "not_run_success_claim"
+      ],
+      "path_escape": [
+        "path_escape"
+      ]
+    },
+    "authenticated": false,
+    "internally_consistent": true,
+    "valid_failures": []
+  },
+  "replay": "replay"
+}

--- a/book/labs/ch12_the_pilot_begins_with_a_receipt/lab.json
+++ b/book/labs/ch12_the_pilot_begins_with_a_receipt/lab.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "chapter": "ch12_the_pilot_begins_with_a_receipt",
+  "title": "The pilot begins with a receipt",
+  "production_sources": [
+    "src/reference_organizations/store/pilot.py:start_pilot",
+    "src/reference_organizations/store/pilot.py:active_pilot_id",
+    "src/sovereign_agent/evidence.py:record_check"
+  ],
+  "production_tests": [
+    "tests/test_pilot.py::test_replaying_the_same_start_request_does_not_create_a_second_pilot",
+    "tests/test_pilot.py::test_a_refused_start_leaves_no_orphaned_pilot_row",
+    "tests/test_proof_pack.py::test_andrea_not_run_with_success_prose_is_rejected",
+    "tests/test_proof_pack.py::test_digest_mismatch_still_rejected",
+    "tests/test_proof_pack.py::test_path_escape_still_rejected"
+  ],
+  "entrypoint": "exercise",
+  "expected": "expected.json"
+}

--- a/book/labs/ch12_the_pilot_begins_with_a_receipt/solution.py
+++ b/book/labs/ch12_the_pilot_begins_with_a_receipt/solution.py
@@ -1,0 +1,209 @@
+"""Executable pilot-start and proof-pack honesty model."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+STUDENT_TODO = False
+
+SUCCESS_WORDS = re.compile(r"\b(pass(?:ed)?|succeed(?:ed)?|verified live)\b", re.IGNORECASE)
+ALLOWED_STATUSES = {"NOT_RUN", "NOT_RUN_UNAVAILABLE", "NOT_RUN_UNAUTHENTICATED", "PASS", "FAIL"}
+
+
+class PilotStart:
+    def __init__(
+        self,
+        pilot_id: str,
+        store_org_id: str,
+        pilot_profile_id: str,
+        evidence_namespace: str,
+    ) -> None:
+        self.pilot_id = pilot_id
+        self.store_org_id = store_org_id
+        self.pilot_profile_id = pilot_profile_id
+        self.evidence_namespace = evidence_namespace
+
+
+def initialize(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.executescript(
+            """
+            PRAGMA journal_mode = WAL;
+            CREATE TABLE IF NOT EXISTS pilots (
+                pilot_id TEXT PRIMARY KEY,
+                store_org_id TEXT NOT NULL,
+                pilot_profile_id TEXT NOT NULL,
+                evidence_namespace TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS active_pilot (
+                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                pilot_id TEXT NOT NULL UNIQUE REFERENCES pilots(pilot_id)
+            );
+            CREATE TABLE IF NOT EXISTS events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                kind TEXT NOT NULL,
+                subject TEXT NOT NULL
+            );
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def start_pilot(db_path: Path, request: PilotStart, *, fault: str | None = None) -> str:
+    connection = sqlite3.connect(db_path, timeout=10)
+    connection.row_factory = sqlite3.Row
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        existing = connection.execute(
+            "SELECT store_org_id, pilot_profile_id, evidence_namespace "
+            "FROM pilots WHERE pilot_id = ?",
+            (request.pilot_id,),
+        ).fetchone()
+        identity = (
+            request.store_org_id,
+            request.pilot_profile_id,
+            request.evidence_namespace,
+        )
+        if existing is not None:
+            if tuple(existing) != identity:
+                raise ValueError("pilot_identity_conflict")
+            connection.commit()
+            return "replay"
+
+        connection.execute(
+            "INSERT INTO pilots VALUES (?, ?, ?, ?)",
+            (request.pilot_id, *identity),
+        )
+        if fault == "after_pilot":
+            raise RuntimeError("injected_after_pilot")
+        try:
+            connection.execute(
+                "INSERT INTO active_pilot(singleton, pilot_id) VALUES (1, ?)",
+                (request.pilot_id,),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError("pilot_already_active") from exc
+        connection.execute(
+            "INSERT INTO events(kind, subject) VALUES ('pilot.started', ?)",
+            (request.pilot_id,),
+        )
+        connection.commit()
+        return "started"
+    except BaseException:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def pilot_snapshot(db_path: Path) -> dict[str, object]:
+    connection = sqlite3.connect(db_path)
+    try:
+        pilots = connection.execute("SELECT pilot_id FROM pilots ORDER BY pilot_id").fetchall()
+        active = connection.execute("SELECT pilot_id FROM active_pilot").fetchone()
+        events = connection.execute(
+            "SELECT COUNT(*) FROM events WHERE kind = 'pilot.started'"
+        ).fetchone()[0]
+        return {
+            "pilots": [row[0] for row in pilots],
+            "active": None if active is None else active[0],
+            "started_events": events,
+        }
+    finally:
+        connection.close()
+
+
+def verify_manifest(manifest: dict[str, Any], evidence_root: Path) -> list[str]:
+    """Check internal consistency; deliberately make no authenticity claim."""
+    failures: list[str] = []
+    status = manifest.get("evaluation", {}).get("status")
+    note = manifest.get("evaluation", {}).get("note", "")
+    if status not in ALLOWED_STATUSES:
+        failures.append("unknown_status")
+    if isinstance(status, str) and status.startswith("NOT_RUN") and SUCCESS_WORDS.search(str(note)):
+        failures.append("not_run_success_claim")
+
+    root = evidence_root.resolve()
+    for artifact in manifest.get("artifacts", []):
+        relative = artifact.get("path")
+        if not isinstance(relative, str):
+            failures.append("invalid_path")
+            continue
+        candidate = (root / relative).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            failures.append("path_escape")
+            continue
+        if not candidate.is_file():
+            failures.append("missing_artifact")
+            continue
+        actual = hashlib.sha256(candidate.read_bytes()).hexdigest()
+        if actual != artifact.get("sha256"):
+            failures.append("digest_mismatch")
+    return sorted(set(failures))
+
+
+def exercise(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    db_path = root / "pilot.sqlite3"
+    initialize(db_path)
+    pilot = PilotStart("pilot-lucy-01", "store-lucy", "profile-safe", "evidence/lucy-01")
+    start_pilot(db_path, pilot)
+    replay = start_pilot(db_path, pilot)
+
+    before_fault = pilot_snapshot(db_path)
+    fault = "not_tested"
+    try:
+        start_pilot(
+            db_path,
+            PilotStart("pilot-orphan", "store-other", "profile-other", "evidence/other"),
+            fault="after_pilot",
+        )
+    except RuntimeError as exc:
+        fault = str(exc)
+
+    evidence = root / "evidence" / "result.txt"
+    evidence.parent.mkdir(parents=True, exist_ok=True)
+    if not evidence.exists():
+        evidence.write_text("local preflight complete\n", encoding="utf-8")
+    digest = hashlib.sha256(evidence.read_bytes()).hexdigest()
+    valid = {
+        "evaluation": {
+            "status": "NOT_RUN_UNAUTHENTICATED",
+            "note": "Credentialed evaluation did not run.",
+        },
+        "artifacts": [{"path": "evidence/result.txt", "sha256": digest}],
+    }
+    attacks = {
+        "path_escape": json.loads(json.dumps(valid)),
+        "digest_mismatch": json.loads(json.dumps(valid)),
+        "not_run_lie": json.loads(json.dumps(valid)),
+    }
+    attacks["path_escape"]["artifacts"][0]["path"] = "../outside.txt"
+    attacks["digest_mismatch"]["artifacts"][0]["sha256"] = "0" * 64
+    attacks["not_run_lie"]["evaluation"]["note"] = "Live evaluation passed."
+
+    return {
+        "pilot": pilot_snapshot(db_path),
+        "replay": replay,
+        "fault": fault,
+        "no_orphan_after_fault": before_fault == pilot_snapshot(db_path),
+        "proof_pack": {
+            "valid_failures": verify_manifest(valid, root),
+            "attacks": {
+                name: verify_manifest(manifest, root) for name, manifest in attacks.items()
+            },
+            "internally_consistent": True,
+            "authenticated": False,
+        },
+    }

--- a/book/labs/ch12_the_pilot_begins_with_a_receipt/starter.py
+++ b/book/labs/ch12_the_pilot_begins_with_a_receipt/starter.py
@@ -1,0 +1,42 @@
+"""Starter for Chapter 12's pilot and proof-pack lab."""
+
+from pathlib import Path
+from typing import Any
+
+STUDENT_TODO = True
+
+
+class PilotStart:
+    """The four fields whose exact equality defines a safe replay."""
+
+    def __init__(
+        self,
+        pilot_id: str,
+        store_org_id: str,
+        pilot_profile_id: str,
+        evidence_namespace: str,
+    ) -> None:
+        self.pilot_id = pilot_id
+        self.store_org_id = store_org_id
+        self.pilot_profile_id = pilot_profile_id
+        self.evidence_namespace = evidence_namespace
+
+
+def start_pilot(db_path: Path, request: PilotStart, *, fault: str | None = None) -> str:
+    """Start, replay, or refuse while preserving one atomic pilot state."""
+    # TODO(1): Compare full identity and transact row, singleton slot, and event together.
+    raise NotImplementedError
+
+
+def verify_manifest(manifest: dict[str, Any], evidence_root: Path) -> list[str]:
+    """Return deterministic path, digest, status, and honesty failures."""
+    # TODO(2): Resolve evidence paths, recompute hashes, and reject NOT_RUN success prose.
+    raise NotImplementedError
+
+
+def exercise(root: Path) -> dict[str, object]:
+    """Start exactly one pilot and verify honest, confined evidence."""
+    # TODO(3): Prove replay/no-orphan behavior and run all proof-pack mutations.
+    raise NotImplementedError(
+        "Make replay exact, pilot start atomic, and proof-pack validation fail closed."
+    )

--- a/book/labs/lab.schema.json
+++ b/book/labs/lab.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zeroemployee.org/sovereign-agent/book-lab.schema.json",
+  "title": "Sovereign Agent companion lab",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "chapter",
+    "title",
+    "production_sources",
+    "production_tests",
+    "entrypoint",
+    "expected"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "chapter": {
+      "type": "string",
+      "pattern": "^ch(0[0-9]|1[0-2])_[a-z0-9_]+$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "production_sources": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^src/(?!.*(?:^|/)\\.\\.(?:/|$))[^:]+\\.py:[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+      }
+    },
+    "production_tests": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^tests/[^:]+\\.py::[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)?$"
+      }
+    },
+    "entrypoint": {
+      "const": "exercise"
+    },
+    "expected": {
+      "const": "expected.json"
+    }
+  }
+}

--- a/scripts/verify_book_labs.py
+++ b/scripts/verify_book_labs.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Verify the thirteen runnable companion labs.
+
+This gate uses only the Python standard library. It validates metadata against
+the live source and test trees, imports the learner and reference modules, and
+runs each behavioral checker twice against independent temporary roots.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import inspect
+import io
+import json
+import re
+import sys
+import tempfile
+import tokenize
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LABS_ROOT = REPO_ROOT / "book" / "labs"
+SRC_ROOT = (REPO_ROOT / "src").resolve()
+TESTS_ROOT = (REPO_ROOT / "tests").resolve()
+
+CHAPTERS = (
+    "ch00_first_shift",
+    "ch01_organization_remembers",
+    "ch02_work_needs_governance",
+    "ch03_actor_is_not_a_model",
+    "ch04_work_stays_inside_its_boundary",
+    "ch05_authority_needs_a_fence",
+    "ch06_the_organization_recovers",
+    "ch07_the_organization_wakes_itself",
+    "ch08_the_store_becomes_a_catalog",
+    "ch09_each_product_has_its_own_threshold",
+    "ch10_one_signal_wakes_one_need",
+    "ch11_replenishment_scales_without_losing_governance",
+    "ch12_the_pilot_begins_with_a_receipt",
+)
+
+REQUIRED_FILES = (
+    "README.md",
+    "lab.json",
+    "starter.py",
+    "solution.py",
+    "check.py",
+    "expected.json",
+)
+
+REQUIRED_HEADINGS = (
+    "## Challenge",
+    "## Production map",
+    "## Run it",
+    "## Break it",
+    "## Explain it back",
+)
+
+LAB_JSON_KEYS = {
+    "schema_version",
+    "chapter",
+    "title",
+    "production_sources",
+    "production_tests",
+    "entrypoint",
+    "expected",
+}
+
+NUMBERED_TODO = re.compile(r"^# TODO\((\d+)\):")
+
+
+def _load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def _safe_repo_file(value: object, *, prefix: str, root: Path) -> tuple[Path | None, str | None]:
+    if not isinstance(value, str) or not value:
+        return None, "must be a nonempty string"
+    relative = Path(value)
+    if relative.is_absolute() or ".." in relative.parts:
+        return None, f"path escapes the repository: {value!r}"
+    if not value.startswith(f"{prefix}/"):
+        return None, f"must be below {prefix}/: {value!r}"
+    candidate = (REPO_ROOT / relative).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None, f"path escapes {prefix}/ after resolution: {value!r}"
+    if not candidate.is_file():
+        return None, f"file does not exist: {value!r}"
+    return candidate, None
+
+
+def _test_node_exists(node: object) -> str | None:
+    if not isinstance(node, str):
+        return "test node must be a string"
+    parts = node.split("::")
+    if len(parts) not in (2, 3) or any(not part for part in parts):
+        return f"test node must be file::test or file::Class::test: {node!r}"
+
+    test_file, error = _safe_repo_file(parts[0], prefix="tests", root=TESTS_ROOT)
+    if error is not None:
+        return error
+    assert test_file is not None
+
+    try:
+        tree = ast.parse(test_file.read_text(encoding="utf-8"), filename=str(test_file))
+    except (OSError, SyntaxError) as exc:
+        return f"cannot inspect test node {node!r}: {type(exc).__name__}: {exc}"
+
+    if len(parts) == 2:
+        name = parts[1]
+        exists = any(
+            isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == name
+            for item in tree.body
+        )
+    else:
+        class_name, method_name = parts[1:]
+        matching_classes = (
+            item for item in tree.body if isinstance(item, ast.ClassDef) and item.name == class_name
+        )
+        exists = any(
+            isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and member.name == method_name
+            for class_node in matching_classes
+            for member in class_node.body
+        )
+    if not exists:
+        return f"test node does not exist: {node!r}"
+    return None
+
+
+def _assignment_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return {name for item in target.elts for name in _assignment_names(item)}
+    return set()
+
+
+def _production_source_exists(reference: object) -> str | None:
+    if not isinstance(reference, str):
+        return "production source must be a string"
+    try:
+        file_name, symbol = reference.rsplit(":", 1)
+    except ValueError:
+        return f"production source must be file.py:Symbol: {reference!r}"
+    symbol_parts = symbol.split(".")
+    if not symbol_parts or any(not part.isidentifier() for part in symbol_parts):
+        return f"production source has invalid symbol: {reference!r}"
+    source_file, error = _safe_repo_file(file_name, prefix="src", root=SRC_ROOT)
+    if error is not None:
+        return error
+    assert source_file is not None
+    try:
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+    except (OSError, SyntaxError) as exc:
+        return f"cannot inspect production source {reference!r}: {type(exc).__name__}: {exc}"
+
+    def named_children(nodes: list[ast.stmt]) -> dict[str, ast.AST]:
+        found: dict[str, ast.AST] = {}
+        for item in nodes:
+            if isinstance(item, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                found[item.name] = item
+            elif isinstance(item, ast.Assign):
+                for target in item.targets:
+                    for name in _assignment_names(target):
+                        found[name] = item
+            elif isinstance(item, ast.AnnAssign):
+                for name in _assignment_names(item.target):
+                    found[name] = item
+        return found
+
+    current: ast.AST | None = named_children(tree.body).get(symbol_parts[0])
+    for part in symbol_parts[1:]:
+        if not isinstance(current, ast.ClassDef):
+            current = None
+            break
+        current = named_children(current.body).get(part)
+    if current is None:
+        return f"production symbol does not exist: {reference!r}"
+    return None
+
+
+def _import_module(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not create an import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _has_positional_contract(function: object, names: tuple[str, ...]) -> bool:
+    if not callable(function):
+        return False
+    try:
+        signature = inspect.signature(function)
+    except TypeError:
+        return False
+    except ValueError:
+        return False
+    parameters = tuple(signature.parameters.values())
+    return len(parameters) == len(names) and all(
+        parameter.name == name
+        and parameter.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        for parameter, name in zip(parameters, names, strict=True)
+    )
+
+
+def _json_round_trip(value: object) -> object:
+    encoded = json.dumps(value, allow_nan=False, sort_keys=True, separators=(",", ":"))
+    return json.loads(encoded)
+
+
+def _check_starter_shape(path: Path) -> list[str]:
+    problems: list[str] = []
+    source = path.read_text(encoding="utf-8")
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(source).readline))
+    except (IndentationError, tokenize.TokenError) as exc:
+        problems.append(f"starter.py cannot be tokenized: {type(exc).__name__}: {exc}")
+        tokens = []
+    todo_numbers = {
+        int(match.group(1))
+        for token in tokens
+        if token.type == tokenize.COMMENT
+        for match in [NUMBERED_TODO.match(token.string)]
+        if match is not None
+    }
+    if len(todo_numbers) < 3:
+        problems.append(
+            "starter.py must contain at least three distinct numbered markers such as '# TODO(1):'"
+        )
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        problems.append(f"starter.py cannot be parsed: {type(exc).__name__}: {exc}")
+        return problems
+    helpers = [
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        and node.name != "exercise"
+    ]
+    if not helpers:
+        problems.append(
+            "starter.py must contain a top-level helper function or class besides exercise"
+        )
+    return problems
+
+
+def _check_metadata(chapter: str, lab_dir: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    problems: list[str] = []
+    path = lab_dir / "lab.json"
+    try:
+        metadata = _load_json(path)
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, [f"lab.json cannot be read: {type(exc).__name__}: {exc}"]
+    if not isinstance(metadata, dict):
+        return None, ["lab.json must contain one JSON object"]
+
+    keys = set(metadata)
+    if keys != LAB_JSON_KEYS:
+        missing = sorted(LAB_JSON_KEYS - keys)
+        extra = sorted(keys - LAB_JSON_KEYS)
+        if missing:
+            problems.append(f"lab.json missing keys: {', '.join(missing)}")
+        if extra:
+            problems.append(f"lab.json unknown keys: {', '.join(extra)}")
+    if metadata.get("schema_version") != 1:
+        problems.append("lab.json schema_version must be 1")
+    if metadata.get("chapter") != chapter:
+        problems.append(f"lab.json chapter must be {chapter!r}")
+    title = metadata.get("title")
+    if not isinstance(title, str) or not title.strip():
+        problems.append("lab.json title must be a nonempty string")
+    if metadata.get("entrypoint") != "exercise":
+        problems.append("lab.json entrypoint must be 'exercise'")
+    if metadata.get("expected") != "expected.json":
+        problems.append("lab.json expected must be 'expected.json'")
+
+    sources = metadata.get("production_sources")
+    if not isinstance(sources, list) or not sources:
+        problems.append("lab.json production_sources must be a nonempty list")
+    else:
+        if len(sources) != len(set(item for item in sources if isinstance(item, str))):
+            problems.append("lab.json production_sources contains duplicates")
+        for source in sources:
+            error = _production_source_exists(source)
+            if error is not None:
+                problems.append(f"production_sources: {error}")
+
+    nodes = metadata.get("production_tests")
+    if not isinstance(nodes, list) or not nodes:
+        problems.append("lab.json production_tests must be a nonempty list")
+    else:
+        if len(nodes) != len(set(item for item in nodes if isinstance(item, str))):
+            problems.append("lab.json production_tests contains duplicates")
+        for node in nodes:
+            error = _test_node_exists(node)
+            if error is not None:
+                problems.append(f"production_tests: {error}")
+    return metadata, problems
+
+
+def check_lab(chapter: str) -> list[str]:
+    problems: list[str] = []
+    lab_dir = LABS_ROOT / chapter
+    if not lab_dir.is_dir():
+        return ["lab directory is missing"]
+
+    for filename in REQUIRED_FILES:
+        if not (lab_dir / filename).is_file():
+            problems.append(f"required file is missing: {filename}")
+    if problems:
+        return problems
+
+    readme = (lab_dir / "README.md").read_text(encoding="utf-8")
+    for heading in REQUIRED_HEADINGS:
+        if heading not in readme.splitlines():
+            problems.append(f"README.md is missing exact heading {heading!r}")
+
+    problems.extend(_check_starter_shape(lab_dir / "starter.py"))
+
+    metadata, metadata_problems = _check_metadata(chapter, lab_dir)
+    problems.extend(metadata_problems)
+
+    try:
+        expected = _load_json(lab_dir / "expected.json")
+        if not isinstance(expected, dict):
+            problems.append("expected.json must contain one JSON object")
+        expected = _json_round_trip(expected)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        problems.append(f"expected.json is not strict JSON: {type(exc).__name__}: {exc}")
+        expected = None
+
+    old_path = list(sys.path)
+    sys.path[:0] = [str(lab_dir), str(REPO_ROOT / "src"), str(REPO_ROOT)]
+    try:
+        starter = _import_module(lab_dir / "starter.py", f"book_lab_{chapter}_starter")
+        solution = _import_module(lab_dir / "solution.py", f"book_lab_{chapter}_solution")
+        checker = _import_module(lab_dir / "check.py", f"book_lab_{chapter}_check")
+    except Exception as exc:  # noqa: BLE001 - every import defect is reported by the gate
+        problems.append(f"module import failed: {type(exc).__name__}: {exc}")
+        return problems
+    finally:
+        sys.path[:] = old_path
+
+    starter_exercise = getattr(starter, "exercise", None)
+    solution_exercise = getattr(solution, "exercise", None)
+    check = getattr(checker, "check", None)
+    if getattr(starter, "STUDENT_TODO", None) is not True:
+        problems.append("starter.py must set STUDENT_TODO = True")
+    if getattr(solution, "STUDENT_TODO", None) is not False:
+        problems.append("solution.py must set STUDENT_TODO = False")
+    if not _has_positional_contract(starter_exercise, ("root",)):
+        problems.append("starter.py must expose exercise(root) with exactly that parameter")
+    if not _has_positional_contract(solution_exercise, ("root",)):
+        problems.append("solution.py must expose exercise(root) with exactly that parameter")
+    if not _has_positional_contract(check, ("target_module", "root")):
+        problems.append("check.py must expose check(target_module, root)")
+
+    if callable(starter_exercise):
+        with tempfile.TemporaryDirectory(prefix=f"book-lab-{chapter}-starter-") as scratch:
+            root = Path(scratch) / "root"
+            try:
+                starter_exercise(root)
+            except NotImplementedError:
+                pass
+            except Exception as exc:  # noqa: BLE001 - report wrong pedagogical failure
+                problems.append(
+                    f"starter exercise raised the wrong exception: {type(exc).__name__}: {exc}"
+                )
+            else:
+                problems.append("starter exercise must raise NotImplementedError")
+
+    if _has_positional_contract(solution_exercise, ("root",)) and _has_positional_contract(
+        check, ("target_module", "root")
+    ):
+        observations: list[object] = []
+        for run_number in (1, 2):
+            with tempfile.TemporaryDirectory(
+                prefix=f"book-lab-{chapter}-solution-{run_number}-"
+            ) as scratch:
+                root = Path(scratch) / "root"
+                exercise_calls = 0
+
+                def observed_exercise(exercise_root: Path) -> dict[str, object]:
+                    nonlocal exercise_calls
+                    exercise_calls += 1
+                    return solution_exercise(exercise_root)
+
+                solution.exercise = observed_exercise
+                try:
+                    result = check(solution, root)
+                    if not isinstance(result, dict):
+                        raise TypeError("check() must return a dictionary")
+                    observations.append(_json_round_trip(result))
+                except Exception as exc:  # noqa: BLE001 - behavioral failures are gate failures
+                    problems.append(
+                        f"solution check run {run_number} failed: {type(exc).__name__}: {exc}"
+                    )
+                finally:
+                    solution.exercise = solution_exercise
+                if exercise_calls == 0:
+                    problems.append(f"solution check run {run_number} did not call exercise(root)")
+        if len(observations) == 2:
+            if observations[0] != observations[1]:
+                problems.append("solution observations differ across two fresh roots")
+            if expected is not None:
+                for index, observation in enumerate(observations, start=1):
+                    if observation != expected:
+                        problems.append(
+                            f"solution check run {index} does not match expected.json: "
+                            f"observed={json.dumps(observation, sort_keys=True)}"
+                        )
+    return problems
+
+
+def main() -> int:
+    failures: list[str] = []
+    if not LABS_ROOT.is_dir():
+        print("FAIL book/labs directory is missing")
+        return 1
+
+    actual_directories = {
+        path.name
+        for path in LABS_ROOT.iterdir()
+        if path.is_dir() and path.name != "__pycache__" and not path.name.startswith(".")
+    }
+    expected_directories = set(CHAPTERS)
+    for extra in sorted(actual_directories - expected_directories):
+        failures.append(f"{extra}: unexpected lab directory")
+
+    for chapter in CHAPTERS:
+        chapter_problems = check_lab(chapter)
+        if chapter_problems:
+            for problem in chapter_problems:
+                failures.append(f"{chapter}: {problem}")
+            print(f"FAIL {chapter} ({len(chapter_problems)} defects)")
+        else:
+            print(f"PASS {chapter}")
+
+    if failures:
+        print(f"\nbook labs: FAIL ({len(failures)} defects)")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print(f"\nbook labs: PASS ({len(CHAPTERS)} labs, solutions deterministic twice)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Outcome

Adds a runnable companion lab for every book chapter without changing the chapter prose owned by PR #58.

Each of the 13 labs contains:

- an actionable student starter with numbered implementation seams;
- an offline reference solution;
- behavioral checks that grade invariants rather than source shape;
- deterministic expected observations;
- adversarial mutation prompts; and
- exact production-symbol and production-test mappings.

`scripts/verify_book_labs.py` validates the lab schema, paths, AST-resolved production symbols, exact test nodes, starter scaffolding, intentional incomplete seam, behavioral checker invocation, strict JSON output, and twice-from-independent-fresh-roots determinism. It is wired into CI and `make verify`.

## Technical coverage

- ch00–03: governed trace, ledger/projection drift, layered acceptance proof, real Actor/provider capability contract.
- ch04–06: hostile workspace paths and receipt scope, mailbox CAS/fencing, crash recovery without guessed success.
- ch07–09: transactional manual Pulse tick, populated catalog migration, atomic reservation-aware sales under contention.
- ch10–12: exact causal binding, idempotent authorized restock, replayable pilot and proof-pack honesty mutations.

## Verification at exact head `eb249f927760c87dc752bc8d192897b2bda87910`

- `make verify`: PASS
- Ruff format/check: PASS
- mypy: PASS
- pytest: 385 passed, 10 deselected
- existing curriculum: 13 chapters, 13 exercises executed
- companion labs: 13/13 PASS, every solution twice from independent fresh roots
- runtime dependency and source-budget gates: PASS
- offline doctor and simulated accepted outcome: PASS

Coordination: rodriveracom/org-zeroemployeeorg#207, `corr_book-raschka`.

This PR is additive and path-fenced from PR #58's chapter prose. It is not self-authorized to merge.
