### PR TITLE
Repair main: uv.lock for 1.1.1 (fix missed by the #64 merge race)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "sovereign-agent"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
PR #64 merged at head 765d084 — a race that predated the lockfile fix b072ddd already pushed to the release branch, so main is red on `uv lock --check` (the exact defect the Master's review caught). This cherry-picks that one-line fix onto main. After this lands and CI is green, the v1.1.1 tag goes on the repaired head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYxaQ6TTxKDsD6rzmswHRJ