### PR TITLE
Upgrade zeo.yml to v2.1 (fast lane + certify lane split)

### DIFF
--- a/.github/workflows/zeo.yml
+++ b/.github/workflows/zeo.yml
@@ -4,12 +4,19 @@ on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    - cron: "17 3 * * *"
+
+concurrency:
+  group: zeo-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   zeo:
     name: zeo
+    if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 8
     env:
       NO_COLOR: "1"
     steps:
@@ -33,71 +40,81 @@ jobs:
       - name: Install zero-employee (zeo) — PINNED
         run: uv tool install 'zero-employee==0.12.0'
 
-      - name: Corpus-wide integrity check (ruling/SOW n-collisions)
+      - name: Corpus-wide integrity check
         run: |
           if [ -f "claude-md/CLAUDE.md" ]; then
             uv tool run --from 'zero-employee==0.12.0' zeo --commit-check-corpus
           else
-            echo "No claude-md/CLAUDE.md marker — not a zeo corpus root; corpus check not applicable."
+            echo "Not a zeo corpus root; corpus check not applicable."
           fi
 
       - name: Per-file commit-check (changed sow/ and ruling/ files)
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.head.sha }}"
-            RANGE="${BASE}...${HEAD}"
+            RANGE="${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
           else
             BEFORE="${{ github.event.before }}"
-            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              RANGE=""
-            else
-              RANGE="${BEFORE}...${{ github.sha }}"
-            fi
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then RANGE=""; else RANGE="${BEFORE}...${{ github.sha }}"; fi
           fi
-
           if [ -n "$RANGE" ]; then
             CHANGED=$(git diff --name-only --diff-filter=ACMR "$RANGE" -- | grep -E '(^|/)(sow|ruling)/.*\.md$' || true)
           else
             CHANGED=$(git ls-files | grep -E '(^|/)(sow|ruling)/.*\.md$' || true)
           fi
-
-          if [ -z "$CHANGED" ]; then
-            echo "No sow/ or ruling/ .md files in range — nothing to lint."
-            exit 0
-          fi
-
-          echo "Files to check:"
+          [ -z "$CHANGED" ] && { echo "No sow/ruling files in range."; exit 0; }
           echo "$CHANGED"
-          echo ""
-
           FAILED=0
           while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            [ -f "$f" ] || continue
-            echo "-- checking $f --"
-            if ! uv tool run --from 'zero-employee==0.12.0' zeo --commit-check "$f"; then
-              echo "-- FAILED: $f --"
-              FAILED=1
-            fi
+            [ -z "$f" ] && continue; [ -f "$f" ] || continue
+            uv tool run --from 'zero-employee==0.12.0' zeo --commit-check "$f" || FAILED=1
           done <<< "$CHANGED"
+          [ "$FAILED" -ne 0 ] && exit 1 || true
 
-          if [ "$FAILED" -ne 0 ]; then
-            echo "One or more sow/ruling files failed zeo --commit-check." >&2
+      - name: Fast lane — declared gate check (anti-hollow, honest scope)
+        run: |
+          set -euo pipefail
+          if [ -f Makefile ] && grep -qE '^verify-fast:' Makefile; then
+            echo "SCOPE: fast lane runs verify-fast; FULL gate is seat-side + certify lane."
+            make verify-fast
+          elif [ -f Makefile ] && grep -qE '^verify:' Makefile; then
+            echo "SCOPE: gate DECLARED (verify target present); fast subset not declared."
+            echo "Behavior proof lives in seat-side receipts + the certify lane on main."
+          elif [ -f "claude-md/CLAUDE.md" ]; then
+            echo "SCOPE: corpus repo — corpus checks above are the gate."
+          else
+            echo "DEFECT: no corpus marker AND no verify target (CLAUDE.md s6a)." >&2
+            echo "Refusing green-by-absence." >&2
             exit 1
           fi
 
-      - name: Real gate — make verify (the anti-hollow step)
+  zeo-certify:
+    name: zeo-certify
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      NO_COLOR: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install Go (only when the repo has a Go module)
+        if: ${{ hashFiles('go.mod') != '' }}
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Full gate — make verify (post-merge certification)
         run: |
           set -euo pipefail
           if [ -f Makefile ] && grep -qE '^verify:' Makefile; then
-            echo "Repo declares the mandated gate target — running make verify."
             make verify
-          elif [ -f "claude-md/CLAUDE.md" ]; then
-            echo "Corpus repo with no Makefile gate — corpus checks above are the gate."
           else
-            echo "DEFECT: no corpus marker AND no 'verify' Makefile target." >&2
-            echo "A governed repo must declare its gate (CLAUDE.md s6a). Refusing green-by-absence." >&2
-            exit 1
+            echo "No verify target — certification not applicable to this repo."
           fi


### PR DESCRIPTION
## Outcome

Upgrades `.github/workflows/zeo.yml` from v2 (PR #62) to v2.1, adopting the canonical bytes from `rodriveracom/org-zeroemployeeorg#276` comment [5493602614](https://github.com/rodriveracom/org-zeroemployeeorg/issues/276#issuecomment-5493602614) (`msg_8d3f7a25`).

Byte-identical, confirmed two independent ways: extracted directly from the source comment (sha256 `5825e4630560deb1dadea078cb7c987e1194b74628afb37785ece464831c388b`), matching the hash zeocore's Sparring independently reported for the same source on the same coordination thread.

## What changes

- Splits the single `zeo` job into two: `zeo` (required PR check, 8-minute budget) and `zeo-certify` (45-minute budget, runs the real `make verify` once per merge on push to `main`, plus nightly via cron).
- The PR-time `zeo` check drops the full `make verify` run in favor of an honestly-scoped fast lane: governance lint + the anti-hollow declared-gate check (this repo has no `verify-fast` target, so behavior proof stays with the certify lane and seat-side hooks, not the PR check — stated in-workflow, not silently narrowed).
- `zeo-certify` is correctly **not** a required PR check, per the directive's explicit warning that it would deadlock every merge (it never reports on PRs).
- Adds concurrency cancel-in-progress on PR pushes, and a nightly schedule trigger.

## Why sovereign-agent doesn't need the nightly-certify downgrade

Full `make verify` runs in ~1m26s on CI (confirmed at PR #62's `zeo` run) — comfortably inside the 45-minute certify budget and the ~5-minute fast-lane guidance both. The fast/certify split matters most for larger repos (zeocore's stated reasoning); adopting the byte-identical file here regardless, per the no-variance rule.

No `verify-fast` target added: the full suite is already inside the fast lane's rough budget, so a separate bounded target would add maintenance surface without a latency win — matching zeocore Sparring's independently-stated reasoning for the same choice.

## Verification

Pre-push hook (installed per the interim seat-side hook standard, `org#276` comment `5493602338`/`msg_6e1a4d92`) fired on this push and ran the real gate before bytes left the machine: 421 tests passed, all four book instruments green, offline doctor/demo working. Also verified independently in a fresh clone before opening this PR.

Correlation: `rodriveracom/org-zeroemployeeorg#276`, `corr_zero-employee-autonomous-delivery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)