### PR TITLE
Prepare sovereign agent 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Repository: [`profrodai/sovereign-agent`](https://github.com/profrodai/sovereign
 
 ## Unreleased
 
+## [1.4.0] — 2026-09-05
+
+Sovereign Agent 1.4.0 is a correctness release for two boundaries the
+executable book teaches learners to distrust: replacing durable files and
+selling inventory already promised elsewhere. It turns both claims into
+behavioral guarantees without adding a runtime dependency.
+
 - Make `atomic_write` safe under concurrent writers by using a unique
   same-directory temporary file, syncing its contents before replacement, and
   cleaning it on both success and failure. Parent-directory durability remains

--- a/docs/release-notes/1.4.0.md
+++ b/docs/release-notes/1.4.0.md
@@ -1,0 +1,78 @@
+# v1.4.0 release notes
+
+Sovereign Agent 1.4.0 closes the last two implementation gaps declared by the
+executable book. The release makes file replacement safe under simultaneous
+writers and makes sales respect inventory already reserved for someone else.
+
+Both changes preserve the project's teaching constraints: the implementation
+is small, offline, inspectable Python; SQLite remains the durable ledger; and
+the only runtime dependency is Pydantic.
+
+## Concurrent file replacement has a behavioral contract
+
+`sovereign_agent.files.atomic_write` now allocates a unique temporary file in
+the target directory, writes and fsyncs its bytes, and atomically replaces the
+destination with `os.replace`. Cleanup runs after both success and failure.
+
+The regression suite synchronizes two real writers at the replace boundary and
+proves they never share a temporary path. The destination ends as one complete
+payload rather than a torn mixture. A separately injected `os.replace` failure
+proves the old destination survives and the abandoned temporary file is
+removed.
+
+Read this guarantee narrowly: the file contents are synced before replacement,
+but the parent directory is not fsynced. The implementation does not claim to
+survive every filesystem or power-loss model.
+
+## Sales cannot consume promised stock
+
+The reference store's `record_sale` now makes its decision from:
+
+```text
+available = on_hand - reserved
+available_after = available - quantity
+```
+
+A sale is refused before any write when its quantity is zero, negative, or
+greater than available inventory. Signal severity is based on
+`available_after`, not raw on-hand stock, and the committed event records the
+reservation arithmetic for inspection.
+
+The stock read, refusal, inventory update, cash entry, signal, and event remain
+inside one SQLite immediate transaction. A two-connection concurrency test
+proves exactly one buyer can consume the only unreserved unit; the loser leaves
+no partial cash, signal, or event rows.
+
+This is sale-time enforcement, not a full reservation system. Sovereign Agent
+still does not create, expire, allocate, release, or fulfill reservations, and
+`unit_price_cents` remains caller supplied rather than catalog authoritative.
+
+## The book follows the hard bytes
+
+Chapters 1, 2, 9, and 10 now teach the exact corrected contracts:
+
+- unique sibling temporary files and the parent-directory durability boundary;
+- a digest time-of-check/time-of-use sequence;
+- reservation-aware stock and severity equations; and
+- consistent available-inventory language across signal and Pulse chapters.
+
+The coverage manifest now reports zero known implementation gaps. The
+repository gate continues to execute 102 Python snippets, byte-match 92 outputs,
+and run all 13 companion labs twice from fresh roots.
+
+The derived publication at <https://profrod.ai/book> independently parses and
+captions 39 implementation-grounded diagrams. Its deterministic editorial
+instrument scores all 13 chapters above 90, averaging 96. That score guides
+revision; it is not a publisher endorsement or a substitute for human editing.
+
+## Compatibility
+
+- Requires Python 3.14 or newer.
+- Runtime dependencies remain `pydantic>=2,<3` only.
+- Existing positive, unreserved sales retain their behavior.
+- Callers that used zero or negative quantities, or sold into reserved stock,
+  now receive the intended fail-closed `Refusal` instead of a ledger mutation.
+- No public name was removed or renamed.
+
+A git tag is not a public release until the built wheel and source distribution
+are installed from PyPI and verified outside the source tree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sovereign-agent"
-version = "1.3.0"
+version = "1.4.0"
 description = "An executable textbook for learning Zero-Employee Organizations"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/sovereign_agent/__init__.py
+++ b/src/sovereign_agent/__init__.py
@@ -10,7 +10,7 @@ from sovereign_agent.ids import new_id
 from sovereign_agent.models import Actor, Outcome, StatementOfWork
 from sovereign_agent.organization import Organization
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 __all__ = [
     "Actor",

--- a/tests/test_clean_import.py
+++ b/tests/test_clean_import.py
@@ -23,4 +23,4 @@ print(json.dumps({'before': before, 'after': after, 'version': sovereign_agent._
         text=True,
     )
     observed = json.loads(result.stdout)
-    assert observed == {"before": [], "after": [], "version": "1.3.0"}
+    assert observed == {"before": [], "after": [], "version": "1.4.0"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,4 +33,4 @@ def test_module_entry_point_reports_version() -> None:
         capture_output=True,
         text=True,
     )
-    assert result.stdout.strip() == "sovereign-agent 1.3.0"
+    assert result.stdout.strip() == "sovereign-agent 1.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "sovereign-agent"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Outcome

Prepares Sovereign Agent 1.4.0 as a backward-compatible correctness release for the file-replacement and reservation-aware sale guarantees merged in PR #84.

## Release surfaces

- version `1.4.0` in `pyproject.toml`, package `__version__`, `uv.lock`, and version assertions;
- dated 1.4.0 changelog section, leaving `Unreleased` empty for the next change;
- standalone `docs/release-notes/1.4.0.md` with behavior, compatibility, migration impact, and explicit non-claims.

## Compatibility

- Python remains 3.14+.
- Runtime dependencies remain exactly `pydantic>=2,<3`.
- No public name is removed or renamed.
- Positive unreserved sales retain their contract.
- Zero/negative sales and attempts to consume reserved stock now fail closed with `Refusal`; this is the intentional observable tightening.
- Parent-directory fsync, a reservation lifecycle, and catalog-authoritative sale pricing remain explicitly outside the claim.

## Exact-head verification

- `make verify` — passed at committed head:
  - 476 passed, 10 deselected;
  - clean hostile-PATH archive installed `sovereign-agent==1.4.0`, then 471 passed, 5 Git-only skipped, 10 deselected;
  - 35/40 modules, 7207/7250 nonblank lines, 7/30 root exports;
  - 13/13 curriculum exercises;
  - 102 executable Python blocks and 92 byte-matched outputs;
  - 13/13 companion labs deterministic twice.
- `scripts/verify_release_candidate.py` — all six stages passed, including installed-wheel isolation, Andrea machine-checkable rubric, proof-pack verification, and non-claim checks.
- separately built wheel installed into a fresh Python 3.14 venv outside the source tree:
  - CLI version: `sovereign-agent 1.4.0`;
  - import version and distribution metadata: `1.4.0`;
  - module resolved from the fresh venv's `site-packages`;
  - `sovereign-agent doctor` passed.

Local candidate artifact digests, recorded as reproducibility evidence rather than future PyPI claims:

- wheel: `570fbca90710341b25ebb8f806acf0e9ca79dfef141d0e2004c00e80cec59e25`
- sdist: `352877ad962c8a01100effbd805c4320919dbdf7f248185559fa6a6dd5c88f61`

The hosted tag workflow will build its own immutable artifacts; their PyPI hashes must be read back after publication and must not be inferred from these local candidates.

## Post-merge sequence

1. Verify the reviewed PR head is an ancestor of the merge commit and rerun the release gate if the head changes.
2. Create annotated tag `v1.4.0` on the exact accepted merge commit.
3. Publish the GitHub release using `docs/release-notes/1.4.0.md`.
4. Observe the tag-triggered `publish` workflow; approve the `pypi` environment gate when requested.
5. Verify PyPI JSON, hashes, and a fresh real `pip`/`uv` install before calling the release complete.
6. Only then update `sovereign-agent-resources` to immutable 1.4.0 artifacts.

This PR does not itself create a tag, GitHub release, or PyPI publication.
