### PR TITLE
Deepen ch07 (the organization wakes itself): outcome-disambiguation trace, mutation exercise, second figure

### DIFF
--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -383,25 +383,36 @@ from reference_organizations.store.pulse_gate import store_wake_gate
 root = Path("/tmp/lucy-ch07-ambiguous")
 org = Organization.init(root)
 from reference_organizations.store import seed
+
 seed(org.db)
 first = org.create_outcome(
-    "Keep the tea jar stocked", "On-hand tea is at or above reorder.",
-    ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA",
+    "Keep the tea jar stocked",
+    "On-hand tea is at or above reorder.",
+    ["inventory_at_or_above_reorder_point"],
+    "principal-human",
+    "SKU-TEA",
 )
 org.activate(first.id, "master-course")
 second = org.create_outcome(
-    "A second outcome about the same SKU", "Also tea.",
-    ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA",
+    "A second outcome about the same SKU",
+    "Also tea.",
+    ["inventory_at_or_above_reorder_point"],
+    "principal-human",
+    "SKU-TEA",
 )
 org.activate(second.id, "master-course")  # two ACTIVE outcomes now name SKU-TEA
 
 signal = record_sale(org.db, "SKU-TEA", 2, 400)
 report = run_pulse_once(org, store_wake_gate)
-print("created:", report.created)          # () -- refused, not fired
-print("signal still has no decision:", org.db.connection.execute(
-    "SELECT COUNT(*) FROM pulse_wake_decisions WHERE source_signal_id = ?",
-    (signal.id,),
-).fetchone()[0] == 0)
+print("created:", report.created)  # () -- refused, not fired
+print(
+    "signal still has no decision:",
+    org.db.connection.execute(
+        "SELECT COUNT(*) FROM pulse_wake_decisions WHERE source_signal_id = ?",
+        (signal.id,),
+    ).fetchone()[0]
+    == 0,
+)
 ```
 
 ```text

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -307,6 +307,121 @@ running each as its own separate operation. Recovery reconciles work that
 exists; Pulse creates work that should; a mechanism that did both would be a
 process nobody could reason about when it failed halfway through either job.
 
