### PR TITLE
Release 1.2.0 — heartbeat, deepened book pedagogy, repository modernization, v2.2 canon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,48 @@ All notable changes to sovereign-agent.
 
 Repository: [`profrodai/sovereign-agent`](https://github.com/profrodai/sovereign-agent).
 
-## Unreleased
+## [1.2.0] — 2026-09-02
 
-- Modernized the public repository surface: complete community-health files,
-  canonical project metadata, a complete Apache-2.0 license, typed-package
-  signaling, and current 1.x architecture and API documentation. An obsolete
-  pre-1.0 manifest is no longer tracked as public project source.
+- **New `heartbeat` mechanism, deliberately separate from work.**
+  `sovereign-agent heartbeat` records or reads a durable liveness beat: an
+  append-only `heartbeats` table (a plain `INSERT`, no update path — history
+  of beats is a record, not a mutable "last seen" field) that lives apart
+  from the `events` ledger by design, so "the process is running" can never
+  masquerade as "governed work happened." Default invocation appends one
+  beat (`--source <name>`, default `cli`) and prints its id; `--status`
+  reads the newest beat and prints a verdict — `ALIVE` (a beat within
+  `--stale-after` seconds, default 900), `STALE` (no beat recorded in the
+  window — proof of silence, not of death), or `NO_BEATS` (the table is
+  empty) — and exits `0` only on `ALIVE`, so a cron or watchdog can key off
+  the exit code directly. This is explicitly **not** the Pulse: the book's
+  chapters use "heartbeat" informally for the organization waking itself to
+  create work (`sovereign-agent pulse`); this mechanism creates no work,
+  ever, under any circumstance.
+- **Book pedagogy deepened with implementation-grounded diagrams.** Every
+  finished chapter (ch00–ch12, both `full`-depth and guided-`tour`-depth) now
+  carries at least one conceptual Mermaid diagram showing the real mechanism,
+  not a rendering of a transcript — the book depth verifier's finished-chapter
+  gate (`scripts/verify_book_depth.py::check_depth_gates`) now refuses any
+  finished chapter that has no such diagram, or one that is empty, backed by
+  new regression tests in `tests/test_book_verifiers.py`. Chapter 7's Pulse
+  narrative is sharpened into explicit stages (signal, wake gate, wake
+  decision, execution) with a "four clocks" table distinguishing Signal, Pulse
+  tick, Supervisor tick, and Heartbeat so the mechanisms are never mistaken
+  for one another. Chapter 0's coverage manifest entry was corrected from an
+  absolute "the organization has no heartbeat yet" to the narrower,
+  still-accurate "this demo does not run an unattended scheduler or a
+  heartbeat," now that a heartbeat module exists elsewhere in the package. A
+  `known_gap` was added to Chapter 9's manifest entry documenting that its
+  acceptance check models a stronger sale contract (reserved-stock aware) than
+  production `record_sale` currently implements.
+- **Modernized the public repository surface** (carried over from the prior
+  Unreleased entry): complete community-health files, canonical project
+  metadata, a complete Apache-2.0 license, typed-package signaling, and
+  current 1.x architecture and API documentation. An obsolete pre-1.0
+  manifest is no longer tracked as public project source.
+- **Adopted fleet canon `zeo.yml` v2.2** (org issue #276): both CI jobs now
+  pin `actions/checkout@v7` (up from `v4`), and the workflow file's own
+  header now carries the canon marker recording byte-identical adoption.
 
 ## [1.1.1] — 2026-09-01
 

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -78,7 +78,7 @@ only once.
 | Signal | Domain transaction | A relevant fact occurred. |
 | Pulse tick | Caller invocation | Eligible signals were evaluated once. |
 | Supervisor tick | Loop or caller | Expired claims/attempts were reconciled. |
-| Heartbeat | Not implemented in this version | Would report periodic actor/process liveness. |
+| Heartbeat | Explicit `record_heartbeat` call | The runtime was alive at that moment; never that work happened, never a Pulse trigger. |
 
 Keeping these clocks distinct prevents an operational command loop from being
 mistaken for a liveness protocol, or a liveness protocol from being mistaken for

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -139,3 +139,40 @@ business signal into governed work during one explicit pass, but this example
 does not invoke it and its ledger contains no `pulse.*` event. Pulse is distinct
 from both scheduling and the heartbeat liveness record. Continue to Chapter 7
 and [the Pulse reference](v1-unit9-pulse-proactive-work.md) for that mechanism.
+
+## Liveness, separately: the `heartbeat` command
+
+Heartbeat is unrelated to everything above — it is not Pulse, it is not the
+supervisor, and it never creates work. It answers exactly one question: "was
+this organization's runtime alive recently?"
+
+```bash
+# Record one liveness beat (default source "cli"):
+uv run sovereign-agent heartbeat --root /tmp/andrea-shift
+# -> beat recorded: <beat-id>
+
+# From a different watcher/source:
+uv run sovereign-agent heartbeat --root /tmp/andrea-shift --source watchdog
+
+# Read the verdict on the newest beat:
+uv run sovereign-agent heartbeat --status --root /tmp/andrea-shift
+# -> ALIVE: last beat <id> from 'watchdog' at <timestamp>, <N>s ago (threshold 900s)
+```
+
+`--status` prints one of three honest verdicts and exits accordingly:
+
+- `ALIVE` — the newest beat is within the staleness window (`--stale-after`
+  seconds, default `900`). Exit code `0`.
+- `STALE` — no beat was recorded within the window. This proves silence, not
+  death: the recorder may be wedged, crashed, or merely cut off from the
+  database. Exit code `1`.
+- `NO_BEATS` — the `heartbeats` table is empty; nothing has ever recorded a
+  beat here. Exit code `1`.
+
+Because `--status` exits `0` only on `ALIVE`, a cron job or external watchdog
+can key off the exit code directly, without parsing output.
+
+Beats live in their own append-only `heartbeats` table, entirely separate from
+the `events` ledger that records governed work — so a live process can never
+be mistaken for progress having been made. See
+[`heartbeat.py`](../src/sovereign_agent/heartbeat.py) for the full contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sovereign-agent"
-version = "1.1.1"
+version = "1.2.0"
 description = "An executable textbook for learning Zero-Employee Organizations"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -10,7 +10,7 @@ from sovereign_agent.ids import new_id
 from sovereign_agent.models import Actor, Outcome, StatementOfWork
 from sovereign_agent.organization import Organization
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 __all__ = [
     "Actor",

--- a/src/sovereign_agent/pulse.py
+++ b/src/sovereign_agent/pulse.py
@@ -85,16 +85,17 @@ class PulseReport:
 def _unevaluated_signals(org: Organization) -> list[Signal]:
     """Every durable signal with no wake decision yet, oldest first.
 
-    A signal that already has a `pulse_wake_decisions` row (fired or not --
-    the row exists the instant this process wins the CAS, before the SOW
-    itself is created) is never re-offered to the GATE: re-evaluating it
-    would either race the canonical creation transaction pointlessly or, for
-    a signal the gate would now refuse, produce no new information. Read
-    fresh, from the current authoritative Store state, exactly as the SOW
-    requires -- this is a live SELECT, not a cached list. A signal that
-    already fired but whose assignment has not yet reached a terminal or
-    running state is picked up separately, by `_resumable_signals` below --
-    this function is only ever about NEW gate evaluations.
+    A signal that already has a `pulse_wake_decisions` row -- which exists
+    only once a firing decision wins the CAS and commits, never for a
+    non-firing pass, which writes nothing -- is never re-offered to the
+    GATE: re-evaluating it would either race the canonical creation
+    transaction pointlessly or, for a signal the gate would now refuse,
+    produce no new information. Read fresh, from the current authoritative
+    Store state, exactly as the SOW requires -- this is a live SELECT, not
+    a cached list. A signal that already fired but whose assignment has
+    not yet reached a terminal or running state is picked up separately,
+    by `_resumable_signals` below -- this function is only ever about NEW
+    gate evaluations.
     """
     rows = org.db.connection.execute(
         "SELECT s.record AS record FROM signals s "

--- a/tests/test_clean_import.py
+++ b/tests/test_clean_import.py
@@ -23,4 +23,4 @@ print(json.dumps({'before': before, 'after': after, 'version': sovereign_agent._
         text=True,
     )
     observed = json.loads(result.stdout)
-    assert observed == {"before": [], "after": [], "version": "1.1.1"}
+    assert observed == {"before": [], "after": [], "version": "1.2.0"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,4 +33,4 @@ def test_module_entry_point_reports_version() -> None:
         capture_output=True,
         text=True,
     )
-    assert result.stdout.strip() == "sovereign-agent 1.1.1"
+    assert result.stdout.strip() == "sovereign-agent 1.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "sovereign-agent"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Version bump to 1.2.0, covering everything merged to main since 1.1.1:

- **New `heartbeat` mechanism** (PR #66) — durable liveness records, deliberately separate from Pulse and from governed work.
- **Book pedagogy deepened** (PR #67) — implementation-grounded Mermaid diagrams on every finished chapter, ch07's Pulse narrative sharpened, ch00/ch09 manifest corrections.
- **Public repository modernization** (PR #68) — community-health files, license completion, typed-package signaling, current docs.
- **Fleet-canon `zeo.yml` v2.2 adoption** (PR #69).

Plus two small riders, folded in during release prep:
- `pulse.py`'s `_unevaluated_signals` docstring corrected (a non-firing revalidation writes nothing — was worded backwards).
- `book/ch07`'s "four clocks" table row for Heartbeat corrected from stale "Not implemented in this version" to reflect that it now exists, while preserving the table's distinction from Pulse.

## Verification (independently reproduced by Master before opening this PR)

- Version consistent across `pyproject.toml`, `src/sovereign_agent/__init__.py`, and `uv.lock` (regenerated; `uv lock --check` passes clean — the exact check the 1.1.1 cycle's #65 incident was about).
- Every CHANGELOG claim checked against actual bytes: reproduced the heartbeat CLI's exact output myself (`beat recorded: <id>`, `ALIVE: ...` verdict line, exit code 0 only on ALIVE — confirmed against `cli.py`'s `_heartbeat` handler directly).
- `pulse.py` docstring fix confirmed against `organization.py`'s `create_pulse_work` — a non-firing revalidation genuinely returns `None` before any INSERT.
- `docs/quickstart.md`'s new heartbeat section verified by actually running the documented commands in a scratch root and confirming byte-for-byte output shape.
- Full `make verify` green from a fresh clone.

## Not in this PR

Publish/tag to PyPI remains the Operator's act, per standing practice — this PR only prepares the version bump and changelog; no seat publishes directly.

🤖 Generated with delegated implementation, independently re-verified from scratch by Master before opening.