### PR TITLE
fix(book): ch11 mermaid sequenceDiagram parse failure

### DIFF
--- a/book/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/ch11_replenishment_scales_without_losing_governance/README.md
@@ -52,11 +52,11 @@ sequenceDiagram
     alt A wins unique claim
         DB-->>A: inserted
         A->>DB: inventory + cash + event, same transaction
-        DB-->>B: conflict; read canonical effect
+        DB-->>B: conflict, read canonical effect
     else B wins unique claim
         DB-->>B: inserted
         B->>DB: inventory + cash + event, same transaction
-        DB-->>A: conflict; read canonical effect
+        DB-->>A: conflict, read canonical effect
     end
 ```
 


### PR DESCRIPTION
## Summary

- `book/ch11_replenishment_scales_without_losing_governance/README.md` had one mermaid `sequenceDiagram` block that failed to parse under `mermaid.parse` (mermaid 11.16.0).
- Cause: two message lines used `;` inside the message text (`conflict; read canonical effect`), which the sequenceDiagram lexer treats as a statement separator.
- Fix: replaced `;` with `,` on both occurrences (lines 55 and 59). Same clause structure, same meaning — the loser of the unique-claim race reads the canonical effect after conflict — just not a character mermaid's parser special-cases.

## Sweep (before fixing anything)

Ran `mermaid.parse` (same mermaid 11.16.0 / jsdom 26.1.0 parse path as profrod-site's `scripts/check-book-diagrams.mjs`) across every ```mermaid block in all 13 chapters, before making any change:

| chapter | blocks | result |
|---|---|---|
| ch00_first_shift | 1 | parses |
| ch01_organization_remembers | 2 | parses |
| ch02_work_needs_governance | 1 | parses |
| ch03_actor_is_not_a_model | 1 | parses |
| ch04_work_stays_inside_its_boundary | 1 | parses |
| ch05_authority_needs_a_fence | 1 | parses |
| ch06_the_organization_recovers | 1 | parses |
| ch07_the_organization_wakes_itself | 1 | parses |
| ch08_the_store_becomes_a_catalog | 1 | parses |
| ch09_each_product_has_its_own_threshold | 1 | parses |
| ch10_one_signal_wakes_one_need | 1 | parses |
| ch11_replenishment_scales_without_losing_governance | 1 | **FAIL** (this PR) |
| ch12_the_pilot_begins_with_a_receipt | 1 | parses |

14 blocks total across 13 chapters. Exactly one defect found, matching the one that blocked profrod-site's `book-derivation-implementation` stream. After the fix, all 14 blocks parse.

## Why this repo, why now

profrod-site's book pipeline derives from this repo and is filed BLOCKED on this exact parse failure. Per RULING-226 §5(c), profrod-site derives and never edits derived output — it correctly refused to patch this downstream. This PR fixes it at the source under this repo's own gates.

## Test plan

- [x] `mermaid.parse` sweep across all 13 chapters / 14 blocks — 0 failures after fix (was 1)
- [x] `make verify` — lint, mypy, pytest (436 passed), verify_runtime_dependencies, verify_source_budget, verify_curriculum, verify_book_snippets, verify_book_depth, verify_book_labs, CLI smoke — all pass
- [x] Diff scoped to 2 changed characters (`;` → `,`) in 1 file, nothing else touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6zudw7qVdSiqwMYTRuAir