+### The real gate refuses a question your toy never had to ask
+
+Your `wake_gate` only checked one thing: is `on_hand` still below `reorder`.
+The Store's own production gate, `store_wake_gate` in
+`src/reference_organizations/store/pulse_gate.py`, checks that and something
+your toy never modeled, because your toy never had more than one outcome to
+choose between. This is quoted verbatim from `pulse_gate.py` — an excerpt to
+read, not a standalone block to run (`org` and `sku` are the surrounding
+function's real arguments, not names this page defines):
+
+```text
+rows = org.db.connection.execute("SELECT record FROM outcomes").fetchall()
+matching = []
+for row in rows:
+    record = json.loads(row["record"])
+    if record.get("subject") == sku and record.get("state") == OutcomeState.ACTIVE.value:
+        matching.append(record)
+if len(matching) != 1:
+    return None  # zero or ambiguous -- no durable rule disambiguates more than one
+```
+
+A signal names a SKU. It does not name which governed outcome the
+replenishment work belongs to — that has to be looked up, and the lookup can
+fail two different ways. Zero matching active outcomes means nobody has
+chartered replenishment for this SKU yet, so there is no outcome to attach
+the work to. More than one matching active outcome is worse: two different
+principals could both plausibly own "keep `SKU-TEA` stocked," and the gate
+has no rule for picking between them. Both cases return `None` — the same
+signal the gate returns for "stock is fine now." A learner reading only the
+JSON report cannot tell "already resolved" from "ambiguous ownership" apart;
+that distinction lives in `pulse_gate.py`'s own source, not in the report.
+
+```mermaid
+flowchart TD
+    Sig[Signal names one SKU] --> Look[Look up ACTIVE outcomes\nwhere subject = SKU]
+    Look --> Zero{How many\nmatch?}
+    Zero -->|0| None1[No outcome chartered yet\ngate returns None]
+    Zero -->|1| Fire[Exactly one owner\ngate fires]
+    Zero -->|2+| None2[Ambiguous ownership\ngate returns None]
+```
+
+*Figure — the Store's outcome-disambiguation check inside `store_wake_gate`.
+The stock-level check from the section above narrows signals to real
+candidates; this second, independent check narrows candidates to signals
+with exactly one unambiguous owner. Either failure mode returns the same
+`None` a caller cannot distinguish from "already resolved" without reading
+the source.*
+
+Two tests in `tests/test_pulse.py` prove both halves fail closed rather than
+guessing:
+`test_no_active_outcome_matching_the_subject_creates_no_work` seeds a sale
+with no outcome created for that SKU at all and asserts `report.created ==
+()`; `test_more_than_one_matching_active_outcome_creates_no_work` activates
+a *second* outcome naming the same SKU alongside the first and asserts the
+identical empty result. Neither test asserts an error — a gate that raised
+on ambiguity would turn an ordinary chartering mistake (two principals both
+opening an outcome for the same SKU) into a crash instead of a quiet,
+re-evaluable no-op. The signal is not consumed either way: it still has no
+`pulse_wake_decisions` row, so a later Pulse pass — after someone closes the
+duplicate outcome — evaluates it again and can still fire.
+
+**Prove the ambiguous case yourself.** Chapter 0 seeded exactly one outcome
+per SKU, so every earlier chapter's exercises never exercised this branch.
+Run `solution.py` once normally, then run this against the same database to
+force the ambiguity and watch the gate refuse where it previously fired:
+
+```python
+from pathlib import Path
+from sovereign_agent.organization import Organization
+from sovereign_agent.pulse import run_pulse_once
+from reference_organizations.store import record_sale
+from reference_organizations.store.pulse_gate import store_wake_gate
+
+root = Path("/tmp/lucy-ch07-ambiguous")
+org = Organization.init(root)
+from reference_organizations.store import seed
+seed(org.db)
+first = org.create_outcome(
+    "Keep the tea jar stocked", "On-hand tea is at or above reorder.",
+    ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA",
+)
+org.activate(first.id, "master-course")
+second = org.create_outcome(
+    "A second outcome about the same SKU", "Also tea.",
+    ["inventory_at_or_above_reorder_point"], "principal-human", "SKU-TEA",
+)
+org.activate(second.id, "master-course")  # two ACTIVE outcomes now name SKU-TEA
+
+signal = record_sale(org.db, "SKU-TEA", 2, 400)
+report = run_pulse_once(org, store_wake_gate)
+print("created:", report.created)          # () -- refused, not fired
+print("signal still has no decision:", org.db.connection.execute(
+    "SELECT COUNT(*) FROM pulse_wake_decisions WHERE source_signal_id = ?",
+    (signal.id,),
+).fetchone()[0] == 0)
+```
+
+```text
+created: ()
+signal still has no decision: True
+```
+
+The mutation: delete the `if len(matching) != 1: return None` guard from
+your own local copy of `pulse_gate.py`'s `store_wake_gate` (leave everything
+else unchanged — do not touch `matching = []` above it) and rerun the same
+script. The gate now has no rule for the two-owner case, so it falls
+through to `matching[0]` — a real `IndexError`-free but silently wrong
+pick, arbitrary Python dict ordering deciding which of two legitimate
+principals' outcomes gets the replenishment work with no record of why
+that one won. `report.created` becomes a one-item tuple instead of `()`:
+the mutated gate fires exactly where the real one must refuse, which is the
+provable, falsifiable failure this exercise is built to expose — not an
+assertion that the guard matters, but the guard's absence producing a
+different, wrong, observable result on the same input.
+
 ## The exercise
 
 ```bash

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -605,13 +605,29 @@
             "tests/test_pulse.py::test_seeded_store_with_no_sale_creates_no_work"
           ],
           "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
+        },
+        {
+          "concept": "gate-refuses-ambiguous-outcome-ownership",
+          "anchor": "The real gate refuses a question your toy never had to ask",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/pulse_gate.py",
+              "name": "store_wake_gate"
+            }
+          ],
+          "tests": [
+            "tests/test_pulse.py::test_no_active_outcome_matching_the_subject_creates_no_work",
+            "tests/test_pulse.py::test_more_than_one_matching_active_outcome_creates_no_work"
+          ],
+          "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
         }
       ],
       "limits_anchor": "It does **not**",
       "break_evidence": [
         "SOWs on the ledger: 2",
         "already decided: canonical work is sow-sig-1",
-        "signal no longer qualifies"
+        "signal no longer qualifies",
+        "signal still has no decision: True"
       ],
       "lab": "book/labs/ch07_the_organization_wakes_itself"
     },

--- a/tests/test_book_snippets_verifier.py
+++ b/tests/test_book_snippets_verifier.py
@@ -360,5 +360,5 @@ def test_main_succeeds_when_attempted_count_matches_expected(
 def test_real_book_chapters_still_pass_unchanged() -> None:
     result = run_cli(REPO_ROOT)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "book snippets sound: 13 chapters, 95 python block(s) executed" in result.stdout
-    assert "85 text-pair(s) checked, all matched" in result.stdout
+    assert "book snippets sound: 13 chapters, 96 python block(s) executed" in result.stdout
+    assert "86 text-pair(s) checked, all matched" in result.stdout


### PR DESCRIPTION
## Summary

Per `zeroemployeeorg/org` `projects/sovereign-agent/briefs/BOOK-SCORE-OPTIMIZATION-DIRECTIVE-2026-09-03.md` (Wave A, ch07 last in order: ch02, ch08, ch10, ch07), this deepens `book/ch07_the_organization_wakes_itself/README.md`.

**Baseline, confirmed live** against `profrod-site` `origin/main` `quality/books/sovereign-agent/latest.json` (sourceSha `f37581a343bcb1eb913b65fd9782869aa375d263`) before starting, not trusted from the spawn brief's paraphrase: score **83/90**, depth **83.55**, practice **75** (lowest dimension), words **3196**, figures **1** (recommendedFigures **2**). `nextActions` explicitly asked to deepen toward 4000+ words and add one figure.

**What was added.** The chapter's existing worked-mechanism walkthrough (naive tick → atomic tick → fault handling → world-moved edge case) builds a toy `wake_gate` that only ever checks stock level. The real production gate, `store_wake_gate` in `src/reference_organizations/store/pulse_gate.py`, does something the toy never modeled: it fails closed on **ambiguous outcome ownership** — zero or 2+ ACTIVE outcomes naming the same SKU both return `None`, same as "already resolved," a distinction only visible in the source, not the JSON report. This was real, previously-untraced behavior, proven by two existing tests (`test_no_active_outcome_matching_the_subject_creates_no_work`, `test_more_than_one_matching_active_outcome_creates_no_work`) that had no chapter-level walkthrough.

Added:
- A new subsection ("The real gate refuses a question your toy never had to ask") tracing this check against the real source, quoted verbatim.
- A new, captioned Mermaid figure showing the zero/one/2+ branch (figures 1 → 2, keeping pace with `recommendedFigures` — see figure-math note below).
- A **falsifiable mutation exercise**: run the real gate against a genuinely ambiguous fixture (two ACTIVE outcomes naming the same SKU) and observe it refuse (`report.created == ()`); then delete the disambiguation guard from a local copy and rerun — the mutated gate fires where production must refuse. Both the real and mutated behavior were verified by standalone execution (`uv run python`) before being written into the chapter; the mutated gate's actual captured output (`created: (PulseItem(..., status='created', ...),)`) matches exactly what the chapter claims it will do.
- One new `coverage_manifest.json` concept entry and one new `break_evidence` line, both passing `verify_book_depth.py`'s exact-substring/AST-symbol checks.
- The hardcoded book-snippet canary in `tests/test_book_snippets_verifier.py`, from `95 python block(s) / 85 text-pair(s)` to `96 / 86` — computed by diffing this chapter's own block count against committed HEAD in isolation (see collision note below), not by trusting a single contaminated run.

**Figure-count math, checked deliberately** (per ch02's packet, which learned this the hard way — adding words without adding figures in proportion lowers `figureCoverage` under `recommendedFigures = max(2, ceil(words/2000))`): word count went 3196 → 3982, staying under the 4000 threshold that would raise `recommendedFigures` to 3. Figures went 1 → 2, exactly matching the resulting `recommendedFigures` at this word count — deliberately not pushed past 4000, which would have required a third figure to avoid regressing visuals.

**A real defect found and fixed along the way**: an illustrative source-code excerpt (quoting `pulse_gate.py`'s disambiguation check for the reader, referencing `org`/`sku` from the surrounding real function, not standalone-runnable) was initially fenced as ` ```python ` and failed `verify_book_snippets.py`'s strict "every python block must execute" contract. Refenced as ` ```text ` since it's a verbatim quote to read, not a snippet to run — every other block in the chapter (7 total) is genuinely runnable and unaffected.

