### PR TITLE
Deepen ch10: wake-gate ambiguity refusal and signal-severity staleness traces

### DIFF
--- a/book/ch10_one_signal_wakes_one_need/INSTRUCTOR.md
+++ b/book/ch10_one_signal_wakes_one_need/INSTRUCTOR.md
@@ -23,9 +23,12 @@ one). Chapter 9's per-SKU threshold proof is also assumed.
 - **"The gate picks the FIRST matching outcome, so order matters."** It
   does not pick by order — it filters outcomes by `subject == sku` AND
   `state == ACTIVE`, and refuses (returns `None`) unless EXACTLY one
-  matches. Point at `store_wake_gate`'s own `len(matching) != 1` check and
-  have the learner explain what happens if this chapter accidentally
-  created two ACTIVE outcomes for the same SKU.
+  matches. "Break it" now runs this for real: the mutation that DOES pick
+  the first match on ambiguity gets the older row purely as an artifact of
+  SQLite's own row order, never a governed fact. Point the learner at the
+  comparison table right after the mutated run and have them state, in
+  their own words, why "picked the first row" and "resolved the ambiguity
+  correctly" are indistinguishable from the caller's side.
 - **"Two signals means Pulse runs twice."** `run_pulse_once` is still one
   deterministic pass — it evaluates every unevaluated signal within that
   one call, not once per signal. Confirm the learner reads `report.items`
@@ -35,6 +38,14 @@ one). Chapter 9's per-SKU threshold proof is also assumed.
   proves signal-to-outcome BINDING and canonical SOW creation are correct.
   Chapter 11 is where the actual replenishment effects (inventory, cash)
   are shown not to cross between SKUs.
+- **"A stale signal just means the alert was late."** The `severity`
+  section shows the more precise failure mode: staleness is not about
+  timing, it is about which field the gate is willing to trust. The signal
+  itself is never wrong (it recorded a true fact for a moment in the
+  past); the mistake would be treating a snapshot field as if it were a
+  live one. Have the learner say what would happen if `store_wake_gate`
+  branched on `signal.severity == "warning"` instead of calling
+  `below_reorder(org.db)` again.
 
 ## Observation checkpoints
 
@@ -55,16 +66,27 @@ one). Chapter 9's per-SKU threshold proof is also assumed.
 - "If a third SKU were added to this chapter's catalog with no active
   outcome naming it, what would `store_wake_gate` do with a qualifying
   signal for that SKU?"
+- "'Break it' shows two refusal causes (zero matches, ambiguous matches)
+  collapsing to the same `None`. Name a system you've used where an error
+  message DID distinguish those two causes to the caller, and say whether
+  `store_wake_gate` losing that distinction is a real cost or a deliberate,
+  acceptable simplification given what a Pulse pass does with the result."
 
 ## Facilitation timing
 
-Roughly 20-25 minutes: 5 minutes reviewing Chapter 7's gate mechanism, 10
+Roughly 25-30 minutes: 5 minutes reviewing Chapter 7's gate mechanism, 10
 minutes on the exercise output and the `sqlite3` cross-check, 5-10 minutes
-on the discussion prompts, particularly the concurrency-test pointer.
+on "Break it" and the severity/live-read distinction, 5-10 minutes on the
+discussion prompts, particularly the concurrency-test pointer.
 
 ## Exercise debrief and assessment
 
 A learner has landed this chapter if they can explain what `store_wake_
 gate` would do (refuse, via `len(matching) != 1`) if this chapter
-accidentally created two ACTIVE outcomes for the same SKU — reasoning from
-the gate's own fail-closed contract, not from having watched it happen.
+accidentally created two ACTIVE outcomes for the same SKU, AND has now
+watched it happen against the real function in "Break it" — the two
+should agree. A learner has landed the severity material if they can state,
+without re-reading the source, which fields on a `Signal` the gate reads
+(`kind`, `source`, `subject_ref`) and which one it deliberately never reads
+(`severity`), and why that omission is the whole point rather than an
+oversight.

--- a/book/ch10_one_signal_wakes_one_need/README.md
+++ b/book/ch10_one_signal_wakes_one_need/README.md
@@ -325,6 +325,269 @@ authentication: an actor with raw database access could forge every row in
 it, agreeing with itself perfectly. Chapter 2 drew that boundary; Chapter 12
 will price it.
 
