### PR TITLE
book/ch07: fix practice-dimension gap (88 -> 96 measured)

### DIFF
--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -307,7 +307,7 @@ running each as its own separate operation. Recovery reconciles work that
 exists; Pulse creates work that should; a mechanism that did both would be a
 process nobody could reason about when it failed halfway through either job.
 
-### The real gate refuses a question your toy never had to ask
+### Break it: what the outcome-disambiguation guard is actually preventing
 
 Your `wake_gate` only checked one thing: is `on_hand` still below `reorder`.
 The Store's own production gate, `store_wake_gate` in
@@ -552,6 +552,142 @@ and that Pulse-created work is not exempt from Chapter 5's fencing.
 `verify_curriculum.py` proves this chapter's own claim is backed by durable
 evidence, not merely present in the prose — the mechanical guard this
 project's own curriculum checker enforces specifically for Chapter 7.
+
+## Exercise 2: prove the crash-window resume, don't just read the prose about it
+
+Two sections back, this chapter asserted something and moved on: "a tick
+that finds the decision already committed but the work not yet run doesn't
+create anything — it picks up the canonical identifiers and resumes from
+there, which is precisely `run_pulse_once`'s step one in production." That
+sentence is a claim about `_resumable_signals` and `_resumable_signals`
+alone (`src/sovereign_agent/pulse.py`). Exercise 1 never exercises this
+path — its sale-to-completion run never crosses a crash boundary, so
+`_resumable_signals` always returns nothing for that run. This exercise
+forces the crash window open and checks what actually comes back.
+
+```mermaid
+flowchart LR
+    C1[create_pulse_work\ncommits SOW + assignment\nassignment.state = CREATED] -->|hard kill here| K[process dies\nrun_assignment never called]
+    K --> R2[fresh run_pulse_once\n_resumable_signals finds it]
+    R2 -->|resumes SAME assignment| Done[assignment.state = COMPLETED\nledger: 1 SOW, 1 assignment]
+```
+
+*Figure — the crash window `_resumable_signals` closes. A hard kill between
+canonical creation and provider execution leaves an assignment stuck at
+`CREATED`; the next ordinary `run_pulse_once` pass — no special "resume"
+flag, no operator action — finds it via the same query every pass runs and
+invokes the identical assignment rather than minting a second one.*
+
+Call `Organization.create_pulse_work` directly instead of `run_pulse_once`,
+so the assignment it creates is left at `CREATED` — exactly what a hard
+kill between canonical creation and provider execution would leave behind:
+
+```python
+from pathlib import Path
+import shutil
+
+from reference_organizations.store import record_sale, seed
+from reference_organizations.store.pulse_gate import store_wake_gate
+from sovereign_agent.models import Role
+from sovereign_agent.organization import Organization
+from sovereign_agent.pulse import run_pulse_once
+
+root = Path("/tmp/lucy-ch07-crash")
+shutil.rmtree(root, ignore_errors=True)
+
+org = Organization.init(root)
+seed(org.db)
+outcome = org.create_outcome(
+    "Keep the tea jar stocked",
+    "On-hand tea is at or above the reorder point.",
+    ["inventory_at_or_above_reorder_point"],
+    "principal-human",
+    "SKU-TEA",
+)
+org.activate(outcome.id, "master-course")
+
+signal = record_sale(org.db, "SKU-TEA", 2, 400)
+source_event_id = org.db.connection.execute(
+    "SELECT id FROM events WHERE kind = 'sale.committed'"
+).fetchone()["id"]
+
+# THIS is the simulated crash: create_pulse_work runs, so the SOW,
+# assignment, pulse.work_created event, and origin row are all durable --
+# but nobody calls run_assignment. The assignment is left at CREATED.
+sow, assignment, created = org.create_pulse_work(
+    source_signal_id=signal.id,
+    source_event_id=source_event_id,
+    subject="SKU-TEA",
+    outcome_id=outcome.id,
+    scope="pulse replenishment",
+    role=Role.OPERATOR,
+    planner_id="master-course",
+    worker_id="operator-course",
+    required_effect_kind="replenishment",
+)
+print("assignment state after simulated crash:", assignment.state.value)
+org.db.close()
+
+# "Restart": a fresh Organization handle over the SAME database file, then
+# one ORDINARY Pulse pass -- nothing tells it a crash happened.
+resumed = Organization(root)
+report = run_pulse_once(resumed, store_wake_gate)
+print("items in the resume pass's report:", len(report.items))
+print("status:", report.items[0].status)
+print("resumed assignment id == original:", report.items[0].assignment_id == assignment.id)
+print("resumed assignment state:", report.items[0].assignment_state)
+```
+
+```text
+assignment state after simulated crash: CREATED
+items in the resume pass's report: 1
+status: replayed
+resumed assignment id == original: True
+resumed assignment state: COMPLETED
+```
+
+Four things this proves, read back from the report rather than asserted:
+the resume pass reports exactly one item for a signal that already has a
+wake decision — `_unevaluated_signals` correctly does not re-offer it to
+the gate, because re-deciding an already-decided signal is not this
+function's job; the status is `"replayed"`, never `"created"` — nothing
+new was minted; the assignment id is byte-identical to the one
+`create_pulse_work` returned before the simulated crash — this is
+*resumption*, not a lookup that merely resembles one; and the assignment
+that was stuck at `CREATED` reaches `COMPLETED` through the exact same
+`run_assignment` call every other path in this chapter uses, with no
+special-cased "resume" branch that could drift from ordinary execution.
+
+**The mutation.** Comment out exactly the resume loop in
+`src/sovereign_agent/pulse.py`'s `run_pulse_once` — the two lines quoted
+verbatim below, to read and delete in your own local copy, not a
+standalone block to run:
+
+```text
+    for signal, sow_id, assignment in _resumable_signals(org):
+        items.append(_invoke_or_report(org, signal.id, sow_id, assignment, created=False))
+```
+
+— leaving `_unevaluated_signals` and everything below it untouched, then
+rerun the script above against a fresh `/tmp/lucy-ch07-crash`. The mutated
+function no longer asks the database which signals already fired but never
+finished; it only asks which signals have never been decided at all — and
+this signal already has a decision, so it is invisible to both loops:
+
+```text
+assignment state after simulated crash: CREATED
+items in the resume pass's report: 0
+```
+
+`report.items` is `()`. Not an error, not a refusal — silence. The
+`CREATED` assignment this run left behind is never picked up by this or
+any later pass, because nothing in the mutated function ever looks for it
+again; the sale that woke the organization produced work that then sits
+forever, half-finished, with a green `create_pulse_work` return and no
+downstream signal that anything is wrong. This is the exact failure mode
+`tests/test_pulse.py::test_canonical_created_work_survives_restart_and_resumes_without_duplication`
+exists to catch on every commit — restore the two lines before moving on;
+this repository's own suite will otherwise fail on the next `make verify`.
 
 ## Summary
 

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -608,7 +608,7 @@
         },
         {
           "concept": "gate-refuses-ambiguous-outcome-ownership",
-          "anchor": "The real gate refuses a question your toy never had to ask",
+          "anchor": "Break it: what the outcome-disambiguation guard is actually preventing",
           "symbols": [
             {
               "file": "src/reference_organizations/store/pulse_gate.py",
@@ -620,6 +620,20 @@
             "tests/test_pulse.py::test_more_than_one_matching_active_outcome_creates_no_work"
           ],
           "exercise": "book/ch07_the_organization_wakes_itself/solution.py"
+        },
+        {
+          "concept": "crash-window-resume-invokes-same-assignment",
+          "anchor": "Exercise 2: prove the crash-window resume, don't just read the prose about it",
+          "symbols": [
+            {
+              "file": "src/sovereign_agent/pulse.py",
+              "name": "_resumable_signals"
+            }
+          ],
+          "tests": [
+            "tests/test_pulse.py::test_canonical_created_work_survives_restart_and_resumes_without_duplication"
+          ],
+          "exercise": "book/ch07_the_organization_wakes_itself/README.md"
         }
       ],
       "limits_anchor": "It does **not**",

--- a/tests/test_book_snippets_verifier.py
+++ b/tests/test_book_snippets_verifier.py
@@ -360,5 +360,5 @@ def test_main_succeeds_when_attempted_count_matches_expected(
 def test_real_book_chapters_still_pass_unchanged() -> None:
     result = run_cli(REPO_ROOT)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "book snippets sound: 13 chapters, 99 python block(s) executed" in result.stdout
-    assert "89 text-pair(s) checked, all matched" in result.stdout
+    assert "book snippets sound: 13 chapters, 100 python block(s) executed" in result.stdout
+    assert "90 text-pair(s) checked, all matched" in result.stdout


### PR DESCRIPTION
## Summary

profrod-site's scoring pipeline (`scripts/content-lint/book-score.mjs` in
`rodriveracom/profrod-site`) measured ch07 ("The organization wakes itself")
at **88/100**, just short of the 90 target, with `practice: 75` — the only
dimension below 90 on this chapter, versus 90-100 on every other Wave A
chapter. Diagnosis was verified fresh against the current scoring code and
a live re-run before any change was made (not assumed from the charter):

```
practice = min(30, exercises*20) + min(20, codeFenceCount*4)
         + (learner-verification heading ? 20 : 0)
         + (expected-output heading ? 15 : 0)
         + (break/attack/falsif/failure/experiment/adversarial heading ? 15 : 0)
```

`exercises: 1` capped the exercises term at `min(30,20)=20`, ten points
below the 30-point max. Separately, the chapter's own falsification section
already contained a genuine runnable mutation (a real deleted guard, real
captured "wrong" output) but was titled in a way that matched none of the
regex's keywords — forfeiting the 15-point heading bonus for a labeling
reason unrelated to content. And at the chapter's real word count (4,011,
not an earlier miscount of 3,885), `recommendedFigures` is 3; the chapter
had 2.

## What changed

1. **New "Exercise 2: prove the crash-window resume."** The chapter's prose
   asserts twice that a crashed-but-committed Pulse assignment resumes on
   the next ordinary pass ("the crash-window resume in miniature... precisely
   `run_pulse_once`'s step one in production") but Exercise 1's happy-path
   run never crosses that boundary, so the claim was never proven to the
   reader. The new exercise calls `Organization.create_pulse_work` directly
   to leave an assignment at `CREATED` (simulating a hard kill before
   `run_assignment`), then runs an ordinary `run_pulse_once` and shows the
   real report: `status: "replayed"`, the same assignment id, reaching
   `COMPLETED`. The mutation — deleting the `_resumable_signals` call site
   in `pulse.py` — produces an empty report and a permanently stuck
   `CREATED` assignment: exactly the failure
   `tests/test_pulse.py::test_canonical_created_work_survives_restart_and_resumes_without_duplication`
   exists to catch. Both the correct and the mutated runs were executed for
   real to capture the quoted output; `pulse.py` was restored after each
   test and the working tree confirmed clean before committing.

2. **Honest retitle of the existing falsification section**, from "The real
   gate refuses a question your toy never had to ask" to "Break it: what the
   outcome-disambiguation guard is actually preventing" — matching ch08's
   and ch10's own "Break it:" convention for the identical kind of section.
   The section's content (a real deleted guard in `store_wake_gate`, real
   captured `report.created` output showing the wrong pick) is unchanged;
   only the label now says what the section already does.
   `book/coverage_manifest.json`'s anchor for that concept was updated to
   match, and a new concept entry was added for the new exercise, pointing
   at `_resumable_signals` and the crash-window test. (The manifest's
   pre-existing `creation-rolls-back-whole-at-any-fault` entry already cited
   that same test under an unrelated heading — a pre-existing mismatch, left
   untouched, out of this change's scope.)

3. The new exercise's mermaid figure brings `figures` to 3/3, matching
   `recommendedFigures` at the chapter's real length (previously 2/3).

4. `tests/test_book_snippets_verifier.py::test_real_book_chapters_still_pass_unchanged`
   asserted an exact literal python-block/text-pair count across the whole
   book (99/89). The new exercise's one runnable block legitimately raises
   these to 100/90 (verified via `scripts/verify_book_snippets.py` directly
   before touching the test), so the literals were updated — a content-
   driven regression guard being bumped for real new content, not the kind
   of structural hardcoded-SHA defect PR #22 fixed on the profrod-site side.

## Verification

Live-scored this exact commit against `profrod-site`'s real scoring
pipeline (`node scripts/sync-book.mjs --source <this repo> --sha
407a4306ab068c0b4795934a2e7e293df29faf06 --target 90`):

| | before | after |
|---|---|---|
| score | 88 | **96** |
| practice | 75 | **100** |
| visuals | 66.67 | **85** |
| exercises | 1 | 2 |
| figures | 2/3 | 3/3 |

`ok: true` in the live report. Full dimension/metric JSON captured during
this PR's own verification run.

`make verify` passes clean on this branch (lint, mypy, full pytest suite,
`verify_curriculum.py`, `verify_book_snippets.py`, `verify_book_depth.py`,
`verify_book_labs.py`, CLI smoke, `doctor`, `demo`, onboarding smoke) — ran
via the repo's normal pre-push hook with no `--no-verify`.

## Test plan

- [x] `make verify` exit 0 on this branch (confirmed twice: once directly,
      once via the pre-push hook on `git push`)
- [x] New exercise's correct-path script run for real, output captured
      verbatim into the chapter
- [x] New exercise's mutation run for real against a temporarily-swapped,
      then fully restored, copy of `pulse.py`; `git status` confirmed clean
      afterward
- [x] Live profrod-site scorer re-run against this exact commit SHA,
      confirming practice 75→100, visuals 66.67→85, overall 88→96

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01PEj2RTZMxcLAMupUQx76Ns