**Known, pre-existing rubric gap, not addressed here per standing instruction**: figure captions are structurally unreachable through `profrod-site`'s `derive-book.mjs` transform (bare mermaid fences become caption-less blocks by design, RULING-226). This chapter's new figure has a real caption written at the source in `book/`; it will not render through the current pipeline, same known ceiling ch02/ch08's packets already flagged.

**A live collision, worked around, not fixed by this PR**: this checkout is shared with a concurrently-running stream (`sa-wave-a-ch10`), which has its own uncommitted changes to `book/ch10_one_signal_wakes_one_need/README.md`, `tests/test_store_multi_sku.py`, and an in-progress addition to `book/coverage_manifest.json` sitting in the same working tree. This PR's commits were staged and committed by explicit pathspec (never `git add -A`), touch only `book/ch07_the_organization_wakes_itself/README.md`, `book/coverage_manifest.json` (ch07's own section only — diffed and confirmed no ch10 content included), and `tests/test_book_snippets_verifier.py`. Verification was run from an isolated `git worktree --detach` at this branch's exact commit, specifically to avoid the other stream's uncommitted, unformatted work contaminating the `make verify` result — that contamination is real and did block a first push attempt (ruff format failures in `ch10`'s uncommitted file) before the isolated-worktree push succeeded cleanly.

## Verification

- `make verify`: **exit 0**, run three times independently — twice manually in an isolated detached worktree at this exact commit, once more by the pre-push hook's own separate re-run at push time (visible in the push output: lint, mypy, 440 tests passed, curriculum sound, `book snippets sound: 13 chapters, 96 python block(s) executed, 86 text-pair(s) checked, all matched`, `book depth sound: 12 full + 1 tour + 2 known gaps`, `book labs: PASS (13 labs, solutions deterministic twice)`, doctor/demo/onboarding-smoke all OK).
- Both the real and the mutated `store_wake_gate` behavior were executed standalone and their real captured stdout matches what the chapter prose claims, before being embedded.
- Both chapter Mermaid diagrams (1 pre-existing, 1 new) dry-run parsed clean via the real `mermaid` package (profrod-site's own `check-book-diagrams.mjs` method, run from a throwaway script inside the profrod-site checkout, deleted after use — confirmed `git status --short` empty there afterward).

## Not done here

- No merge — per RULING-372, this stream has no merge authority.
- No craft-dimension em-dash cleanup: ch07's em-dash rate (44/3196 words) exceeds the rubric's hard max, same as ch08's already-merged chapter (50 em-dashes) — left as a known, unaddressed gap consistent with that precedent; depth/practice was this packet's stated focus, not craft.
- Word/figure counts and dimension scores are read from `profrod-site`'s live instrument as of this PR's writing; this stream did not re-run `make sync-book`/`make score-book` against this candidate head, per the directive's own sequencing (that step is Master's, after merge).

Directive: `zeroemployeeorg/org` `projects/sovereign-agent/briefs/BOOK-SCORE-OPTIMIZATION-DIRECTIVE-2026-09-03.md`

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns