### PR TITLE
Bind companion labs into the coverage manifest (three-instrument agreement)

### DIFF
--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -54,7 +54,8 @@
         "UPDATE inventory SET on_hand = 0 WHERE on_hand > 0;",
         "available=0 (on_hand=0 - reserved=0) vs reorder_point=3",
         "3 problem(s): this outcome is NOT truthfully accepted."
-      ]
+      ],
+      "lab": "book/labs/ch00_first_shift"
     },
     "ch01_organization_remembers": {
       "depth": "full",
@@ -137,7 +138,8 @@
         "left behind:",
         "still broken:",
         "OK\nOK"
-      ]
+      ],
+      "lab": "book/labs/ch01_organization_remembers"
     },
     "ch02_work_needs_governance": {
       "depth": "full",
@@ -214,7 +216,8 @@
         "receipts on file: 0",
         "evidence reassigned: 1",
         "holds for OTHER reasons"
-      ]
+      ],
+      "lab": "book/labs/ch02_work_needs_governance"
     },
     "ch03_actor_is_not_a_model": {
       "depth": "full",
@@ -291,7 +294,8 @@
         "ledger's last rebind: scripted",
         "silence is not success",
         "cannot prove capability"
-      ]
+      ],
+      "lab": "book/labs/ch03_actor_is_not_a_model"
     },
     "ch04_work_stays_inside_its_boundary": {
       "depth": "full",
@@ -367,7 +371,8 @@
         "inside according to the string check: True",
         "deliverable(s) already exist",
         "INJECTED"
-      ]
+      ],
+      "lab": "book/labs/ch04_work_stays_inside_its_boundary"
     },
     "ch05_authority_needs_a_fence": {
       "depth": "full",
@@ -438,7 +443,8 @@
         "owner on disk: worker-b",
         "refused, unexpired lease held by worker-b",
         "refused, stale or wrong token"
-      ]
+      ],
+      "lab": "book/labs/ch05_authority_needs_a_fence"
     },
     "ch06_the_organization_recovers": {
       "depth": "full",
@@ -505,7 +511,8 @@
         "worker left a completed report -- marked COMPLETED",
         "nothing to recover",
         "kept: ['report.json']"
-      ]
+      ],
+      "lab": "book/labs/ch06_the_organization_recovers"
     },
     "ch07_the_organization_wakes_itself": {
       "depth": "full",
@@ -580,7 +587,8 @@
         "SOWs on the ledger: 2",
         "already decided: canonical work is sow-sig-1",
         "signal no longer qualifies"
-      ]
+      ],
+      "lab": "book/labs/ch07_the_organization_wakes_itself"
     },
     "ch08_the_store_becomes_a_catalog": {
       "depth": "full",
@@ -661,7 +669,8 @@
         "refused: duplicate SKUs in catalog: ['SKU-TEA', 'SKU-TEA']",
         "refused: negative opening stock is unrecorded debt, not inventory",
         "the shop row, untouched: (1, 'Assam tea', 4, 3)"
-      ]
+      ],
+      "lab": "book/labs/ch08_the_store_becomes_a_catalog"
     },
     "ch09_each_product_has_its_own_threshold": {
       "depth": "full",
@@ -741,7 +750,8 @@
         "on hand now: -2",
         "refused: only 1 available (6 on hand, 5 reserved)",
         "on_hand=5 cash_rows=4 events=4"
-      ]
+      ],
+      "lab": "book/labs/ch09_each_product_has_its_own_threshold"
     },
     "ch10_one_signal_wakes_one_need": {
       "depth": "full",
@@ -821,7 +831,8 @@
         "run-t did something",
         "ACCEPTED: run-x caused a replenishment on SKU-TEA",
         "replenishment on SKU-COFFEE"
-      ]
+      ],
+      "lab": "book/labs/ch10_one_signal_wakes_one_need"
     },
     "ch11_replenishment_scales_without_losing_governance": {
       "depth": "full",
@@ -900,7 +911,8 @@
         "on_hand=14 purchase_entries=2",
         "idempotent replay: 6 SKU-TEA for 1500c",
         "refused: asg-invented is not an authorized assignment"
-      ]
+      ],
+      "lab": "book/labs/ch11_replenishment_scales_without_losing_governance"
     },
     "ch12_the_pilot_begins_with_a_receipt": {
       "depth": "full",
@@ -995,7 +1007,8 @@
         "who pilot-1 actually belongs to: ('lucys-shop', 'standard')",
         "refused: pilot-1 already exists with DIFFERENT identity (lucys-shop/standard)",
         "['dishonest NOT_RUN: live-provider.txt claims success in prose']"
-      ]
+      ],
+      "lab": "book/labs/ch12_the_pilot_begins_with_a_receipt"
     }
   }
 }

--- a/scripts/verify_book_depth.py
+++ b/scripts/verify_book_depth.py
@@ -32,7 +32,11 @@ The contract:
 - a full-depth concept needs at least one symbol AND (at least one test OR
   an explicit `known_gap` string). A known gap is machine-readable honesty:
   it is counted and reported in the summary, so a chapter carrying one can
-  never be mistaken for fully test-backed.
+  never be mistaken for fully test-backed;
+- every finished chapter (full or tour) declares its companion lab, and the
+  binding is checked as IDENTITY (directory under book/labs/, lab.json
+  naming this exact chapter) -- lab BEHAVIOR is the disjoint
+  scripts/verify_book_labs.py gate's job, deliberately not duplicated here.
 
 Chapters marked "tour" are finished guided-tour chapters (bash transcripts,
 no inline python): exempt from the python-construction gate ONLY — concepts,
@@ -277,6 +281,41 @@ def check_depth_gates(
     for evidence in evidence_list:
         if str(evidence) not in readme_text:
             problems.append(f"{chapter}: break-experiment evidence {str(evidence)!r} not present")
+    problems.extend(check_lab_binding(chapter, entry))
+    return problems
+
+
+def check_lab_binding(chapter: str, entry: dict[str, Any]) -> list[str]:
+    """Bind the chapter to its companion lab as declared evidence.
+
+    This is an IDENTITY binding, not a behavioral claim: it checks the declared
+    lab directory exists under book/labs/, carries a lab.json, and that
+    lab.json's own "chapter" field names this chapter. Whether the lab actually
+    RUNS and its checks hold is the disjoint scripts/verify_book_labs.py gate's
+    job — this check deliberately does not duplicate it, and passing here says
+    nothing about lab behavior.
+    """
+    problems: list[str] = []
+    lab_raw = str(entry.get("lab", ""))
+    if not lab_raw:
+        problems.append(f"{chapter}: finished chapter declares no companion lab")
+        return problems
+    lab_dir = contained_path(lab_raw, REPO_ROOT / "book" / "labs")
+    if lab_dir is None or not lab_dir.is_dir():
+        problems.append(f"{chapter}: lab {lab_raw!r} is not a directory under book/labs/")
+        return problems
+    lab_json = lab_dir / "lab.json"
+    if not lab_json.is_file():
+        problems.append(f"{chapter}: lab {lab_raw!r} has no lab.json")
+        return problems
+    try:
+        declared = json.loads(lab_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        problems.append(f"{chapter}: lab.json unreadable ({error})")
+        return problems
+    lab_chapter = str(declared.get("chapter", ""))
+    if lab_chapter != chapter:
+        problems.append(f"{chapter}: lab.json declares chapter {lab_chapter!r} — identity mismatch")
     return problems
 
 

--- a/tests/test_book_verifiers.py
+++ b/tests/test_book_verifiers.py
@@ -258,8 +258,40 @@ def test_a_full_book_reports_zero_pending(capsys) -> None:
     assert "0 pending" in output
 
 
+def test_a_missing_lab_binding_is_refused(tmp_path, capsys) -> None:
+    """Every finished chapter must declare its companion lab."""
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    del manifest["chapters"][chapter]["lab"]
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "declares no companion lab" in output
+
+
+def test_a_lab_outside_book_labs_is_refused(tmp_path, capsys) -> None:
+    manifest = real_manifest()
+    chapter = first_full_chapter(manifest)
+    manifest["chapters"][chapter]["lab"] = "book/" + chapter
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "is not a directory under book/labs/" in output
+
+
+def test_a_lab_identity_mismatch_is_refused(tmp_path, capsys) -> None:
+    """Pointing a chapter at a DIFFERENT chapter's real lab must be refused —
+    presence of a valid lab is not identity with THIS chapter's lab."""
+    manifest = real_manifest()
+    manifest["chapters"]["ch01_organization_remembers"]["lab"] = (
+        "book/labs/ch02_work_needs_governance"
+    )
+    code, output = run_with_manifest(tmp_path, manifest, capsys)
+    assert code == 1
+    assert "identity mismatch" in output
+
+
 def test_canonical_chapter_sets_agree_across_verifiers() -> None:
-    """The three book instruments must never disagree on the denominator."""
+    """The book instruments must never disagree on the denominator — depth,
+    curriculum, AND the companion-labs gate."""
     depth = _load_depth_module()
     curriculum_spec = importlib.util.spec_from_file_location(
         "verify_curriculum", REPO_ROOT / "scripts" / "verify_curriculum.py"
@@ -267,7 +299,14 @@ def test_canonical_chapter_sets_agree_across_verifiers() -> None:
     assert curriculum_spec is not None and curriculum_spec.loader is not None
     curriculum = importlib.util.module_from_spec(curriculum_spec)
     curriculum_spec.loader.exec_module(curriculum)
+    labs_spec = importlib.util.spec_from_file_location(
+        "verify_book_labs", REPO_ROOT / "scripts" / "verify_book_labs.py"
+    )
+    assert labs_spec is not None and labs_spec.loader is not None
+    labs = importlib.util.module_from_spec(labs_spec)
+    labs_spec.loader.exec_module(labs)
     assert set(depth.CANONICAL_CHAPTERS) == set(curriculum.REQUIRED_CHAPTERS)
+    assert set(depth.CANONICAL_CHAPTERS) == set(labs.CHAPTERS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The fold volunteered at the PR #59 review, actionable since PR #60 merged.

- Every finished chapter's `coverage_manifest.json` entry declares its companion lab; `verify_book_depth.py` checks the binding as **identity** (contained under `book/labs/`, `lab.json` present, its `chapter` field names this exact chapter). Lab **behavior** remains `verify_book_labs.py`'s job — deliberately not duplicated, and the docstring says so.
- The canonical-chapter agreement test now binds all three instruments' denominators: depth == curriculum == labs. No instrument can drift alone.
- Three new mutation tests: missing lab refused; lab outside `book/labs/` refused; cross-chapter lab identity mismatch refused.

Gates at head: 421 tests; depth 12 full + 1 tour + 0 pending (BOOK-DEPTH-COMPLETE); snippets 92/82; curriculum sound; labs PASS ×2 deterministic; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYxaQ6TTxKDsD6rzmswHRJ