+## Break it: what the gate's ambiguity refusal is actually preventing
+
+`store_wake_gate`'s docstring makes a claim this chapter has not yet
+proven: a qualifying signal must map "to EXACTLY one ACTIVE outcome naming
+that subject." Every run so far has quietly kept that true by construction
+(one outcome per SKU, seeded once, never duplicated). This section breaks
+that assumption on purpose and watches the gate's own code decide what to
+do about it, against the real production function, not a paraphrase of it.
+
+`store_wake_gate` (`src/reference_organizations/store/pulse_gate.py`)
+builds `matching` by scanning every row in `outcomes` and keeping the ones
+whose `subject` equals the signal's SKU *and* whose `state` is `ACTIVE`.
+The one line that decides everything downstream is `if len(matching) != 1:
+return None`. Read literally, that line refuses two shapes of input for
+the same reason: a SKU nobody governs yet (zero matches), and a SKU two
+outcomes both claim to govern (two or more matches). Both refusals are
+`None` — no exception, no partial decision, nothing durable recorded.
+
+```mermaid
+flowchart TD
+    R[rows: every ACTIVE outcome\nwhere subject == sku] --> C{len matching}
+    C -->|0| REFUSE0[return None\nno outcome governs this SKU yet]
+    C -->|1| FIRE[WakeDecision\noutcome_id = the one match]
+    C -->|2 or more| REFUSE2[return None\nno durable rule disambiguates more than one]
+```
+
+**What this figure shows:** the gate has exactly one branch that fires,
+flanked by two refusal branches that look nothing alike in cause — one is
+under-coverage, the other is over-coverage — but collapse to the identical
+observable outcome. A caller reading only "did it fire?" cannot tell which
+refusal happened, and the gate's own contract says it should not have to:
+either way, nothing governs this signal well enough to act.
+
+Prove the ambiguous branch against the real function. Seed one SKU with
+*two* ACTIVE outcomes both naming it (the shape a human could produce by
+activating a second "keep the tea stocked" outcome without noticing the
+first was never closed), then run a real qualifying sale against it:
+
+```python
+import tempfile
+from pathlib import Path
+
+from reference_organizations.store import record_sale, seed_catalog
+from reference_organizations.store.pulse_gate import store_wake_gate
+from sovereign_agent.organization import Organization
+from sovereign_agent.pulse import run_pulse_once
+
+root_ch10 = Path(tempfile.mkdtemp())
+org_ch10 = Organization.init(root_ch10)
+seed_catalog(org_ch10.db)
+
+outcome_original = org_ch10.create_outcome(
+    "Keep the tea jar stocked (original)",
+    "On-hand SKU-TEA is at or above the reorder point.",
+    ["inventory_at_or_above_reorder_point"],
+    "principal-human",
+    "SKU-TEA",
+)
+org_ch10.activate(outcome_original.id, "master-course")
+
+outcome_duplicate = org_ch10.create_outcome(
+    "Keep the tea jar stocked (accidental duplicate)",
+    "On-hand SKU-TEA is at or above the reorder point.",
+    ["inventory_at_or_above_reorder_point"],
+    "principal-human",
+    "SKU-TEA",
+)
+org_ch10.activate(outcome_duplicate.id, "master-course")
+
+tea_signal = record_sale(org_ch10.db, "SKU-TEA", 2, 400)
+
+real_decision = store_wake_gate(org_ch10, tea_signal)
+print("real gate, two ACTIVE outcomes for one SKU:", real_decision)
+
+real_report = run_pulse_once(org_ch10, store_wake_gate)
+print(
+    "real gate, pulse pass status:", real_report.items[0].status, "-", real_report.items[0].detail
+)
+sows_real = org_ch10.db.connection.execute("SELECT COUNT(*) c FROM sows").fetchone()["c"]
+print("real gate, sows created:", sows_real)
+```
+
+```text
+real gate, two ACTIVE outcomes for one SKU: None
+real gate, pulse pass status: skipped - wake gate did not fire
+real gate, sows created: 0
+```
+
+The real function does exactly what its docstring claims: two matches
+refuse as cleanly as zero would. No SOW, no assignment, no wake decision
+row — the signal stays durably recorded and unevaluated, waiting for a
+human to close the duplicate outcome and let the next Pulse pass resolve
+it cleanly.
+
+Now the mutation: a `store_wake_gate` with the `len(matching) != 1` check
+weakened to `if not matching: return None` — it still refuses the
+zero-match case, but silently accepts the ambiguous one by taking whichever
+row `matching[0]` happens to be. Every other line is copied verbatim from
+production, so the only variable is that one refusal condition:
+
+```python
+import json
+
+from reference_organizations.store import below_reorder
+from sovereign_agent.models import OutcomeState, Role
+from sovereign_agent.pulse import WakeDecision
+
+
+def store_wake_gate_picks_first_on_ambiguity(org, signal):
+    if signal.kind != "inventory.changed" or signal.source != "sale":
+        return None
+    sku = signal.subject_ref
+    if sku not in below_reorder(org.db):
+        return None
+    rows = org.db.connection.execute("SELECT record FROM outcomes").fetchall()
+    matching = []
+    for row in rows:
+        record = json.loads(row["record"])
+        if record.get("subject") == sku and record.get("state") == OutcomeState.ACTIVE.value:
+            matching.append(record)
+    if not matching:
+        return None  # BUG: was `if len(matching) != 1`, so ambiguity is no longer refused
+    outcome_id = str(matching[0]["id"])
+    return WakeDecision(
+        outcome_id=outcome_id,
+        scope=f"Pulse-dispatched replenishment after signal {signal.id}",
+        role=Role.OPERATOR,
+        planner_id="master-course",
+        worker_id="operator-course",
+        required_effect_kind="replenishment",
+    )
+
+
+mutated_decision = store_wake_gate_picks_first_on_ambiguity(org_ch10, tea_signal)
+print("mutated gate fired:", mutated_decision is not None)
+print(
+    "mutated gate picked the OLDER outcome (created first):",
+    mutated_decision.outcome_id == outcome_original.id,
+)
+print(
+    "mutated gate picked the NEWER outcome (the actual duplicate):",
+    mutated_decision.outcome_id == outcome_duplicate.id,
+)
+```
+
+```text
+mutated gate fired: True
+mutated gate picked the OLDER outcome (created first): True
+mutated gate picked the NEWER outcome (the actual duplicate): False
+```
+
+This is the false green. The mutated gate does not crash and does not
+notice anything is wrong. It fires, builds a real `WakeDecision`, and a
+full Pulse pass would create an ordinary-looking SOW, assignment, and
+eventually a replenishment effect against `outcome_original` — a choice
+determined entirely by which row SQLite happened to return first, which is
+*never* a governed fact. `sows.outcome_id` would look perfectly ordinary: one row,
+one signal, one outcome, no trace anywhere that a second outcome was
+silently discarded. Nothing downstream (Chapter 9's threshold checks,
+Chapter 12's release evidence) can tell "the gate resolved a real tie
+correctly" apart from "the gate ignored a real conflict and got lucky,"
+because both produce the identical shape of record.
+
+| | Real `store_wake_gate` | Mutated (`if not matching`) |
+| --- | --- | --- |
+| Zero ACTIVE outcomes for the SKU | Refuses, `None` | Refuses, `None` (unchanged) |
+| Two ACTIVE outcomes for the SKU | Refuses, `None` | Fires, picks row order |
+| SOWs created on the duplicate-outcome input | 0 | 1 (arbitrary target) |
+| What a caller would believe | Nothing governs this yet (correct) | The right outcome fired (unverifiable) |
+
+`tests/test_store_multi_sku.py::test_wake_gate_refuses_when_two_active_outcomes_name_the_same_sku`
+pins this as a regression against the real function, and a paired test
+runs the exact mutation shown above and asserts it fires when the real
+gate would not — so a future refactor that weakens the cardinality check
+the way this section did is caught by the test suite, not by a chapter's
+prose.
+
+**Why "exactly one," not "at least one."** A gate that fired on the first
+match rather than refusing on more than one would still pass every test
+this book has run before this section, because every prior exercise seeds
+precisely one ACTIVE outcome per SKU — the bug is invisible until the
+precondition it silently assumes stops holding. A rule that is correct
+under an assumption the code never states, let alone verifies, is a rule
+waiting for the day the assumption breaks. `store_wake_gate` states it and
+verifies it in the same line.
+
+## The signal is a snapshot; the gate re-checks live
+
+The two-outcome case is one way the gate refuses to trust an assumption.
+There is a second, quieter one, named directly in `store_wake_gate`'s own
+docstring: a qualifying trigger's subject must be "CURRENTLY below its
+reorder point (re-checked now, not trusted from the signal's own
+`severity` at the time it was written — stock may have already been
+replenished since)." A `Signal` row's `severity` field is written once, at
+`record_sale`'s moment of creation, and never updated again — it is a
+snapshot, not a live view. If the gate trusted it, a signal born as
+`"warning"` would stay a reason to fire forever, even long after the shelf
+it described was quietly restocked.
+
+```mermaid
+sequenceDiagram
+    participant Sale as record_sale
+    participant Sig as Signal row
+    participant Shelf as inventory table
+    participant Gate as store_wake_gate
+    Sale->>Sig: severity = "warning" (written once)
+    Sale->>Shelf: on_hand below reorder
+    Note over Shelf: off-the-books restock<br/>on_hand updated directly
+    Gate->>Sig: read kind, source, subject_ref<br/>(never severity)
+    Gate->>Shelf: below_reorder(db) -- LIVE read
+    Shelf-->>Gate: on_hand now above reorder
+    Gate-->>Gate: refuse, return None
+    Note over Sig: severity still says "warning" --<br/>the field itself never changes
+```
+
+**What this figure shows:** everything the gate reads from the signal
+object — `kind`, `source`, `subject_ref` — is identity and provenance, set
+once and never expected to change. `severity` is the one field on the same
+object that describes the *world*, not the signal, and the gate never
+reads it at all: every freshness question — is this SKU still below
+reorder, right now — is answered by a second, independent read against
+`inventory`. The frozen `severity` field and the live `below_reorder` read
+can disagree, and when they do, the gate trusts the live read every time.
+
+Prove it against the real gate. Record a real qualifying sale, then
+restock the SKU off the books — direct SQL, exactly the "delivery driver
+restocked it this morning" scene this chapter opened with, never touching
+the signal row itself — and run the same signal through the gate again:
+
+```python
+tea_signal_2 = record_sale(org_ch10.db, "SKU-COFFEE", 5, 650)
+print("signal severity at creation:", tea_signal_2.severity)
+
+org_ch10.db.connection.execute("UPDATE inventory SET on_hand = 20 WHERE sku = 'SKU-COFFEE'")
+org_ch10.db.connection.commit()
+
+decision_after_restock = store_wake_gate(org_ch10, tea_signal_2)
+print("gate decision after an off-the-books restock:", decision_after_restock)
+print("signal severity is still:", tea_signal_2.severity, "(the field itself never changes)")
+```
+
+```text
+signal severity at creation: warning
+gate decision after an off-the-books restock: None
+signal severity is still: warning (the field itself never changes)
+```
+
+The signal's own `severity` field is frozen at `"warning"` forever — reading
+it in isolation would say this SKU still needs attention. The gate ignores
+that frozen field entirely and re-reads `below_reorder(org.db)` against the
+inventory table as it stands right now, so the restock the signal never
+learned about still refuses the decision correctly. Two different fields
+carry two different kinds of truth here: `severity` answers "how urgent did
+this look the moment it was recorded," a fact about the past that a caller
+might reasonably want for triage or an alert dashboard; `below_reorder`'s
+live query answers "does this still need action," the only fact
+`store_wake_gate` is allowed to act on. Confusing the two would make the
+gate's decision depend on how long a signal sat unevaluated rather than on
+the world's current state — the same durable-fact-versus-live-decision
+separation Chapter 7's four-clocks table drew for signals, ticks,
+supervisor sweeps, and heartbeats, applied here to a single field instead
+of a whole mechanism.
+
 ## The exercise
 
 ```bash
@@ -415,18 +678,32 @@ attack shows exactly this — every individual binding correct, and the whole
 chain still pointed at the wrong SKU — closed only once every fact is
 derived from the ledger instead of supplied by the caller.
 
+The same discipline governs the gate that starts this whole chain.
+`store_wake_gate` fires on exactly one condition and refuses on two
+different-looking ones that both reduce to "no durable rule disambiguates
+this": zero ACTIVE outcomes naming the SKU, or more than one. The mutation
+in "Break it" showed what silently narrowing that refusal to only the
+zero-match case buys — a decision that looks identical to a correct one
+in every field it returns, chosen by row order instead of governance. And
+the gate's live re-read of `inventory` against a `Signal`'s frozen
+`severity` field is the same "never trust a cached fact when a live one is
+available" rule this book keeps re-deriving, one mechanism at a time.
+
 Back at Lucy's shop: vanilla's alarm at 2:00 and chocolate's alarm at 2:05
-each wake their own restock and only their own, however close together they
-fire.
+each wake their own restock and only their own, however close together
+they fire — and if a second, forgotten "restock the vanilla" outcome were
+still sitting ACTIVE from last month, the gate would refuse both alarms
+rather than guess which one it meant.
 
 ## Explain it back
 
 1. `store_wake_gate` takes a `Signal`, not a SKU string, as its argument.
    Where inside the gate does it decide WHICH outcome the signal is about?
-2. This chapter creates two ACTIVE outcomes, one per SKU. What would
-   `store_wake_gate` do if TWO active outcomes both named the same SKU as
-   their subject? (Look at the gate's own docstring, not just its code, for
-   the answer.)
+2. "Break it" proved what `store_wake_gate` does when TWO active outcomes
+   both name the same SKU. State the exact one-line change that turns the
+   real gate into the mutated one, and say why the mutated version's return
+   value gives a caller no way to tell it fired on an arbitrary pick rather
+   than a governed decision.
 3. `decisions_never_cross` compares two `outcome_id` strings for
    inequality. Why is that a meaningful proof of isolation, rather than an
    accident of how identifiers happen to be generated?
@@ -436,20 +713,33 @@ fire.
 5. Generation 4 had every individual binding right and was still defeated.
    What single design rule closes it, and where else in this book have you
    seen the same rule?
-6. `sow-coffee` was refused even though its execution genuinely restocked a
-   real SKU. Explain why "causal binding cuts in both directions" is a
-   feature and not bureaucratic cruelty — what would crediting `run-x`'s
-   tea work to `sow-coffee` corrupt downstream?
+6. `sow-coffee` was refused even though its execution restocked a real
+   SKU. Explain why "causal binding cuts in both directions" is a feature
+   and not bureaucratic cruelty — what would crediting `run-x`'s tea work
+   to `sow-coffee` corrupt downstream?
 7. Every arrow in the proof graph is a foreign key. Name the one claim in
    the graph that is NOT a stored row but a live act, and say why it cannot
    be replaced by a stored row.
+8. `Signal.severity` and `store_wake_gate`'s live `below_reorder` read can
+   disagree. Name a legitimate use for the frozen `severity` field (one
+   this chapter says a caller "might reasonably want") that does NOT
+   require it to match the live inventory state.
+9. Both of the gate's refusal branches — zero matching outcomes, and more
+   than one — return the identical value: `None`. What does the chapter's
+   own diagram of this branch (the flowchart, not the sequence diagram)
+   say a caller loses by that collapse, and why does the gate's contract
+   treat that loss as acceptable rather than as a defect to fix?
 
 ## Where to look next
 
 - `src/reference_organizations/store/pulse_gate.py` — `store_wake_gate`, the
-  same gate from Chapter 7, now proven across two SKUs at once
+  same gate from Chapter 7, now proven across two SKUs and one ambiguous
+  case at once
 - `tests/test_store_multi_sku.py` — the wake-decision-isolation and
-  Pulse-origin-isolation tests this chapter's proof extends
+  Pulse-origin-isolation tests this chapter's proof extends, including
+  `test_wake_gate_refuses_when_two_active_outcomes_name_the_same_sku` and
+  `test_removing_the_cardinality_check_makes_the_gate_fire_on_ambiguity`,
+  the pinned regressions for this chapter's "Break it" section
 
 `solution.py` imports the production package rather than copying it.
 

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -874,6 +874,47 @@
               "text": "Subject is read from the outcome, not supplied"
             }
           ]
+        },
+        {
+          "concept": "gate-refuses-zero-or-ambiguous-matches-identically",
+          "anchor": "Break it: what the gate's ambiguity refusal is actually preventing",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/pulse_gate.py",
+              "name": "store_wake_gate"
+            }
+          ],
+          "tests": [
+            "tests/test_store_multi_sku.py::test_wake_gate_refuses_when_two_active_outcomes_name_the_same_sku",
+            "tests/test_store_multi_sku.py::test_removing_the_cardinality_check_makes_the_gate_fire_on_ambiguity"
+          ],
+          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py",
+          "source_text": [
+            {
+              "file": "src/reference_organizations/store/pulse_gate.py",
+              "text": "zero or ambiguous -- no durable rule disambiguates more than one"
+            }
+          ]
+        },
+        {
+          "concept": "signal-severity-is-a-snapshot-gate-re-reads-live",
+          "anchor": "The signal is a snapshot; the gate re-checks live",
+          "symbols": [
+            {
+              "file": "src/reference_organizations/store/pulse_gate.py",
+              "name": "store_wake_gate"
+            }
+          ],
+          "tests": [
+            "tests/test_store_multi_sku.py::test_wake_gate_never_fires_for_a_sku_still_above_reorder"
+          ],
+          "exercise": "book/ch10_one_signal_wakes_one_need/solution.py",
+          "source_text": [
+            {
+              "file": "src/reference_organizations/store/pulse_gate.py",
+              "text": "trusted from the signal's own `severity` at the time it was written"
+            }
+          ]
         }
       ],
       "limits_anchor": "forge every row in",
@@ -881,7 +922,9 @@
         "effects recorded by run-t: 0",
         "run-t did something",
         "ACCEPTED: run-x caused a replenishment on SKU-TEA",
-        "replenishment on SKU-COFFEE"
+        "replenishment on SKU-COFFEE",
+        "mutated gate fired: True",
+        "gate decision after an off-the-books restock: None"
       ],
       "lab": "book/labs/ch10_one_signal_wakes_one_need"
     },

--- a/tests/test_book_snippets_verifier.py
+++ b/tests/test_book_snippets_verifier.py
@@ -360,5 +360,5 @@ def test_main_succeeds_when_attempted_count_matches_expected(
 def test_real_book_chapters_still_pass_unchanged() -> None:
     result = run_cli(REPO_ROOT)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "book snippets sound: 13 chapters, 95 python block(s) executed" in result.stdout
-    assert "85 text-pair(s) checked, all matched" in result.stdout
+    assert "book snippets sound: 13 chapters, 98 python block(s) executed" in result.stdout
+    assert "88 text-pair(s) checked, all matched" in result.stdout

--- a/tests/test_store_multi_sku.py
+++ b/tests/test_store_multi_sku.py
@@ -138,6 +138,89 @@ def test_wake_gate_never_fires_for_a_sku_still_above_reorder(tmp_path: Path) -> 
     assert store_wake_gate(org, coffee_signal) is None
 
 
+def test_wake_gate_refuses_when_two_active_outcomes_name_the_same_sku(
+    tmp_path: Path,
+) -> None:
+    """Ch10's own 'Break it' section: the gate's `len(matching) != 1` check
+    refuses BOTH zero-match and ambiguous-match inputs, not only the
+    zero-match case every other test in this module happens to exercise.
+    A human who activates a second "keep the tea stocked" outcome without
+    closing the first must not get an arbitrary, unverifiable pick."""
+    org, outcome_ids = _seeded_multi_sku_org(tmp_path)
+    duplicate = org.create_outcome(
+        "Keep the tea jar stocked (accidental duplicate)",
+        "On-hand SKU-TEA is at or above the reorder point.",
+        ["inventory_at_or_above_reorder_point"],
+        "principal-human",
+        TEA,
+    )
+    org.activate(duplicate.id, "master-course")
+
+    tea_signal = record_sale(org.db, TEA, 2, 400)
+    assert store_wake_gate(org, tea_signal) is None
+
+    report = run_pulse_once(org, store_wake_gate)
+    assert report.items[0].status == "skipped"
+    assert report.items[0].detail == "wake gate did not fire"
+    sows = org.db.connection.execute("SELECT COUNT(*) AS c FROM sows").fetchone()["c"]
+    assert sows == 0
+    assert outcome_ids[TEA] != duplicate.id  # the fixture's original outcome is untouched
+
+
+def test_removing_the_cardinality_check_makes_the_gate_fire_on_ambiguity(
+    tmp_path: Path,
+) -> None:
+    """Runs the exact mutation ch10's chapter text shows -- `len(matching)
+    != 1` weakened to `not matching` -- and asserts it fires on the same
+    two-active-outcome input the sibling test above proves the real gate
+    refuses. If a future refactor of `store_wake_gate` ever narrows that
+    check the same way, this test catches it; the chapter's prose does
+    not re-run itself."""
+    import json
+
+    from sovereign_agent.models import OutcomeState
+    from sovereign_agent.pulse import WakeDecision
+
+    def store_wake_gate_picks_first_on_ambiguity(org, signal):
+        if signal.kind != "inventory.changed" or signal.source != "sale":
+            return None
+        sku = signal.subject_ref
+        if sku not in below_reorder(org.db):
+            return None
+        rows = org.db.connection.execute("SELECT record FROM outcomes").fetchall()
+        matching = []
+        for row in rows:
+            record = json.loads(row["record"])
+            if record.get("subject") == sku and record.get("state") == OutcomeState.ACTIVE.value:
+                matching.append(record)
+        if not matching:
+            return None  # BUG: was `if len(matching) != 1`
+        return WakeDecision(
+            outcome_id=str(matching[0]["id"]),
+            scope=f"Pulse-dispatched replenishment after signal {signal.id}",
+            role=Role.OPERATOR,
+            planner_id="master-course",
+            worker_id="operator-course",
+            required_effect_kind="replenishment",
+        )
+
+    org, outcome_ids = _seeded_multi_sku_org(tmp_path)
+    duplicate = org.create_outcome(
+        "Keep the tea jar stocked (accidental duplicate)",
+        "On-hand SKU-TEA is at or above the reorder point.",
+        ["inventory_at_or_above_reorder_point"],
+        "principal-human",
+        TEA,
+    )
+    org.activate(duplicate.id, "master-course")
+
+    tea_signal = record_sale(org.db, TEA, 2, 400)
+    mutated_decision = store_wake_gate_picks_first_on_ambiguity(org, tea_signal)
+
+    assert mutated_decision is not None
+    assert mutated_decision.outcome_id == outcome_ids[TEA]  # the older row, an arbitrary pick
+
+
 # === Pulse-origin isolation ======================================================
 
 


### PR DESCRIPTION
## Summary

Wave A depth packet for `book/ch10_one_signal_wakes_one_need`, per sap1's directive (org issue #377, `projects/sovereign-agent/briefs/BOOK-SCORE-OPTIMIZATION-DIRECTIVE-2026-09-03.md`). Confirmed live against `quality/books/sovereign-agent/latest.json` at profrod-site `origin/main` (`be7f423f`) before starting: **ch10 measured depth=75.025, score=81/90, 2779 words** — genuinely depth-deficient, not at ceiling the way ch02 was.

Two new worked mechanism traces against real production code in `store_wake_gate` (`src/reference_organizations/store/pulse_gate.py`), both covering behavior that existed in production but had zero prior test coverage anywhere in the repo:

1. **The ambiguity refusal.** `store_wake_gate`'s `if len(matching) != 1: return None` collapses two different-cause refusals — zero matching ACTIVE outcomes, and more than one — to an identical `None`. Proven against the real function (two ACTIVE outcomes seeded for one SKU, gate correctly refuses, Pulse pass reports `skipped`/`wake gate did not fire`, zero SOWs created), then against a real mutation (`if not matching: return None`, copied verbatim from production except that one condition) that silently fires on the ambiguous case, picking whichever row SQLite happens to return first — an arbitrary row-order artifact, never a governed fact.
2. **Signal severity is a snapshot; the gate re-checks live.** `Signal.severity` is written once at `record_sale`'s creation time and never updated. `store_wake_gate` never reads it, re-checking `below_reorder(org.db)` live instead. Proven by recording a qualifying sale, then restocking the SKU off the books via direct SQL (the exact "delivery driver restocked it this morning" scene the chapter opens with), and showing the gate still refuses correctly even though the signal's `severity` field is still permanently `"warning"`.

Both traces are pinned as new regression tests in `tests/test_store_multi_sku.py` (`test_wake_gate_refuses_when_two_active_outcomes_name_the_same_sku`, `test_removing_the_cardinality_check_makes_the_gate_fire_on_ambiguity`) and two new `coverage_manifest.json` concept entries, verified against `scripts/verify_book_depth.py`'s strict AST-symbol / exact-substring checks. Two new Mermaid figures (a flowchart for the three-way refusal/fire branch, a sequence diagram for the snapshot-vs-live-read timeline) bring the chapter to 3 figures, matching `recommendedFigures` at the new word count.

Also fixed the sole Tier 1A AI-writing marker ("genuinely") flagged in the last measured pass, and avoided introducing new instances while drafting.

## Metrics

- Word count: 2779 → 4813 (+2034), inside the rubric's 4000–7000 ideal band (was below `idealMin`)
- Figures: 1 → 3, matching `recommendedFigures = max(2, ceil(words/2000)) = 3` at the new word count
- `verify_book_snippets.py`: ch10 python blocks 7 → 10, text-pairs 6 → 9, all matched; whole-repo canary in `tests/test_book_snippets_verifier.py` updated 95→98 blocks / 85→88 pairs to reflect the 3 legitimate new blocks (caught failing on first `make verify` run, fixed, re-verified)
- `verify_book_depth.py`: clean, 12 full-depth + 1 tour chapter(s), 2 known gaps unchanged
- 3 Mermaid diagrams (1 pre-existing + 2 new) dry-run verified via a throwaway `jsdom`+`mermaid.parse()` script mirroring profrod-site's own `scripts/check-book-diagrams.mjs`, run from the profrod-site checkout for correct `node_modules` resolution, deleted immediately after — `git status --short` confirmed empty in that checkout before and after

## Known cross-chapter gap, not addressed here

Figure captions are structurally unreachable through profrod-site's `derive-book.mjs` transform (bare `mermaid` fences become caption-less blocks by design, RULING-226) — same known gap ch02's and ch08's packets already flagged. Not attempted here per the standing instruction.

## Explicitly not done

- Did not do a wholesale em-dash reduction pass. The chapter's em-dash rate (~12.68/1000) barely moved from baseline (~12.59/1000) because new prose was written in the same voice as the rest of the book — this matches every other chapter's rate (ch08 currently sits at ~11.94/1000, unaddressed by its own Wave A packet) and is a book-wide condition, not unique to ch10. Flagged here rather than force-fixed, since the brief's primary ask was depth-first/practice-second, not a craft rewrite, and a partial fix would have been an inconsistent, arbitrary edit against the book's established voice.
- Did not build a public "cancel/close the duplicate outcome" recovery demo. `OutcomeState.ACTIVE → CANCELLED` is a legal transition in `policy.py`'s `OUTCOME_TRANSITIONS` table, but there is no public `Organization` method wired to reach it — verified by grep before deciding not to fabricate a workaround.

## Verification

```
$ make verify   (run independently 4x: 3x manually across the editing session
                  after a mid-session branch correction — see note below —
                  plus once more by the pre-push hook's own independent
                  re-run at push time)
...
book snippets sound: 13 chapters, 98 python block(s) executed, 88 text-pair(s) checked, all matched
book depth sound: 12 chapter(s) at full depth verified, 1 tour chapter(s) verified, 0 pending, 2 explicit known gap(s) on record
book labs: PASS (13 labs, solutions deterministic twice)
442 passed, 10 deselected
... (lint, mypy, curriculum, doctor, demo, onboarding smoke all OK)
```

**Mid-session branch correction, reported for transparency:** this shared checkout had a stale branch (`stream/sa-wave-a-ch07-2026-09-04`, a sibling stream's own two commits) checked out when this session started editing — not `main`. Caught via `git log` showing unexpected ch07 commits ahead of this session's own diff. No commits were made on the wrong branch (all edits were uncommitted working-tree changes at the time of discovery); the diff was saved as a patch, the wrong branch's tracked-file changes were discarded, and the patch was cleanly reapplied on a fresh branch created directly from `origin/main` at `38dc646c` (the exact SHA this task was scoped against). The sibling ch07 branch and its own commits were left completely untouched.

## Test plan

- [x] `make verify` exit 0, run independently 4 times (3 manual + 1 pre-push-hook)
- [x] `tests/test_store_multi_sku.py` — 14/14 passing, including 2 new regression tests
- [x] `scripts/verify_book_snippets.py` — 13 chapters, all matched
- [x] `scripts/verify_book_depth.py` — sound, ch10's 2 new concepts verified against real AST symbols and exact source substrings
- [x] 3 Mermaid diagrams parse clean against the real `mermaid` package
- [ ] Sparring/Master independent re-verification (not performed by this stream — no standing to self-certify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns