### PR TITLE
Close file and reservation proof gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Repository: [`profrodai/sovereign-agent`](https://github.com/profrodai/sovereign
 
 ## Unreleased
 
+- Make `atomic_write` safe under concurrent writers by using a unique
+  same-directory temporary file, syncing its contents before replacement, and
+  cleaning it on both success and failure. Parent-directory durability remains
+  an explicit boundary rather than an implied guarantee.
+- Make sales honor reserved inventory and reject non-positive quantities before
+  any ledger write. Low-stock severity now derives from post-sale available
+  inventory, with adversarial and concurrent-buyer regression coverage.
+- Reconcile the executable manuscript with those runtime contracts, add a
+  digest time-of-check/time-of-use diagram, and remove the final two declared
+  implementation gaps from the book coverage manifest.
+
 ## [1.3.0] — 2026-09-05
 
 Sovereign Agent 1.3.0 turns six patterns from current agent systems into small,

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -696,9 +696,11 @@ print((shop_root / "STATUS.md").read_text(), end="")
 The crash landed at the worst moment — after the (truncated) temp file was
 written, before the swap — and the real file is untouched. Whatever instant
 the power dies, a reader sees the complete old file or the complete new file,
-never a torn one. This is byte-for-byte the production mechanism: every
-governance file the organization writes goes through `atomic_write` in
-`sovereign_agent/files.py` — sibling temp file, flush, `fsync`, `os.replace`.
+never a torn one. The production mechanism strengthens the example for
+concurrent callers: every governance file goes through `atomic_write` in
+`sovereign_agent/files.py` — a **unique** sibling temp file, flush, `fsync`,
+then `os.replace`. Unique names prevent two writers from truncating each
+other's staging file; replacement still decides which complete value wins.
 
 **What this does not guarantee.** Be precise about the promise. `os.replace`
 swaps the *directory entry* atomically, but this helper does not `fsync` the

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -550,6 +550,30 @@ accept against evidence describing a world that no longer exists. The final
 clause compares the **evidence's state digest** against the world's digest at
 acceptance time:
 
+```mermaid
+sequenceDiagram
+    participant W as World state
+    participant V as Verifier
+    participant E as Evidence ledger
+    participant A as Accepter
+    V->>W: read exact proof inputs
+    W-->>V: state W1
+    V->>E: append PASS + digest(W1)
+    Note over W: a later sale creates W2
+    A->>W: rerun check and recompute digest
+    W-->>A: check PASS + digest(W2)
+    A->>E: compare current digest with recorded digest
+    alt digest(W2) differs from digest(W1)
+        A-->>A: refuse stale evidence
+    else digests match
+        A-->>A: acceptance may continue
+    end
+```
+
+The check can still return `PASS` in both worlds. The digest rejects the
+stronger lie: that today's passing state is the same state an independent
+reviewer actually examined.
+
 ```python
 def accept_v7(db, outcome_id, accepter):
     subject = db.execute("SELECT subject FROM outcomes WHERE id = ?", (outcome_id,)).fetchone()[0]

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -349,12 +349,12 @@ sequenceDiagram
     participant DB as SQLite
     participant B as Sale B
     A->>DB: BEGIN IMMEDIATE
-    A->>DB: read SKU-TEA on_hand
+    A->>DB: read SKU-TEA on_hand + reserved
     B->>DB: BEGIN IMMEDIATE
     Note over B,DB: waits for the writer lock
     A->>DB: validate available stock, write inventory, cash, signal, event
     A->>DB: COMMIT
-    B->>DB: lock acquired, read new on_hand
+    B->>DB: lock acquired, read new on_hand + reserved
     B->>DB: validate against the committed value
 ```
 

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -41,7 +41,7 @@ flowchart LR
     A -->|quantity ≤ available| U[decrement on_hand]
     A -->|quantity > available| R[refuse + rollback]
     U --> C[append positive\ncash movement]
-    U --> N[new_on_hand ≤\nthis SKU's reorder point?]
+    U --> N[available_after ≤\nthis SKU's reorder point?]
     N --> S[append signal\nwarning or info]
     S --> E[append sale event]
     C --> K[COMMIT]
@@ -56,13 +56,14 @@ against competing writers. Checking before the transaction creates a classic
 check-then-act race: two sellers can both observe one remaining tub and both
 decide it is available.
 
-The threshold predicate is evaluated against `new_on_hand`, not the opening
-quantity. It is also local to the selected row. Write it mathematically:
+The threshold predicate is evaluated against `available_after`, not the opening
+quantity or physical stock alone. It is also local to the selected row. Write
+it mathematically:
 
 ```text
 available(sku) = on_hand(sku) - reserved(sku)
 sale allowed    ⇔ quantity > 0 ∧ quantity ≤ available(sku)
-warning         ⇔ on_hand_after(sku) ≤ reorder_point(sku)
+warning         ⇔ available_after(sku) ≤ reorder_point(sku)
 ```
 
 That notation exposes boundary choices prose can hide. Equality produces a
@@ -77,7 +78,7 @@ while allowing the wake gate to decline work. Recording facts broadly and
 creating work narrowly is cleaner than suppressing facts merely because they do
 not yet require action.
 
-### Contract audit: the teaching model is stricter than production
+### Contract audit: where the teaching model and production differ
 
 Read `src/reference_organizations/store/__init__.py::record_sale` before
 assuming the exercise describes it exactly:
@@ -85,17 +86,16 @@ assuming the exercise describes it exactly:
 | Rule | Chapter implementation | Current production implementation |
 | --- | --- | --- |
 | Concurrent read/write | `BEGIN IMMEDIATE` | `db.immediate()`—same guarantee |
-| Reservation-aware availability | checks `on_hand - reserved` | reads only `on_hand`; reservations are ignored |
-| Positive quantity | explicitly refused | no explicit check; a negative quantity can increase stock |
+| Reservation-aware availability | checks `on_hand - reserved` | same rule, inside the transaction |
+| Positive quantity | explicitly refused | same refusal before any write |
 | Price authority | caller supplies unit price | caller also supplies unit price; catalog price is not consulted |
 | Atomic durable effects | inventory, cash, signal, event | same four classes of write in one transaction |
 
-This mismatch is pedagogically useful and operationally real. The exercise
-builds the contract Lucy would want, then the production comparison shows that
-an attractive schema field (`reserved`) is not a guarantee until the mutation
-path consumes it. The chapter proves the current per-SKU threshold behavior; it
-does **not** claim production already enforces reservation-aware selling or
-catalog-authoritative pricing.
+The remaining mismatch is operationally real: accepting a caller-supplied price
+is a deliberate teaching seam, not catalog-authoritative commerce. Reservations
+show a different lesson. A schema field became a guarantee only when the
+mutation path consumed it and fault-injection tests proved refusal left every
+table unchanged. The chapter and production now share that stronger contract.
 
 ## Build the sale yourself, then oversell the freezer
 
@@ -139,10 +139,11 @@ def record_sale(db, sku, quantity, unit_price_cents):
         db.execute("ROLLBACK")
         return f"refused: only {available} available ({on_hand} on hand, {reserved} reserved)"
     new_on_hand = on_hand - quantity
+    available_after = new_on_hand - reserved
     total = quantity * unit_price_cents
     db.execute("UPDATE inventory SET on_hand = ? WHERE sku = ?", (new_on_hand, sku))
     db.execute("INSERT INTO cash_entries(amount_cents) VALUES (?)", (total,))
-    severity = "warning" if new_on_hand <= reorder else "info"
+    severity = "warning" if available_after <= reorder else "info"
     count = db.execute("SELECT COUNT(*) FROM signals").fetchone()[0]
     sig_id = f"sig-{count}"
     db.execute(
@@ -262,11 +263,11 @@ processes colliding — `BEGIN IMMEDIATE`'s reserved lock is what serializes
 genuinely concurrent connections, and the production suite proves that case
 with real separate connections.
 
-### Available is not on-hand—and production has not wired that rule yet
+### Available is not on-hand
 
 Chapter 2's acceptance checks count reservations; a consistent sale contract
-should too. The current production `record_sale` does not. Build the desired
-rule in the chapter model to see the missing behavior precisely: six tubs
+must too. Build the rule in the chapter model to see the behavior precisely:
+six tubs
 physically in the freezer, five promised to a wedding order:
 
 ```python
@@ -278,15 +279,16 @@ print(record_sale(db, "SKU-TEA", 1, 400))
 
 ```text
 refused: only 1 available (6 on hand, 5 reserved)
-sold 1 SKU-TEA for 400c -> on_hand 5, signal info
+sold 1 SKU-TEA for 400c -> on_hand 5, signal warning
 ```
 
 Selling from `on_hand` alone can double-promise the wedding's tubs to a
 walk-in customer — both truths recorded, both impossible to honor.
 `available = on_hand - reserved` is one subtraction, and it is the entire
 difference between a ledger that models commitments and one that models
-shelves. Treat this as a named implementation gap until a production test and
-code change close it.
+shelves. Production now performs that subtraction inside `db.immediate()`,
+refuses before any write, and computes signal severity from the remaining
+available stock—not the physically present stock.
 
 ### All five writes, or none
 
@@ -328,10 +330,11 @@ rollback took both back. A sale that decrements stock but records no cash,
 or takes cash but emits no signal for Pulse to wake on, is not a partial
 sale; it is a ledger at war with itself. The production version—`record_sale`
 in `src/reference_organizations/store/__init__.py`—shares the
-inside-the-transaction read, caller-price multiplication, per-SKU severity,
-per-occurrence dedupe key, and all-or-nothing commit. It does not share this
-toy model's reservation or positive-quantity checks. Similarity of transaction
-shape must not be inflated into equality of domain validation.
+inside-the-transaction read, reservation and quantity guards,
+caller-price multiplication, per-SKU severity, per-occurrence dedupe key, and
+all-or-nothing commit. It deliberately does not resolve the caller-price seam.
+Similarity of transaction shape must not be inflated into equality of every
+domain policy.
 
 ## Numeric state belongs in the transaction, not in the prompt
 
@@ -349,7 +352,7 @@ sequenceDiagram
     A->>DB: read SKU-TEA on_hand
     B->>DB: BEGIN IMMEDIATE
     Note over B,DB: waits for the writer lock
-    A->>DB: validate nonnegative, write inventory, cash, signal, event
+    A->>DB: validate available stock, write inventory, cash, signal, event
     A->>DB: COMMIT
     B->>DB: lock acquired, read new on_hand
     B->>DB: validate against the committed value
@@ -417,11 +420,12 @@ For any sale function, write the edge matrix before implementation:
 | 5 on hand, 3 reserved | 3 | refuse if the contract sells only available stock |
 | missing SKU | 1 | refuse; actors cannot invent inventory |
 
-The current Store demo's `record_sale` guards negative post-sale `on_hand` and
-unknown SKUs, while the acceptance check later uses `on_hand - reserved`.
-That difference is worth noticing: reservations are modeled in verification
-but are not yet consumed by the sale mutation. Do not silently infer a complete
-reservation system from the presence of the column.
+The current Store demo's `record_sale` guards positive quantity, unknown SKUs,
+and `on_hand - reserved` inside the same immediate transaction. That still does
+not imply a complete reservation lifecycle: this example begins with an
+existing reservation value and protects it during sale. It does not create,
+expire, allocate, or fulfill reservations. Never infer a complete subsystem
+from one correctly consumed column.
 
 ## The exercise
 

--- a/book/ch10_one_signal_wakes_one_need/README.md
+++ b/book/ch10_one_signal_wakes_one_need/README.md
@@ -530,12 +530,12 @@ sequenceDiagram
     participant Sig as Signal row
     participant Shelf as inventory table
     participant Gate as store_wake_gate
-    Sale->>Sig: severity = "warning" (written once)
-    Sale->>Shelf: on_hand below reorder
+    Sale->>Sig: severity = "warning" from available stock (written once)
+    Sale->>Shelf: on_hand minus reserved below reorder
     Note over Shelf: off-the-books restock<br/>on_hand updated directly
     Gate->>Sig: read kind, source, subject_ref<br/>(never severity)
     Gate->>Shelf: below_reorder(db) -- LIVE read
-    Shelf-->>Gate: on_hand now above reorder
+    Shelf-->>Gate: available stock now above reorder
     Gate-->>Gate: refuse, return None
     Note over Sig: severity still says "warning" --<br/>the field itself never changes
 ```

--- a/book/ch10_one_signal_wakes_one_need/README.md
+++ b/book/ch10_one_signal_wakes_one_need/README.md
@@ -658,42 +658,22 @@ Expected: all pass.
 
 ## Summary
 
-This chapter built acceptance across five generations, each closing a way
-"the world is right" gets mistaken for "this execution made it right": read
-current state, require recorded evidence, bind that evidence to this
-outcome's own verification batch, derive the execution from the SOW instead
-of accepting a caller-supplied id, and finally derive the subject itself
-from the outcome rather than accepting it as an argument.
+Acceptance now requires two things at once: the world predicate is true, and
+the proof path from outcome to SOW to execution to effect is the path that made
+it true. The five generations progressively stopped accepting caller-supplied
+facts and derived them from the ledger instead. A right-shaped effect from the
+wrong execution, or the right execution credited to the wrong SKU, refuses.
 
-The invariant it establishes is causal binding: an acceptance requires both
-the correct world predicate *and* the correct provenance path from outcome
-to SOW to execution to effect — a real, right-shaped effect from the wrong
-execution, or the right execution credited against the wrong subject, both
-still refuse.
+The wake gate applies the same discipline earlier. It fires only when one
+ACTIVE outcome names the signal's subject. Zero matches and multiple matches
+both mean that governance cannot select one outcome, so both return no
+decision. A cached warning is not enough either: the gate re-reads available
+inventory before it creates work.
 
-The failure it prevents is the crossed wire named in this chapter's own
-open: two signals close together, and the vanilla alarm's proof accidentally
-crediting the chocolate outcome (or vice versa). Generation 4's own worked
-attack shows exactly this — every individual binding correct, and the whole
-chain still pointed at the wrong SKU — closed only once every fact is
-derived from the ledger instead of supplied by the caller.
-
-The same discipline governs the gate that starts this whole chain.
-`store_wake_gate` fires on exactly one condition and refuses on two
-different-looking ones that both reduce to "no durable rule disambiguates
-this": zero ACTIVE outcomes naming the SKU, or more than one. The mutation
-in "Break it" showed what silently narrowing that refusal to only the
-zero-match case buys — a decision that looks identical to a correct one
-in every field it returns, chosen by row order instead of governance. And
-the gate's live re-read of `inventory` against a `Signal`'s frozen
-`severity` field is the same "never trust a cached fact when a live one is
-available" rule this book keeps re-deriving, one mechanism at a time.
-
-Back at Lucy's shop: vanilla's alarm at 2:00 and chocolate's alarm at 2:05
-each wake their own restock and only their own, however close together
-they fire — and if a second, forgotten "restock the vanilla" outcome were
-still sitting ACTIVE from last month, the gate would refuse both alarms
-rather than guess which one it meant.
+At Lucy's shop, vanilla's alarm and chocolate's alarm can arrive minutes apart
+without crossing. Each wakes only its own restock. If a forgotten second
+vanilla outcome remains ACTIVE, the gate refuses rather than let database row
+order make a governance decision.
 
 ## Explain it back
 

--- a/book/coverage_manifest.json
+++ b/book/coverage_manifest.json
@@ -128,9 +128,12 @@
               "name": "atomic_write"
             }
           ],
-          "tests": [],
-          "exercise": "book/ch01_organization_remembers/solution.py",
-          "known_gap": "files.py atomic_write has no direct behavioral test in the suite; flagged in the Batch 1 filing as scoped follow-up implementation work, not smuggled into book scope."
+          "tests": [
+            "tests/test_files.py::test_atomic_write_replaces_the_target_and_removes_its_tempfile",
+            "tests/test_files.py::test_atomic_write_preserves_the_old_value_when_replace_fails",
+            "tests/test_files.py::test_concurrent_atomic_writers_never_share_a_tempfile_or_tear_bytes"
+          ],
+          "exercise": "book/ch01_organization_remembers/solution.py"
         },
         {
           "concept": "memory-access-filter-before-hybrid-ranking",
@@ -904,10 +907,11 @@
             }
           ],
           "tests": [
-            "tests/test_acceptance_falsification.py::test_reserved_stock_is_not_available_stock"
+            "tests/test_acceptance_falsification.py::test_reserved_stock_is_not_available_stock",
+            "tests/test_persistence.py::test_sale_refuses_reserved_stock_without_partial_writes",
+            "tests/test_concurrency.py::test_concurrent_sales_cannot_consume_reserved_stock"
           ],
-          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py",
-          "known_gap": "The acceptance check subtracts reserved stock, but production record_sale currently reads only on_hand and reorder_point. The chapter model deliberately demonstrates the stronger sale contract and labels the production divergence; reservation-aware selling is not yet implemented."
+          "exercise": "book/ch09_each_product_has_its_own_threshold/solution.py"
         },
         {
           "concept": "dedupe-key-per-occurrence-append-only-signals",

--- a/src/reference_organizations/store/__init__.py
+++ b/src/reference_organizations/store/__init__.py
@@ -171,7 +171,7 @@ def record_sale(db: Database, sku: str, quantity: int, unit_price_cents: int) ->
     """
     with db.immediate() as connection:
         row = connection.execute(
-            "SELECT on_hand, reorder_point FROM inventory WHERE sku = ?", (sku,)
+            "SELECT on_hand, reserved, reorder_point FROM inventory WHERE sku = ?", (sku,)
         ).fetchone()
         if row is None:
             raise Refusal(
@@ -180,14 +180,23 @@ def record_sale(db: Database, sku: str, quantity: int, unit_price_cents: int) ->
                 "inventory list",
                 "Seed the catalog.",
             )
-        on_hand = int(row["on_hand"]) - quantity
-        if on_hand < 0:
+        if quantity <= 0:
             raise Refusal(
-                "Sale would go negative.",
-                "The ledger refuses unrecorded stock.",
+                "Sale quantity must be positive.",
+                "A sale cannot act as a hidden restock.",
+                "status",
+                "Use a positive quantity.",
+            )
+        available = int(row["on_hand"]) - int(row["reserved"])
+        if quantity > available:
+            raise Refusal(
+                "Sale would consume reserved stock or go negative.",
+                "The ledger refuses stock promised elsewhere or not recorded.",
                 "status",
                 "Restock first.",
             )
+        on_hand = int(row["on_hand"]) - quantity
+        available_after = on_hand - int(row["reserved"])
         cash_id = new_id("cash")
         signal_id = new_id("sig")
         signal = Signal(
@@ -195,7 +204,7 @@ def record_sale(db: Database, sku: str, quantity: int, unit_price_cents: int) ->
             kind="inventory.changed",
             source="sale",
             subject_ref=sku,
-            severity="warning" if on_hand <= int(row["reorder_point"]) else "info",
+            severity="warning" if available_after <= int(row["reorder_point"]) else "info",
             observed_at=utc_now(),
             payload_digest=sku,
             # Unit 9, signal stability: the level a signal describes, not a
@@ -236,6 +245,8 @@ def record_sale(db: Database, sku: str, quantity: int, unit_price_cents: int) ->
                 "sku": sku,
                 "qty": quantity,
                 "on_hand": on_hand,
+                "reserved": int(row["reserved"]),
+                "available_after": available_after,
                 "cash_id": cash_id,
                 "signal_id": signal.id,
             },

--- a/src/sovereign_agent/files.py
+++ b/src/sovereign_agent/files.py
@@ -4,19 +4,24 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
 
 def atomic_write(path: Path, data: bytes) -> None:
-    """Write via a sibling tempfile, fsync, then ``os.replace``."""
+    """Write via a unique sibling tempfile, fsync, then ``os.replace``."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f".{path.name}.tmp")
-    with tmp.open("wb") as handle:
-        handle.write(data)
-        handle.flush()
-        os.fsync(handle.fileno())
-    os.replace(tmp, path)
+    handle_id, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(handle_id, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -114,6 +114,30 @@ def test_concurrent_sales_cannot_oversell(tmp_path: Path) -> None:
     assert on_hand == 4 - 3 * results.count("sold")
 
 
+def test_concurrent_sales_cannot_consume_reserved_stock(tmp_path: Path) -> None:
+    """Two buyers cannot both spend the one unit not already promised."""
+    org, _outcome_id, _sow_id, _assignment_id = governed_assignment(tmp_path)
+    org.db.connection.execute(
+        "UPDATE inventory SET on_hand = 4, reserved = 3 WHERE sku = 'SKU-TEA'"
+    )
+    org.db.connection.commit()
+    org.db.close()
+
+    def work(db: Database, _index: int) -> str:
+        record_sale(db, "SKU-TEA", 1, 400)
+        return "sold"
+
+    results = _run_concurrently(tmp_path, work)
+
+    db = Database(tmp_path / ".sovereign" / "organization.db")
+    row = db.connection.execute(
+        "SELECT on_hand, reserved FROM inventory WHERE sku = 'SKU-TEA'"
+    ).fetchone()
+    db.close()
+    assert results.count("sold") == 1
+    assert (row["on_hand"], row["reserved"]) == (3, 3)
+
+
 def test_only_one_contender_wins_a_contested_lease(tmp_path: Path) -> None:
     """Two DISTINCT contenders: exactly one wins.
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,60 @@
+"""Behavioral proofs for the file boundary."""
+
+from __future__ import annotations
+
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from sovereign_agent.files import atomic_write
+
+
+def test_atomic_write_replaces_the_target_and_removes_its_tempfile(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    target.write_bytes(b"old")
+
+    atomic_write(target, b"new")
+
+    assert target.read_bytes() == b"new"
+    assert list(tmp_path.glob(".state.json.*.tmp")) == []
+
+
+def test_atomic_write_preserves_the_old_value_when_replace_fails(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    target.write_bytes(b"old")
+
+    with patch("sovereign_agent.files.os.replace", side_effect=OSError("injected failure")):
+        with pytest.raises(OSError, match="injected failure"):
+            atomic_write(target, b"new")
+
+    assert target.read_bytes() == b"old"
+    assert list(tmp_path.glob(".state.json.*.tmp")) == []
+
+
+def test_concurrent_atomic_writers_never_share_a_tempfile_or_tear_bytes(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "state.json"
+    payloads = (b"A" * 100_000, b"B" * 100_000)
+    barrier = threading.Barrier(2)
+    sources: list[Path] = []
+    sources_lock = threading.Lock()
+    real_replace = os.replace
+
+    def synchronized_replace(source: Path, destination: Path) -> None:
+        with sources_lock:
+            sources.append(Path(source))
+        barrier.wait()
+        real_replace(source, destination)
+
+    with patch("sovereign_agent.files.os.replace", side_effect=synchronized_replace):
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            list(pool.map(lambda payload: atomic_write(target, payload), payloads))
+
+    assert len(set(sources)) == 2
+    assert target.read_bytes() in payloads
+    assert list(tmp_path.glob(".state.json.*.tmp")) == []

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -79,6 +79,62 @@ def test_inventory_never_goes_negative(tmp_path: Path) -> None:
         record_sale(org.db, "SKU-TEA", 99, 400)
 
 
+def test_sale_refuses_reserved_stock_without_partial_writes(tmp_path: Path) -> None:
+    from sovereign_agent.errors import Refusal
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    org.db.connection.execute(
+        "UPDATE inventory SET on_hand = 6, reserved = 5 WHERE sku = 'SKU-TEA'"
+    )
+    org.db.connection.commit()
+    before = {
+        table: int(org.db.connection.execute(f"SELECT COUNT(*) AS c FROM {table}").fetchone()["c"])
+        for table in ("cash_entries", "signals", "events")
+    }
+
+    with pytest.raises(Refusal, match="reserved stock"):
+        record_sale(org.db, "SKU-TEA", 2, 400)
+
+    row = org.db.connection.execute(
+        "SELECT on_hand, reserved FROM inventory WHERE sku = 'SKU-TEA'"
+    ).fetchone()
+    assert (row["on_hand"], row["reserved"]) == (6, 5)
+    assert {
+        table: int(org.db.connection.execute(f"SELECT COUNT(*) AS c FROM {table}").fetchone()["c"])
+        for table in ("cash_entries", "signals", "events")
+    } == before
+
+
+@pytest.mark.parametrize("quantity", [0, -1])
+def test_sale_quantity_must_be_positive(tmp_path: Path, quantity: int) -> None:
+    from sovereign_agent.errors import Refusal
+
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    with pytest.raises(Refusal, match="positive"):
+        record_sale(org.db, "SKU-TEA", quantity, 400)
+
+
+def test_sale_severity_uses_available_stock_after_reservations(tmp_path: Path) -> None:
+    org = Organization.init(tmp_path)
+    seed(org.db)
+    org.db.connection.execute(
+        "UPDATE inventory SET on_hand = 6, reserved = 2, reorder_point = 3 WHERE sku = 'SKU-TEA'"
+    )
+    org.db.connection.commit()
+
+    signal = record_sale(org.db, "SKU-TEA", 1, 400)
+
+    assert signal.severity == "warning"
+    event = org.db.connection.execute(
+        "SELECT payload FROM events WHERE kind = 'sale.committed' ORDER BY rowid DESC LIMIT 1"
+    ).fetchone()
+    payload = json.loads(event["payload"])
+    assert payload["available_after"] == 3
+    assert payload["reserved"] == 2
+
+
 def test_events_reject_update_and_delete(tmp_path: Path) -> None:
     org = Organization.init(tmp_path)
     seed(org.db)


### PR DESCRIPTION
## Outcome

Closes the manuscript's final two recorded implementation gaps and corrects the affected teaching text against the new hard bytes.

## What changed

- makes `atomic_write` use a unique same-directory temporary file, fsync its bytes, atomically replace the target, and clean up after refusal;
- proves success, injected replacement failure, and simultaneous writers behaviorally;
- makes `record_sale` refuse non-positive quantities and stock already promised through `reserved`;
- computes warning severity from `available_after`, and records reservation arithmetic in the sale event;
- proves refusal has no partial ledger effects and that concurrent buyers cannot consume reserved stock;
- removes both `known_gap` entries from the book coverage manifest;
- updates Chapters 1 and 9, including the formula and diagram, to match production exactly while retaining the honest parent-directory-fsync and reservation-lifecycle limits;
- adds an implementation-grounded digest TOCTOU sequence to Chapter 2, corrects stale stock language in Chapter 10, and tightens its oversized summary;
- records the runtime and manuscript changes under `Unreleased` in the changelog.

## Verification

- `make verify`
  - 476 passed, 10 deselected
  - 463 passed, 5 skipped, 10 deselected in the clean onboarding clone
  - 13/13 curriculum exercises
  - 102 executable chapter snippets and 92 byte-matched outputs
  - 13/13 deterministic companion labs
- source budget: 35/40 modules, 7207/7250 nonblank lines, 7/30 root exports
- runtime dependency set remains exactly `pydantic`

## Scope boundary

This does not implement a reservation lifecycle (creation, expiry, allocation, or fulfillment), catalog-authoritative sale pricing, or parent-directory fsync. The book names those boundaries explicitly.

The derived site treatment is proposed separately in `rodriveracom/profrod-site` PR #48, pinned to this exact 40-character head. That PR should not merge before this one is accepted at the same head.
