### PR TITLE
Release 1.3.0 — six advanced mechanisms and executable book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Repository: [`profrodai/sovereign-agent`](https://github.com/profrodai/sovereign
 
 ## Unreleased
 
+## [1.3.0] — 2026-09-05
+
+Sovereign Agent 1.3.0 turns six patterns from current agent systems into small,
+offline mechanisms that learners can inspect, break, and repair. It also brings
+the complete executable book to a deterministic 90+ editorial score on every
+chapter. The score is a prioritization instrument, not a publisher endorsement.
+
 - Integrate all six advanced mechanisms into the canonical thirteen-chapter
   manuscript: hybrid memory in Chapter 1; recoverable context and bounded tool
   discovery in Chapter 3; five-plane isolation in Chapter 4; session
@@ -24,6 +31,21 @@ Repository: [`profrodai/sovereign-agent`](https://github.com/profrodai/sovereign
 - Add the Advanced Mechanisms book companion and adversarial regression suite.
   Runtime dependencies remain exactly `pydantic`; all new machinery uses the
   Python standard library and the existing SQLite ledger.
+- Deepen the executable manuscript with front matter, conventions, a summary in
+  every chapter, course-derived mechanism traces, 38 implementation-grounded
+  Mermaid diagrams, and adversarial exercises. The canonical thirteen chapters
+  now contain 102 executed Python blocks and 92 byte-matched output pairs; all
+  thirteen companion labs remain deterministic across two fresh runs.
+- Add a hostile-`PATH` onboarding proof that runs the README's documented
+  `uv run` commands from a clean archive and refuses stale global `python` or
+  `sovereign-agent` shims. The proof is part of both `make verify` and CI.
+- Harden the six-stage release-candidate verifier by bootstrapping its clean
+  virtual environment in a fresh Python process. Environment-creation failures
+  are now reported as named gate findings instead of unclassified tracebacks.
+- Establish `profrod-site` as the derived rendered home while keeping this
+  repository's `book/` tree canonical. The site imports an exact commit and
+  reports per-chapter editorial scores without writing derived metadata back
+  into the public manuscript.
 
 ## [1.2.0] — 2026-09-02
 

--- a/docs/release-notes/1.3.0.md
+++ b/docs/release-notes/1.3.0.md
@@ -1,0 +1,85 @@
+# v1.3.0 release notes
+
+Sovereign Agent 1.3.0 adds six compact, executable mechanisms for teaching the
+failure boundaries that current agent systems must handle. Every mechanism is
+offline, uses the existing SQLite ledger, and adds no runtime dependency beyond
+Pydantic.
+
+## Six mechanisms you can run and break
+
+Run the complete reference scenario with:
+
+```bash
+uvx sovereign-agent@1.3.0 mechanisms \
+  --root /tmp/sovereign-agent-mechanisms
+```
+
+The scenario demonstrates:
+
+1. **Five-plane isolation policy.** Filesystem, network, credentials, tools,
+   and process isolation are reported independently. Deny wins over allow,
+   paths are resolved before authorization, and unavailable OS enforcement is
+   stated rather than implied.
+2. **Durable condition automation.** SQLite-backed schedules use atomic due-slot
+   claims, persistent condition state, idempotency keys, and bounded failure
+   handling. A watcher that does not fire cannot invent a run.
+3. **Recoverable context compaction.** Source transcript bytes remain append-only;
+   summaries are derived views with durable cursors. Failed or racing compaction
+   cannot erase the conversation it tried to summarize.
+4. **Session incarnations.** Host leases and monotonically increasing
+   incarnations fence stale workers, while delivery attempts remain durable
+   evidence across retries and host takeover.
+5. **Bounded tool discovery.** Search can rank and truncate a large catalog, but
+   discovery never grants authority. Policy still decides whether a returned
+   tool may run.
+6. **Hybrid memory with provenance.** Access control runs before lexical,
+   recency, importance, optional semantic, and diversity ranking. Each result
+   exposes its score components and honestly reports when semantic scoring was
+   unavailable.
+
+These are teaching implementations, not claims of production containment.
+Application-level policy cannot substitute for an operating-system sandbox or
+an egress firewall, and callers supply embeddings when they want semantic
+ranking.
+
+## The executable book now teaches the mechanisms in context
+
+The six mechanisms are woven into Chapters 1, 3, 4, 5, and 7 rather than left
+in an appendix. Each treatment includes a diagram grounded in production
+symbols, a runnable exercise from an empty root, a deliberate mutation that
+exposes a false green, expected invariants, and an independent verification
+command.
+
+Across the book, this release also adds front matter, shared conventions,
+chapter summaries, course-derived concurrency and recovery traces, and deeper
+practice. The repository gate executes 102 Python snippets, byte-matches 92
+outputs, validates all 38 Mermaid diagrams through the derived site pipeline,
+and runs all thirteen companion labs twice from fresh roots.
+
+The `profrod-site` content bridge imports the book from an exact Sovereign Agent
+commit. Its deterministic linter currently scores every chapter at least 90,
+with a 93 average. That number guides revision; it is not a Manning, O'Reilly,
+or other publisher acceptance claim.
+
+## Safer onboarding
+
+The README's development commands consistently use `uv run`. A new behavioral
+gate extracts those commands from a clean Git archive and executes them with
+hostile decoy executables on `PATH`, proving the documented flow cannot silently
+run an unrelated global Python or CLI.
+
+The release-candidate gate also creates its isolated wheel-test environment in
+a fresh Python process. This keeps state accumulated while running chapter
+exercises out of the environment bootstrap and reports bootstrap failures as
+named release findings.
+
+## Compatibility
+
+- Requires Python 3.14 or newer.
+- Runtime dependencies remain `pydantic>=2,<3` only.
+- This is a backward-compatible minor release on the 1.x educational API line.
+- The retired v0.7 fleet framework remains available with
+  `uvx "sovereign-agent<1"`.
+
+A git tag is not a public release until the built wheel and source distribution
+are installed from PyPI and verified outside the source tree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sovereign-agent"
-version = "1.2.0"
+version = "1.3.0"
 description = "An executable textbook for learning Zero-Employee Organizations"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/verify_release_candidate.py
+++ b/scripts/verify_release_candidate.py
@@ -40,7 +40,6 @@ import re
 import subprocess
 import sys
 import tempfile
-import venv
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -124,8 +123,16 @@ def build_and_install_wheel(failures: list[str], work_dir: Path) -> Path | None:
         return None
     wheel = wheels[-1]
 
+    # Stage 1 imports and executes every chapter in this interpreter. Creating
+    # the venv through a fresh interpreter prevents that accumulated module
+    # state from leaking into ensurepip (observed as a macOS Python 3.14
+    # SIGABRT), and lets this gate report bootstrap failure instead of ending
+    # in an unclassified traceback.
     venv_dir = work_dir / "venv"
-    venv.EnvBuilder(with_pip=True, clear=True).create(venv_dir)
+    code, output = run([sys.executable, "-m", "venv", "--clear", str(venv_dir)])
+    if code != 0:
+        fail(failures, f"creating the clean venv failed:\n{output}")
+        return None
     venv_python = venv_dir / "bin" / "python"
     if not venv_python.is_file():
         fail(failures, f"venv creation did not produce {venv_python}")

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -10,7 +10,7 @@ from sovereign_agent.ids import new_id
 from sovereign_agent.models import Actor, Outcome, StatementOfWork
 from sovereign_agent.organization import Organization
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 __all__ = [
     "Actor",

--- a/tests/test_clean_import.py
+++ b/tests/test_clean_import.py
@@ -23,4 +23,4 @@ print(json.dumps({'before': before, 'after': after, 'version': sovereign_agent._
         text=True,
     )
     observed = json.loads(result.stdout)
-    assert observed == {"before": [], "after": [], "version": "1.2.0"}
+    assert observed == {"before": [], "after": [], "version": "1.3.0"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,4 +33,4 @@ def test_module_entry_point_reports_version() -> None:
         capture_output=True,
         text=True,
     )
-    assert result.stdout.strip() == "sovereign-agent 1.2.0"
+    assert result.stdout.strip() == "sovereign-agent 1.3.0"

--- a/tests/test_verification_scripts.py
+++ b/tests/test_verification_scripts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -26,3 +27,33 @@ def test_source_budget_gate() -> None:
     result = run_script("verify_source_budget.py")
     assert "modules=" in result.stdout
     assert "root_exports=" in result.stdout
+
+
+def test_release_gate_bootstraps_venv_in_a_fresh_interpreter(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    script = ROOT / "scripts" / "verify_release_candidate.py"
+    spec = importlib.util.spec_from_file_location("release_candidate_gate", script)
+    assert spec is not None and spec.loader is not None
+    gate = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gate)
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], cwd: Path | None = None) -> tuple[int, str]:
+        del cwd
+        calls.append(argv)
+        if argv[1:4] == ["-m", "build", "--wheel"]:
+            dist_dir = Path(argv[-1])
+            dist_dir.mkdir(parents=True, exist_ok=True)
+            (dist_dir / "sovereign_agent-test-py3-none-any.whl").touch()
+        if argv[1:4] == ["-m", "venv", "--clear"]:
+            venv_python = Path(argv[-1]) / "bin" / "python"
+            venv_python.parent.mkdir(parents=True)
+            venv_python.touch()
+        return 0, ""
+
+    monkeypatch.setattr(gate, "run", fake_run)  # type: ignore[attr-defined]
+    failures: list[str] = []
+    assert gate.build_and_install_wheel(failures, tmp_path) == tmp_path / "venv"
+    assert failures == []
+    assert [sys.executable, "-m", "venv", "--clear", str(tmp_path / "venv")] in calls

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "sovereign-agent"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Outcome

Prepares the backward-compatible `1.3.0` release from the exact merged book and
runtime state on `main`.

- bumps every canonical package version surface to `1.3.0`;
- regenerates `uv.lock`;
- closes the accumulated Unreleased changelog for 2026-09-05;
- adds reader-facing `docs/release-notes/1.3.0.md`;
- hardens the installed-wheel release gate so its venv bootstrap runs in a
  fresh Python process and reports bootstrap failure as a named finding.

The release covers all changes since `v1.2.0`: manuscript front matter and
chapter summaries, course-derived technical depth, a deterministic 90+
per-chapter editorial score, the exact-commit `profrod-site` content bridge,
and six executable mechanisms for isolation, automation, context compaction,
session fencing, bounded tool discovery, and hybrid memory.

## Exact binding

- base: `a118dd90eda4c93fb5a3639f3e7a4809d2e5de9d`
- head: `5b102c048203b1cf9bb077a873878bcc1e5ee280`
- previous public version: PyPI `1.2.0`
- proposed version and tag after merge: `1.3.0` / `v1.3.0`

## Verification

- `make verify`: PASS at the committed head
- pytest: `468 passed, 10 deselected`
- clean Git-archive onboarding: package identified as `1.3.0`; `463 passed,
  5 skipped, 10 deselected`; hostile-`PATH` checks PASS
- `uv lock --check`: PASS
- runtime dependencies: exactly `pydantic`
- source budget: `35/40` modules, `7202/7250` nonblank lines, `7/30` root
  exports
- curriculum: 13 chapters and 13 primary exercises
- snippets: 102 executable Python blocks, 92 byte-matched output pairs
- labs: 13/13 deterministic twice
- six-stage `verify_release_candidate.py`: PASS; the isolated installed wheel
  runs every chapter exercise and is proven outside the source tree
- separately built wheel and sdist: `sovereign_agent-1.3.0-py3-none-any.whl`
  and `sovereign_agent-1.3.0.tar.gz`; fresh external venv reports
  `sovereign-agent 1.3.0`, passes `doctor`, and runs `mechanisms`

## Gate repair found during release preparation

The first two six-stage gate attempts aborted inside Python 3.14 `ensurepip`
after Stage 1 had imported and executed every chapter in-process. A standalone
fresh-interpreter venv bootstrap succeeded, falsifying a broken interpreter or
package artifact. The gate now invokes the standard-library venv module through
a fresh Python subprocess, preserves the same stage order, and converts a
future bootstrap failure into an explicit release-gate finding. A focused
regression test pins that process boundary, and the real six-stage gate passed
afterward.

## Publication sequence

This PR performs no irreversible publication act. After exact-head review and
merge, gate the merged commit, create tag `v1.3.0` on that exact commit, publish
the GitHub release from `docs/release-notes/1.3.0.md`, allow the existing trusted
publishing workflow to build and publish, then verify PyPI JSON plus fresh wheel
and sdist installations. A tag alone is not completion.
