### PR TITLE
Adopt fleet-canonical zeo.yml v2.2

### DIFF
--- a/.github/workflows/zeo.yml
+++ b/.github/workflows/zeo.yml
@@ -1,3 +1,4 @@
+# canon: zeo.yml v2.2 (org issue #276; byte-identical adoption mandatory)
 name: zeo
 
 on:
@@ -21,7 +22,7 @@ jobs:
       NO_COLOR: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -97,7 +98,7 @@ jobs:
       NO_COLOR: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install uv


### PR DESCRIPTION
## Summary

Adopts the fleet's canonical `zeo.yml` v2.2 text (org issue `rodriveracom/org-zeroemployeeorg#276`, message `msg_2e6b8d40`), byte-identical, as required by the byte-identical-adoption mandate for this shared workflow file.

## Changes

- `.github/workflows/zeo.yml`: adds the canon header comment line, bumps `actions/checkout` from `@v4` to `@v7` in both the `zeo` and `zeo-certify` jobs — the only diff from the previous file.
- No other file touched. `ci.yml` and `publish.yml` are explicitly out of scope (repo-local, already independently bumped to `@v7` in a prior PR).

## Verification

- Independently re-extracted the canon text from org issue #276 myself and confirmed byte-identical match via `diff` (empty) and matching sha256 (`f9bc8eb9910d7857f21cbb5f198e72986c7e7a9e8e6c347e3f048b70dbf4df44`) on both the extracted canon and the file in this PR.
- Full `make verify` gate green, run independently from a fresh clone.
- Confirmed this PR touches only `.github/workflows/zeo.yml`.

Not urgent, not blocking anything — purely a fleet-canon-conformance follow-up after PR #67/#68 both merged cleanly to main.

🤖 Generated with delegated implementation, independently verified by Master before opening this PR.