### PR TITLE
Qualify README Unit 1 gates with uv run; add behavioral onboarding smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
           sovereign-agent --help
           sovereign-agent doctor
           sovereign-agent demo store --mode simulated --root "$RUNNER_TEMP/store-demo"
+      - name: Verify the README's documented uv onboarding sequence behaviorally
+        # Grepping the README for "uv run" only proves the text changed, not
+        # that the documented `uv sync` + gate commands actually work from a
+        # clean machine. This runs the exact commands for real, in a fresh
+        # git-archive extraction with a fresh uv cache/venv and a hostile
+        # PATH (decoy python/sovereign-agent shims), and fails by name if any
+        # documented step's real exit code is not 0.
+        run: python scripts/verify_readme_onboarding.py
       - name: Verify the accepted outcome is actually TRUE
         # The demo exiting 0 is not proof. The previous version of this pipeline
         # ran the demo and stopped there, and the demo printed ACCEPTED while the

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,4 @@ verify: lint test
 	$(UV) run --python 3.14 sovereign-agent --help >/dev/null
 	$(UV) run --python 3.14 sovereign-agent doctor
 	$(UV) run --python 3.14 sovereign-agent demo store --mode simulated --root /tmp/sovereign-agent-demo
+	$(UV) run --python 3.14 python scripts/verify_readme_onboarding.py

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ credential allowlists: Claude (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
 ## Unit 1 gates
 
 ```bash
-python -m pytest -q
-python scripts/verify_runtime_dependencies.py
-python scripts/verify_source_budget.py
-sovereign-agent --help
-sovereign-agent doctor
+uv run python -m pytest -q
+uv run python scripts/verify_runtime_dependencies.py
+uv run python scripts/verify_source_budget.py
+uv run sovereign-agent --help
+uv run sovereign-agent doctor
 ```
 
 See the [educational reset ruling](docs/rulings/2026-08-25-educational-reset.md)

--- a/scripts/verify_readme_onboarding.py
+++ b/scripts/verify_readme_onboarding.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Behaviorally prove the README's documented onboarding sequence.
+
+RULING-418 (org issue #184, Unit 12 track) found that the "## Unit 1 gates"
+section of README.md listed bare `python ...` / `sovereign-agent ...`
+commands after `uv sync`. A bare command is not guaranteed to run inside the
+project's managed virtualenv -- a stale global `python` or `sovereign-agent`
+shadowing the project's own can silently intercept it, so the gate either
+fails confusingly or "passes" against the wrong environment.
+
+Grepping the README for the string `uv run` would only prove the TEXT
+changed, not that the documented sequence actually works. This script proves
+behavior instead: it extracts the exact commands from the README's fenced
+code blocks, materializes a genuinely clean copy of the repository (a fresh
+`git archive` extraction, not a reused working tree), points `uv` at a fresh
+cache and a fresh project environment so no prior `uv sync` in this checkout
+can be reused, and then runs the real documented sequence -- `uv sync`
+followed by each Unit 1 gate command -- as real subprocesses against that
+clean state, asserting each one's actual exit code is 0.
+
+If any documented command is not qualified with `uv run` (or is `uv sync`
+itself), and a decoy `python`/`sovereign-agent` shim earlier on PATH would
+intercept it, this script fails and names exactly which documented line
+broke -- the same failure mode the live README defect produced.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+README = ROOT / "README.md"
+GATES_HEADING = "## Unit 1 gates"
+
+# Every one of these must appear, verbatim, as its own documented gate
+# command. This is the behavioral contract this script proves -- not a
+# regex over the README's prose, but the literal command line this script
+# is about to execute for real.
+REQUIRED_GATE_COMMANDS = (
+    "uv run python -m pytest -q",
+    "uv run python scripts/verify_runtime_dependencies.py",
+    "uv run python scripts/verify_source_budget.py",
+    "uv run sovereign-agent --help",
+    "uv run sovereign-agent doctor",
+)
+
+DECOY_SHIM = textwrap.dedent(
+    """\
+    #!/bin/sh
+    echo "DECOY: a stale global '$(basename "$0")' ran instead of the project's own" >&2
+    exit 99
+    """
+)
+
+
+def _extract_gates_block(readme_text: str) -> list[str]:
+    """Return the shell lines inside the fenced block under GATES_HEADING."""
+    if GATES_HEADING not in readme_text:
+        raise AssertionError(f"README.md has no {GATES_HEADING!r} section")
+    after_heading = readme_text.split(GATES_HEADING, 1)[1]
+    fence_match = re.search(r"```bash\n(.*?)\n```", after_heading, re.DOTALL)
+    if not fence_match:
+        raise AssertionError(f"no ```bash fenced block found under {GATES_HEADING!r}")
+    lines = [line.strip() for line in fence_match.group(1).splitlines() if line.strip()]
+    if not lines:
+        raise AssertionError(f"{GATES_HEADING!r} fenced block is empty")
+    return lines
+
+
+def _make_decoy_path(tmp_root: Path) -> Path:
+    """A PATH entry with fake `python`/`sovereign-agent` that fail loudly.
+
+    This is the behavioral trap: if a documented command is a bare `python`
+    or `sovereign-agent` invocation (not routed through `uv run`), *this*
+    decoy is what a stale global tool looks like on a learner's machine, and
+    it will be found first. A command correctly qualified with `uv run`
+    never consults this PATH entry at all, because `uv run` resolves the
+    interpreter/entry point from the project's own synced environment.
+    """
+    decoy_dir = tmp_root / "decoy-path"
+    decoy_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("python", "python3", "sovereign-agent"):
+        shim = decoy_dir / name
+        shim.write_text(DECOY_SHIM, encoding="utf-8")
+        shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return decoy_dir
+
+
+def _clean_worktree_copy(dest: Path) -> None:
+    """Materialize a clone-equivalent copy of the repo's tracked files only.
+
+    Uses `git archive` on HEAD so build artifacts, .venv, __pycache__, and any
+    other untracked local cruft in this checkout cannot leak into the
+    "fresh clone" this script is supposed to be proving the sequence against.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    archive = subprocess.run(
+        ["git", "archive", "HEAD"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["tar", "-x"], input=archive.stdout, cwd=dest, check=True)
+
+
+def _run_step(
+    description: str,
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> None:
+    print(f"--- {description}: {' '.join(command)}")
+    result = subprocess.run(command, cwd=cwd, env=env, capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"documented step failed (exit {result.returncode}): {description}\n"
+            f"  command: {' '.join(command)}"
+        )
+    print("    OK (exit 0)")
+
+
+def main() -> int:
+    readme_text = README.read_text(encoding="utf-8")
+    gate_lines = _extract_gates_block(readme_text)
+
+    missing = [cmd for cmd in REQUIRED_GATE_COMMANDS if cmd not in gate_lines]
+    if missing:
+        print("FAIL: README's Unit 1 gates block is missing required commands:")
+        for cmd in missing:
+            print(f"  - {cmd!r}")
+        print(f"actual fenced block contents: {gate_lines}")
+        return 1
+
+    unqualified = [
+        line
+        for line in gate_lines
+        if (line.startswith("python ") or line.startswith("sovereign-agent "))
+        and not line.startswith("uv run")
+    ]
+    if unqualified:
+        print("FAIL: README's Unit 1 gates block has bare commands not run through uv run:")
+        for line in unqualified:
+            print(f"  - {line!r}")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="sovereign-agent-onboarding-smoke-") as tmp:
+        tmp_root = Path(tmp)
+        fresh_repo = tmp_root / "repo"
+        fresh_cache = tmp_root / "uv-cache"
+        fresh_venv = tmp_root / ".venv"
+        decoy_path = _make_decoy_path(tmp_root)
+
+        print(f"Materializing a clean clone-equivalent tree at {fresh_repo}")
+        _clean_worktree_copy(fresh_repo)
+        if (fresh_repo / ".venv").exists():
+            raise AssertionError("fresh checkout must not already contain a .venv")
+
+        # A hostile PATH: the decoy shims come FIRST, exactly like a stale
+        # global python/sovereign-agent shadowing the project's own would.
+        # `uv` and `git` themselves still need to resolve, so keep the real
+        # PATH after the decoy.
+        env = dict(os.environ)
+        env["PATH"] = os.pathsep.join([str(decoy_path), env.get("PATH", "")])
+        env["UV_CACHE_DIR"] = str(fresh_cache)
+        env["UV_PROJECT_ENVIRONMENT"] = str(fresh_venv)
+        env.pop("VIRTUAL_ENV", None)
+
+        _run_step("uv sync", ["uv", "sync"], cwd=fresh_repo, env=env)
+
+        for line in gate_lines:
+            _run_step(f"documented gate: {line}", line.split(), cwd=fresh_repo, env=env)
+
+    print("\nAll documented onboarding steps executed for real, from a clean")
+    print("state, hostile PATH included, and every one exited 0.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssertionError as error:
+        print(f"FAIL: {error}")
+        sys.exit(1)


### PR DESCRIPTION
## Summary

RULING-418 (org #184, merged to org main at `641fb51b`) named a real defect: the top-level README's "## Unit 1 gates" section listed bare `python ...` / `sovereign-agent ...` commands after `uv sync`, unlike every other command sequence in the file. A bare command isn't guaranteed to resolve inside the project's managed virtualenv — a stale global `python`/`sovereign-agent` shadowing the project's own can silently intercept it.

- Qualifies all five Unit 1 gate commands with `uv run`, matching the convention already established elsewhere in the README.
- Adds `scripts/verify_readme_onboarding.py`: extracts the exact commands from the README's fenced Unit 1 gates block, materializes a clean `git archive` extraction (not a reused working tree), points `uv` at a fresh cache/venv, and runs the real documented sequence against a **hostile PATH with decoy `python`/`sovereign-agent` shims** that fail loudly if reached. This is a genuine behavioral proof, not a text/regex check.
- Wires the new script into `make verify` and into `.github/workflows/ci.yml`, following the same pattern as `verify_source_budget.py` / `verify_book_snippets.py`.

## Independent verification (Master, this session — not the implementing stream's self-report)

I re-derived every claim myself rather than trusting the stream's report:

- Read the full README diff directly: clean, minimal, exactly the five target lines qualified.
- Read the full `scripts/verify_readme_onboarding.py` source: confirmed the hostile-PATH decoy design is genuine (decoy shims are only reachable by a command NOT routed through `uv run`).
- **Positive case**, run myself: script passes, exit 0, real subprocess output from a genuinely fresh `git archive` extraction.
- **Negative case (a)**, run myself: reverted README + guards active → script fails by name, lists the five missing `uv run`-qualified commands.
- **Negative case (b) — the critical one**, run myself: reverted README **and disabled the script's own textual presence/qualification guards** → the decoy PATH mechanism *alone* still catches the bug. The bare `python -m pytest -q` line was genuinely intercepted by the decoy shim (`DECOY: a stale global 'python' ran instead of the project's own`, exit 99), and the script correctly failed by name. This proves the mechanism is behavioral, independent of any text check — confirmed by my own hands, not the implementing stream's word.
- Ran the full existing `make verify` end-to-end myself (including the project's own pre-push hook, which re-ran the entire gate independently on push): all 431 tests pass, full book/curriculum/labs/depth gates green, new onboarding gate green.

## Test plan

- [x] `make verify` green (self-run, twice: once directly, once via the repo's own pre-push hook)
- [x] Positive case of `verify_readme_onboarding.py` run directly
- [x] Negative case (a): reverted README, textual guards active — fails correctly
- [x] Negative case (b): reverted README, textual guards disabled — decoy PATH still catches it, fails correctly
- [x] CI will run the same script via the new `ci.yml` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns