### PR TITLE
Release v1.1.1 — the curriculum release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ Repository: [`zeroemployeeorg/sovereign-agent`](https://github.com/zeroemployeeo
 
 ## Unreleased
 
+## [1.1.1] — 2026-09-01
+
+The curriculum release. The installed package's runtime behavior is
+**identical to 1.1.0** — no source changes beyond the version string itself.
+What this release versions is everything around the code: the book was
+rewritten to executable depth, companion labs were added for every chapter,
+and the repository gained the verification instruments that keep both honest.
+Install it the same way (`pip install sovereign-agent`); read it by cloning
+the repository, where the book and labs live.
+
+- **The book, rewritten to build-break-repair depth.** All thirteen chapters
+  (ch00–ch12) now construct each mechanism inline in small, cumulative,
+  annotated increments; deliberately break a naive version and show the
+  failure verbatim; then repair it into the shape the production package
+  uses. Every python fence in every chapter is executed by CI and its
+  printed output is byte-matched — 92 executed blocks, 82 verified output
+  pairs. Each chapter maps its claims to exact production symbols and test
+  node ids, shows the real refusal and recovery transcripts, and states
+  plainly what it does *not* prove — ending with Chapter 12's boundary:
+  internal consistency is not authenticity.
+- **Thirteen runnable companion labs** (`book/labs/`). One per chapter: an
+  intentionally incomplete starter, behavioral checks that grade observable
+  invariants (not code shape), adversarial mutations, a verified reference
+  solution, and machine-readable production source/test references. The lab
+  gate executes every reference solution twice from fresh roots and compares
+  observations against checked-in expected results.
+- **Verification instruments, mutation-tested.** Three disjoint book gates
+  now run in CI and `make verify`: `verify_book_snippets.py` (executes every
+  chapter's python fences, byte-matches outputs, hardened against silent
+  early-stop false-greens), `verify_book_depth.py` (coverage manifest:
+  AST-verified symbol references, precise test node ids, per-chapter limits
+  and break-evidence anchors, an explicit known-gap register, and identity
+  binding of each chapter to its companion lab), and `verify_book_labs.py`
+  (the lab gate above). The three instruments are pinned to one shared
+  chapter denominator by test, and the false-green paths found during
+  adversarial review are each held closed by a regression suite.
+- **Fleet gate workflow.** The repository adopted the fleet-standard `zeo`
+  check (governance lint fast lane on PRs, full-gate certify lane on main
+  and nightly), alongside branch protection requiring an independent
+  reviewing seat.
+- **Chapter 0 index correction.** The top-level book index now names the
+  protagonist consistently with the chapter it links to.
+
 ## [1.1.0] — 2026-09-01
 
 Adds a first-class **OpenAI-compatible provider** and makes the local-model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ The curriculum release. The installed package's runtime behavior is
 What this release versions is everything around the code: the book was
 rewritten to executable depth, companion labs were added for every chapter,
 and the repository gained the verification instruments that keep both honest.
-Install it the same way (`pip install sovereign-agent`); read it by cloning
-the repository, where the book and labs live.
+Run it with uv (`uvx sovereign-agent@latest doctor`); read it by cloning
+the repository, where the book and labs live (`uv sync && uv run
+sovereign-agent doctor`).
 
 - **The book, rewritten to build-break-repair depth.** All thirteen chapters
   (ch00–ch12) now construct each mechanism inline in small, cumulative,
@@ -46,6 +47,13 @@ the repository, where the book and labs live.
   check (governance lint fast lane on PRs, full-gate certify lane on main
   and nightly), alongside branch protection requiring an independent
   reviewing seat.
+- **uv-first instructions everywhere current.** README, quickstart, and all
+  thirteen chapters' runnable commands now use `uv` (`uvx
+  sovereign-agent@latest` for zero-install runs, `uv sync` + `uv run` for
+  the cloned repository) — every documented flow verified live against
+  real PyPI and a fresh clone before being written. The quickstart's stale
+  "PyPI still serves 0.x" warning, false since 1.0.0 published, is
+  corrected. Legacy v0.x documents are deliberately unchanged.
 - **Chapter 0 index correction.** The top-level book index now names the
   protagonist consistently with the chapter it links to.
 

--- a/README.md
+++ b/README.md
@@ -6,20 +6,39 @@ Sovereign Agent 1.x is a small Python reference implementation for learning how
 an outcome becomes governed work performed by accountable actors. Production
 organizations graduate to [Zero Employee](https://github.com/zeroemployeeorg).
 
-The 1.x API intentionally replaces the v0.7 fleet framework. To keep using that
-framework:
+## Install and run with uv
+
+[`uv`](https://docs.astral.sh/uv/) is the supported way to install and run
+sovereign-agent. Try it without installing anything permanent:
 
 ```bash
-pip install "sovereign-agent<1"
+uvx sovereign-agent@latest doctor
+uvx sovereign-agent@latest demo store --mode simulated --root /tmp/first-shift
 ```
+
+(`@latest` makes uv refresh its cached tool environment, so you always get
+the current release.)
+
+Or install the CLI onto your PATH:
+
+```bash
+uv tool install sovereign-agent
+sovereign-agent doctor
+```
+
+(Plain `pip install sovereign-agent` still works in any Python 3.14
+environment if you prefer it.)
+
+The 1.x API intentionally replaces the v0.7 fleet framework. To keep using that
+framework: `uvx "sovereign-agent<1"`.
 
 ## Educational development install
 
-Python 3.14 is required.
+Python 3.14 is required; `uv` provides it automatically.
 
 ```bash
-python -m pip install -e .
-sovereign-agent doctor
+uv sync
+uv run sovereign-agent doctor
 ```
 
 Expected result:
@@ -40,7 +59,7 @@ Ready for the offline curriculum. Live providers are optional.
 Chapter 0 is runnable as a **manually dispatched** store shift (no Pulse):
 
 ```bash
-sovereign-agent demo store --mode simulated
+uv run sovereign-agent demo store --mode simulated
 ```
 
 See [`book/ch00_first_shift`](book/ch00_first_shift/README.md) and

--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -31,8 +31,8 @@ with no API keys, no network, and no model — it uses a deterministic `scripted
 stand-in so the result is identical on every machine:
 
 ```bash
-sovereign-agent doctor
-sovereign-agent demo store --mode simulated --root /tmp/first-shift
+uv run sovereign-agent doctor
+uv run sovereign-agent demo store --mode simulated --root /tmp/first-shift
 ```
 
 `doctor` tells you which provider CLIs you happen to have installed; the demo
@@ -105,7 +105,7 @@ Here is the exercise that earns this chapter its place. One command checks that
 the accepted outcome is *actually true*:
 
 ```bash
-python scripts/verify_store_outcome.py /tmp/first-shift
+uv run python scripts/verify_store_outcome.py /tmp/first-shift
 ```
 
 It exits `0` only if reality matches the claim. Now sabotage reality by hand and
@@ -114,7 +114,7 @@ run it again:
 ```bash
 sqlite3 /tmp/first-shift/.sovereign/organization.db \
   "UPDATE inventory SET on_hand = 0 WHERE on_hand > 0;"
-python scripts/verify_store_outcome.py /tmp/first-shift
+uv run python scripts/verify_store_outcome.py /tmp/first-shift
 ```
 
 It **fails**, with exit code `1`, and tells you why — this transcript is from a
@@ -177,7 +177,7 @@ do is part of knowing what it does.
 The single command that checks all of it at once:
 
 ```bash
-python scripts/verify_store_outcome.py /tmp/first-shift
+uv run python scripts/verify_store_outcome.py /tmp/first-shift
 ```
 
 Exit `0` means the accepted outcome is genuinely true; exit `1` means it is not,

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -638,7 +638,7 @@ ledger. Durability lives in SQLite; the filesystem only ever holds copies.
 ## Exercise 1: look at the operational state
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/lucy-memory
+uv run sovereign-agent demo store --mode simulated --root /tmp/lucy-memory
 sqlite3 /tmp/lucy-memory/.sovereign/organization.db ".tables"
 ```
 
@@ -772,7 +772,7 @@ three changes happen, or none do.
 ## Exercise 4: find the boundary between governance and operations
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/lucy-boundary
+uv run sovereign-agent demo store --mode simulated --root /tmp/lucy-boundary
 cat /tmp/lucy-boundary/sovereign.toml
 ls /tmp/lucy-boundary/governance/outcomes/*/
 ```
@@ -810,7 +810,7 @@ Read the section titled "The limit you must not lie about".
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_persistence.py -q
+uv run python -m pytest tests/test_persistence.py -q
 ```
 
 Expected: all tests pass. They prove rollback, append-only enforcement,

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -549,7 +549,7 @@ attack the *real* system rather than re-running the toy.
 ## Exercise 1: follow one outcome through the whole chain
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/lucy-gov
+uv run sovereign-agent demo store --mode simulated --root /tmp/lucy-gov
 DB=/tmp/lucy-gov/.sovereign/organization.db
 
 sqlite3 -header -column "$DB" \
@@ -620,7 +620,7 @@ re-reading the world is theatre.
 Each of these is refused for a different reason. Run the suite that proves it:
 
 ```bash
-python -m pytest tests/test_acceptance_falsification.py -v
+uv run python -m pytest tests/test_acceptance_falsification.py -v
 ```
 
 Read the test names. They are the list of lies this system knows how to catch:
@@ -742,7 +742,7 @@ Chapter 2 has spent five exercises showing the organization refusing things. A
 fair question: what happens to work that gets refused? Is it dead?
 
 ```bash
-python -m pytest tests/test_recovery.py -v
+uv run python -m pytest tests/test_recovery.py -v
 ```
 
 Read the test names. The cycle they prove is:
@@ -777,7 +777,7 @@ Recovery is what makes refusal a step in the work rather than the end of it.
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_acceptance_falsification.py tests/test_actors_and_mailbox.py \
+uv run python -m pytest tests/test_acceptance_falsification.py tests/test_actors_and_mailbox.py \
   tests/test_recovery.py -q
 ```
 

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -471,7 +471,7 @@ Confirm all of this in the *real* organization, where `Actor`, `ROLE_AUTHORITY`,
 and `rebind_actor` are the production versions of what you just built:
 
 ```bash
-python book/ch03_actor_is_not_a_model/solution.py --root /tmp/lucy-ch03 --provider ollama
+uv run python book/ch03_actor_is_not_a_model/solution.py --root /tmp/lucy-ch03 --provider ollama
 ```
 
 `solution.py` runs one assignment, rebinds `operator-course`'s provider, runs
@@ -549,7 +549,7 @@ of a run. That is the correct outcome: an unprovable capability fails closed.
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_actors_and_mailbox.py tests/test_providers.py -q
+uv run python -m pytest tests/test_actors_and_mailbox.py tests/test_providers.py -q
 ```
 
 Expected: all pass. These prove actor identity survives a provider rebind, that

--- a/book/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/ch04_work_stays_inside_its_boundary/README.md
@@ -296,7 +296,7 @@ claim; with it, it is a measurement.
 ## The exercise
 
 ```bash
-python book/ch04_work_stays_inside_its_boundary/solution.py --root /tmp/lucy-ch04
+uv run python book/ch04_work_stays_inside_its_boundary/solution.py --root /tmp/lucy-ch04
 ```
 
 Reads real output straight from the production `workspace` module: it runs one
@@ -402,7 +402,7 @@ stayed inside it."
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_workspace_lifecycle.py -k \
+uv run python -m pytest tests/test_workspace_lifecycle.py -k \
   "reclaimed_after_terminal_state or persistent_policy or temporary_directory_policy or detects_write_outside or do_not_trip_the_boundary or traversal or absolute_deliverable or legitimate_nested"
 ```
 

--- a/book/ch05_authority_needs_a_fence/README.md
+++ b/book/ch05_authority_needs_a_fence/README.md
@@ -367,7 +367,7 @@ the *organization*, not of one table.
 ## The exercise
 
 ```bash
-python book/ch05_authority_needs_a_fence/solution.py --root /tmp/lucy-ch05
+uv run python book/ch05_authority_needs_a_fence/solution.py --root /tmp/lucy-ch05
 ```
 
 Exercises `fencing.acquire_actor_lease` and `fencing.acquire_execution_attempt`
@@ -438,7 +438,7 @@ token means the write is refused, not silently accepted.
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_fencing.py -k \
+uv run python -m pytest tests/test_fencing.py -k \
   "acquire_actor_lease_succeeds_with_no_prior_lease or acquire_execution_attempt_succeeds_for_a_fresh_assignment or acquire_execution_attempt_refuses_without_a_live_actor_lease or actor_lease_blocks_a_second_assignment_for_the_same_actor_before_invocation or the_ordinary_run_assignment_path_cannot_bypass_the_actor_lease"
 ```
 

--- a/book/ch06_the_organization_recovers/README.md
+++ b/book/ch06_the_organization_recovers/README.md
@@ -264,7 +264,7 @@ disappears.
 ## The exercise
 
 ```bash
-python book/ch06_the_organization_recovers/solution.py --root /tmp/lucy-ch06
+uv run python book/ch06_the_organization_recovers/solution.py --root /tmp/lucy-ch06
 ```
 
 Takes a few seconds — it genuinely waits for a real subprocess to reach
@@ -325,7 +325,7 @@ governed act (`assign` → `run_assignment` again), never automatic.
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_supervisor.py -k \
+uv run python -m pytest tests/test_supervisor.py -k \
   "sigkilled or recovers_a_real or idempotent or never_guesses_success or workspace_reclaim"
 ```
 

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -265,7 +265,7 @@ process nobody could reason about when it failed halfway through either job.
 ## The exercise
 
 ```bash
-python book/ch07_the_organization_wakes_itself/solution.py --root /tmp/lucy-ch07
+uv run python book/ch07_the_organization_wakes_itself/solution.py --root /tmp/lucy-ch07
 ```
 
 Read the file before you run it. Notice what is missing: no `create_sow`, no
@@ -372,9 +372,9 @@ by the mechanism, not merely phrased carefully.
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_pulse.py -k \
+uv run python -m pytest tests/test_pulse.py -k \
   "full_teaching_slice or attribution or does_not_bypass"
-python scripts/verify_curriculum.py
+uv run python scripts/verify_curriculum.py
 ```
 
 Expected: all pass. The pytest selection proves the full sale-to-accepted

--- a/book/ch08_the_store_becomes_a_catalog/README.md
+++ b/book/ch08_the_store_becomes_a_catalog/README.md
@@ -270,7 +270,7 @@ the way ledgers do: forward.
 ## The exercise
 
 ```bash
-python book/ch08_the_store_becomes_a_catalog/solution.py --root /tmp/lucy-ch08
+uv run python book/ch08_the_store_becomes_a_catalog/solution.py --root /tmp/lucy-ch08
 ```
 
 Read the file first. `seed_catalog` is called once, with the default
@@ -348,8 +348,8 @@ Expected: two rows, `SKU-COFFEE` and `SKU-TEA`, with different
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_store_multi_sku.py -k "sales_isolation or a_sale_of_one_sku"
-python scripts/verify_curriculum.py
+uv run python -m pytest tests/test_store_multi_sku.py -k "sales_isolation or a_sale_of_one_sku"
+uv run python scripts/verify_curriculum.py
 ```
 
 Expected: all pass. The pytest selection proves a sale of one SKU cannot

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -264,7 +264,7 @@ all-or-nothing commit.
 ## The exercise
 
 ```bash
-python book/ch09_each_product_has_its_own_threshold/solution.py --root /tmp/lucy-ch09
+uv run python book/ch09_each_product_has_its_own_threshold/solution.py --root /tmp/lucy-ch09
 ```
 
 Read the file first. Two sales happen: 2 units of tea (4 on hand, reorder at
@@ -329,8 +329,8 @@ Expected: `SKU-TEA` shows `below = 1`; `SKU-COFFEE` shows `below = 0`.
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_store_multi_sku.py -k "threshold or wake_gate_never_fires"
-python scripts/verify_curriculum.py
+uv run python -m pytest tests/test_store_multi_sku.py -k "threshold or wake_gate_never_fires"
+uv run python scripts/verify_curriculum.py
 ```
 
 Expected: all pass.

--- a/book/ch10_one_signal_wakes_one_need/README.md
+++ b/book/ch10_one_signal_wakes_one_need/README.md
@@ -287,7 +287,7 @@ will price it.
 ## The exercise
 
 ```bash
-python book/ch10_one_signal_wakes_one_need/solution.py --root /tmp/lucy-ch10
+uv run python book/ch10_one_signal_wakes_one_need/solution.py --root /tmp/lucy-ch10
 ```
 
 Read the file first. Two outcomes are created, one per SKU. Two sales
@@ -346,8 +346,8 @@ each naming a different `sow_id`.
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_store_multi_sku.py -k "wake_decision or pulse_origins_trace"
-python scripts/verify_curriculum.py
+uv run python -m pytest tests/test_store_multi_sku.py -k "wake_decision or pulse_origins_trace"
+uv run python scripts/verify_curriculum.py
 ```
 
 Expected: all pass.

--- a/book/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/ch11_replenishment_scales_without_losing_governance/README.md
@@ -258,7 +258,7 @@ timing*.
 ## The exercise
 
 ```bash
-python book/ch11_replenishment_scales_without_losing_governance/solution.py --root /tmp/lucy-ch11
+uv run python book/ch11_replenishment_scales_without_losing_governance/solution.py --root /tmp/lucy-ch11
 ```
 
 Read the file first. Both SKUs' signals fire, both get their own canonical
@@ -327,9 +327,9 @@ Expected: two `effects` rows, one per SKU; two `outcomes` rows, both
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_store_multi_sku.py -k "assignment_isolation or replenishment_effect or multiple_qualifying"
-python -m pytest tests/test_store_multi_sku.py -k "two_real_connections"
-python scripts/verify_curriculum.py
+uv run python -m pytest tests/test_store_multi_sku.py -k "assignment_isolation or replenishment_effect or multiple_qualifying"
+uv run python -m pytest tests/test_store_multi_sku.py -k "two_real_connections"
+uv run python scripts/verify_curriculum.py
 ```
 
 Expected: all pass. The second command is the REAL two-connection

--- a/book/ch12_the_pilot_begins_with_a_receipt/README.md
+++ b/book/ch12_the_pilot_begins_with_a_receipt/README.md
@@ -282,7 +282,7 @@ this book ends, because it is where honest engineering begins.
 ## The exercise
 
 ```bash
-python book/ch12_the_pilot_begins_with_a_receipt/solution.py --root /tmp/lucy-ch12
+uv run python book/ch12_the_pilot_begins_with_a_receipt/solution.py --root /tmp/lucy-ch12
 ```
 
 Read the file first, and read `EXERCISE_PILOT_ID`'s own comment before running
@@ -356,8 +356,8 @@ count.
 ## Learner verification command
 
 ```bash
-python -m pytest tests/test_pilot.py
-python scripts/verify_curriculum.py
+uv run python -m pytest tests/test_pilot.py
+uv run python scripts/verify_curriculum.py
 ```
 
 Expected: all pass. `tests/test_pilot.py` is where this mechanism's

--- a/book/labs/README.md
+++ b/book/labs/README.md
@@ -19,7 +19,7 @@ chapter. Every directory contains:
 Run the complete companion-lab gate from the repository root:
 
 ```console
-python scripts/verify_book_labs.py
+uv run python scripts/verify_book_labs.py
 ```
 
 The gate intentionally runs the reference solution twice, each time with a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,43 +3,35 @@
 Ten minutes and no API keys. You will run a small organization through
 one complete piece of work and then check whether it told you the truth.
 
-You need Python **3.14 or newer**, `git`, and a terminal. Nothing else — no
-API key, no network after installation, and no database tools.
+You need [`uv`](https://docs.astral.sh/uv/), `git`, and a terminal. Nothing
+else — uv supplies Python 3.14 itself, and after installation there is no
+API key, no network, and no database tools.
 
 ## 1. Install
 
-!!! warning "Install from the repository, not from PyPI"
+Clone the repository (the book, labs, and audit scripts live there — the
+same walkthrough below uses them) and let uv build the environment:
 
-    PyPI still serves the **0.x** framework, which is a different product with a
-    different API and a lower Python floor. Publishing 1.x is deferred to
-    Unit 12. Until then, `pip install sovereign-agent` would give you the old
-    package while this page teaches the new one.
+```bash
+git clone https://github.com/zeroemployeeorg/sovereign-agent.git
+cd sovereign-agent
+uv sync
+```
 
-=== "macOS and Linux"
+The same three commands work on macOS, Linux, and Windows.
 
-    ```bash
-    git clone https://github.com/zeroemployeeorg/sovereign-agent.git
-    cd sovereign-agent
-    python3.14 -m venv .venv
-    source .venv/bin/activate
-    pip install -e .
-    ```
+!!! note "Just the CLI?"
 
-=== "Windows"
-
-    ```powershell
-    git clone https://github.com/zeroemployeeorg/sovereign-agent.git
-    cd sovereign-agent
-    py -3.14 -m venv .venv
-    .\.venv\Scripts\Activate.ps1
-    pip install -e .
-    ```
+    If you only want the installed organization without the repository,
+    `uvx sovereign-agent@latest doctor` runs the current PyPI release
+    directly. This page assumes the clone, because the audit scripts in
+    step 4 ship in the repository, not the wheel.
 
 Check the install:
 
 ```bash
-sovereign-agent --version
-sovereign-agent doctor
+uv run sovereign-agent --version
+uv run sovereign-agent doctor
 ```
 
 `doctor` reports your Python and Pydantic versions and lists which provider CLIs
@@ -49,7 +41,7 @@ you happen to have. **You do not need any of them.** The quickstart runs on the
 ## 2. Run one shift
 
 ```bash
-sovereign-agent demo store --mode simulated --root /tmp/andrea-shift
+uv run sovereign-agent demo store --mode simulated --root /tmp/andrea-shift
 ```
 
 !!! note "Windows"
@@ -74,7 +66,7 @@ actor, and accepted it.
 This is the part that matters. `ACCEPTED` is a claim; here is how you audit it.
 
 ```bash
-sovereign-agent inspect --root /tmp/andrea-shift
+uv run sovereign-agent inspect --root /tmp/andrea-shift
 ```
 
 Expected, in three parts:
@@ -107,8 +99,8 @@ Read it as three separate claims:
 Change the world behind the organization's back:
 
 ```bash
-python scripts/empty_the_shelf.py /tmp/andrea-shift
-sovereign-agent inspect --root /tmp/andrea-shift
+uv run python scripts/empty_the_shelf.py /tmp/andrea-shift
+uv run sovereign-agent inspect --root /tmp/andrea-shift
 ```
 
 Inventory now reads `LOW`, and the outcome still reads `ACCEPTED` — because that
@@ -118,7 +110,7 @@ If you want the machine-checked version of that judgement, the repository ships
 the release gate that catches exactly this:
 
 ```bash
-python scripts/verify_store_outcome.py /tmp/andrea-shift
+uv run python scripts/verify_store_outcome.py /tmp/andrea-shift
 ```
 
 It exits non-zero and names every claim that no longer holds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sovereign-agent"
-version = "1.1.0"
+version = "1.1.1"
 description = "An executable textbook for learning Zero-Employee Organizations"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -10,7 +10,7 @@ from sovereign_agent.ids import new_id
 from sovereign_agent.models import Actor, Outcome, StatementOfWork
 from sovereign_agent.organization import Organization
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __all__ = [
     "Actor",

--- a/tests/test_clean_import.py
+++ b/tests/test_clean_import.py
@@ -23,4 +23,4 @@ print(json.dumps({'before': before, 'after': after, 'version': sovereign_agent._
         text=True,
     )
     observed = json.loads(result.stdout)
-    assert observed == {"before": [], "after": [], "version": "1.1.0"}
+    assert observed == {"before": [], "after": [], "version": "1.1.1"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,4 +33,4 @@ def test_module_entry_point_reports_version() -> None:
         capture_output=True,
         text=True,
     )
-    assert result.stdout.strip() == "sovereign-agent 1.1.0"
+    assert result.stdout.strip() == "sovereign-agent 1.1.1"


### PR DESCRIPTION
Operator-directed release cut. Four commits:

1. **Version bump + changelog** (`352404b`): 1.1.0 → 1.1.1 in pyproject + `__version__`; honest CHANGELOG entry — runtime behavior identical to 1.1.0, what's versioned is the rewritten book (92 executed blocks / 82 byte-matched outputs), 13 companion labs, the mutation-tested verifier instruments, and the fleet gate adoption.
2. **Version-pin tests** (`ad1392b`): the two deliberate version tripwires updated — they refused the bump until consciously updated, and the pre-push hook refused the push on their failure. Both worked as designed.
3. **uv modernization** (`13748db`, Operator-directed): README/quickstart/all-13-chapters instructions moved to `uvx sovereign-agent@latest` / `uv sync` + `uv run` — every flow verified live against real PyPI and a fresh clone first. Fixes the quickstart's stale-since-1.0.0 "PyPI still serves 0.x" warning.
4. **Changelog touch-up** for item 3.

Gates at head: 421 tests, all four book instruments green, ruff/mypy clean, full `make verify` run by the pre-push hook on every push of this branch.

After merge: tag `v1.1.1` → `publish.yml` (build, wheel-verify, trusted publishing to PyPI) → GitHub Release with notes → clean-venv `pip install sovereign-agent==1.1.1` verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYxaQ6TTxKDsD6rzmswHRJ