### PR TITLE
Add publisher grade book structure and editorial furniture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ verify: lint test
 	$(UV) run --python 3.14 python scripts/verify_curriculum.py
 	$(UV) run --python 3.14 python scripts/verify_book_snippets.py
 	$(UV) run --python 3.14 python scripts/verify_book_depth.py
+	$(UV) run --python 3.14 python scripts/verify_book_structure_v1.py
 	$(UV) run --python 3.14 python scripts/verify_book_labs.py
 	$(UV) run --python 3.14 sovereign-agent --help >/dev/null
 	$(UV) run --python 3.14 sovereign-agent doctor

--- a/book/AGENT_ECOSYSTEM_MAP.md
+++ b/book/AGENT_ECOSYSTEM_MAP.md
@@ -1,0 +1,123 @@
+# Field guide to the agent ecosystem
+
+This book is deliberately framework-independent. Its mechanisms remain necessary whether
+the provider is a script, a hosted model, a local model, or a networked agent. Current
+protocols give those mechanisms recognizable interfaces, but they do not replace them.
+
+This guide maps the book's vocabulary to the wider agent ecosystem. It is a translation
+layer, not a claim that two concepts are identical.
+
+## MCP connects models to capabilities
+
+The [Model Context Protocol specification](https://modelcontextprotocol.io/specification/2025-06-18/index)
+defines a client-server protocol for exposing prompts, resources, and tools. Its control
+model is especially useful alongside Chapters 3 and 4: prompts are user-controlled,
+resources are application-controlled, and tools are model-controlled requests whose
+effects remain the host application's responsibility.
+
+In this book's terms, MCP can describe and transport a capability. It does not decide that
+a particular actor is authorized to use that capability for a particular statement of
+work. Tool discovery still is not tool authority. A host still needs deny-first policy,
+workspace and subject checks, explicit consent where required, and a durable receipt for
+the action it actually committed.
+
+MCP also makes the untrusted-data boundary concrete. Resources, tool results, and elicited
+input may all contain text that looks like instruction. Chapter 3's rule still applies:
+provider and external output enters as data, then schema and policy decide what the host
+may do with it.
+
+## A2A connects independent agents
+
+The [Agent2Agent protocol specification](https://a2a-protocol.org/latest/specification/)
+defines discovery through Agent Cards and a lifecycle built from messages, tasks, status,
+and artifacts. It supports synchronous, streaming, and long-running asynchronous work
+across agents that do not expose their internal memory or tools.
+
+That makes A2A a natural transport for the delegation boundary built in Chapters 2, 5,
+and 7. An A2A task can carry or refer to governed work; an artifact can carry a proposed
+result; task status can report protocol progress. None of those facts alone proves this
+book's `ACCEPTED` claim. The receiving organization still has to bind the remote actor to
+current authority, validate the artifact, rerun outcome checks against the current world,
+and preserve independent review.
+
+The distinction is useful in both directions. This book does not need to invent a wire
+protocol for agent interoperability, and an A2A implementation does not need to pretend
+transport-level task completion is causal proof.
+
+## OpenTelemetry records execution signals
+
+The [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/)
+provide common names for traces, metrics, events, resources, and attributes. The GenAI
+conventions include agent, conversation, tool, retrieval, usage, and evaluation concepts.
+Those conventions make operations from different libraries and providers easier to
+correlate.
+
+Chapters 1, 2, and 12 ask a narrower question: which observations are sufficient for the
+claim being made? A span can show that a tool call occurred. It does not, by its presence,
+prove that the correct subject changed, that the change came from this execution, or that
+the world did not move afterward. Telemetry becomes evidence only when its identity,
+inputs, timing, and relationship to the outcome satisfy the proof contract.
+
+Use standard telemetry where it fits. Keep the evidence ledger's stronger causal and
+retention requirements explicit rather than assuming a trace backend supplies them.
+
+## OWASP names the adversary
+
+The [OWASP Agentic AI threats and mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
+organizes risks created when generative models gain memory, tools, goals, and autonomy.
+Prompt injection, tool misuse, privilege abuse, memory poisoning, and cascading agent
+failures are contemporary names for boundaries this book tests mechanically.
+
+The mapping is direct but not complete:
+
+- Chapter 1's canonical-versus-derived distinction limits memory poisoning and makes
+  projection tampering detectable.
+- Chapter 3 parses provider output and separates discovery from authorization.
+- Chapter 4 checks path, network, credential, tool, and process isolation independently.
+- Chapter 5 expires authority with leases, fencing tokens, and session incarnations.
+- Chapters 6 and 7 preserve evidence across crashes and unattended execution.
+
+A threat list helps a team ask what could go wrong. It does not demonstrate that a
+specific control refuses the attack. The exercises in these chapters supply that second
+step by making the learner run the adversarial path and inspect the resulting state.
+
+## NIST frames residual risk and deployment evidence
+
+The [NIST AI Risk Management Framework Generative AI Profile](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf)
+is a cross-sector companion to the AI RMF. It organizes generative-AI risk work around
+governance, mapping, measurement, and management rather than prescribing one agent
+architecture.
+
+Chapter 12's release ladder fits inside that larger risk process. Deterministic tests,
+installed-artifact checks, credentialed provider evaluation, human-reviewed pilots,
+canaries, and wider release are different evidence environments. A team can use the NIST
+profile to identify affected people, harms, controls, and residual risks while using this
+book's receipts and proof packs to make individual operational claims inspectable.
+
+Neither system certifies the other. A complete proof pack may still encode an inadequate
+acceptance rule. A completed risk worksheet may still describe a control that was never
+exercised. Governance documents and executable evidence have to meet at the same exact
+release candidate.
+
+## What changes when these protocols are present
+
+The practical architecture has three layers:
+
+1. **Interoperability:** MCP exposes tools and context; A2A exchanges tasks, messages, and
+   artifacts.
+2. **Observability:** OpenTelemetry records operations and correlations in a shared
+   vocabulary.
+3. **Governance and proof:** the host binds authority, state, effects, verification, and
+   acceptance under the invariants built in this book.
+
+The layers reinforce one another, but no layer may silently inherit another's guarantee.
+An advertised tool is not authorized work. A completed remote task is not an accepted
+outcome. A trace is not a causal proof. A policy document is not an exercised refusal.
+
+That separation is why the book's mechanisms remain relevant as protocols and providers
+change. The interfaces can evolve. The questions stay stable: who was allowed to act,
+inside which boundary, on which subject, against which current state, with what surviving
+evidence, and who checked the result?
+
+Return to the [book contents](README.md) or continue with
+[Advanced mechanisms](ADVANCED_MECHANISMS.md).

--- a/book/BOOK.json
+++ b/book/BOOK.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "title": "Building Zero Employee Organizations",
+  "subtitle": "Durable authority, recovery, and proof for AI agent systems",
+  "author": {
+    "name": "Rod Rivera",
+    "url": "https://www.profrod.ai/about"
+  },
+  "language": "en",
+  "frontMatter": [
+    {
+      "slug": "preface",
+      "title": "Preface",
+      "path": "PREFACE.md"
+    },
+    {
+      "slug": "conventions",
+      "title": "How to use this book",
+      "path": "CONVENTIONS.md"
+    }
+  ],
+  "parts": [
+    {
+      "number": 1,
+      "slug": "durable-foundations",
+      "title": "Durable foundations",
+      "path": "parts/part-1-durable-foundations.md",
+      "chapters": [0, 1, 2, 3]
+    },
+    {
+      "number": 2,
+      "slug": "bounded-autonomy",
+      "title": "Bounded autonomy",
+      "path": "parts/part-2-bounded-autonomy.md",
+      "chapters": [4, 5, 6, 7]
+    },
+    {
+      "number": 3,
+      "slug": "proof-at-scale",
+      "title": "Proof at scale",
+      "path": "parts/part-3-proof-at-scale.md",
+      "chapters": [8, 9, 10, 11, 12]
+    }
+  ],
+  "appendices": [
+    {
+      "slug": "advanced-mechanisms",
+      "title": "Advanced mechanisms",
+      "path": "ADVANCED_MECHANISMS.md"
+    },
+    {
+      "slug": "agent-ecosystem-map",
+      "title": "Field guide to the agent ecosystem",
+      "path": "AGENT_ECOSYSTEM_MAP.md"
+    }
+  ],
+  "resources": [
+    {
+      "slug": "labs",
+      "title": "Companion labs",
+      "path": "labs/README.md"
+    }
+  ]
+}

--- a/book/CONVENTIONS.md
+++ b/book/CONVENTIONS.md
@@ -1,8 +1,7 @@
 # Notation, conventions, and the chapter-to-lab map
 
-Plain Markdown, no site frontmatter, same as every other file in `book/` —
-see [`CONTENT-SOURCE.md`](CONTENT-SOURCE.md). This file is the second half
-of the book's front matter, alongside [`PREFACE.md`](PREFACE.md).
+This is the second half of the book's front matter, alongside
+[`PREFACE.md`](PREFACE.md).
 
 ## Recurring terms
 
@@ -20,14 +19,7 @@ own recurring narrative and mechanism vocabulary.
   starts here instead of at Chapter 2.
 - **Lucy.** The book's fictional running example: the owner of an ice cream
   shop who hands progressively more governed work to the organization you
-  build. Every chapter's closing narrative returns to her shop. She is not
-  Andrea (below) — see [`PREFACE.md`](PREFACE.md#who-should-read-this-book)
-  for why the book keeps the two separate on purpose.
-- **Andrea.** The real evaluation participant this book calibrates itself
-  against (`docs/andrea-alpha-evaluation.md`). Mentioned here only so a
-  reader who encounters her name in an evaluation document does not mistake
-  her for a second name for Lucy — they measure different things: Lucy is
-  the teaching fiction, Andrea is the human comprehension check.
+  build. Every chapter returns to the operational consequence at her shop.
 - **Compare-and-set (CAS).** A single atomic database statement whose
   `WHERE` clause both decides *and* performs a write in one step, so that no
   window exists between "read the current state" and "act on it" for a

--- a/book/PREFACE.md
+++ b/book/PREFACE.md
@@ -1,9 +1,5 @@
 # Preface
 
-This is a source Markdown file with no site frontmatter, matching every other
-file in `book/` — see `book/CONTENT-SOURCE.md` for why a leading `---` block
-does not belong here.
-
 ## Why this book exists
 
 Most material about AI agents teaches you to write a prompt and trust the
@@ -28,23 +24,15 @@ Chapter 0.
 
 ## Who should read this book
 
-The book is calibrated to one specific reader, not an abstract "beginner."
-`book/INSTRUCTOR.md` names her directly: a master's student who knows some
-Python, has written scripts and notebooks, but has not run a service,
-debugged a transaction, or argued about governance. `docs/andrea-alpha-evaluation.md`
-records her name, Andrea, because she is a specific real evaluation
-participant this project measured itself against across several rounds
-(`docs/andrea-chapters-0-7-evaluation.md`, `docs/andrea-chapters-0-12-evaluation.md`)
-— not a fictional character and not the book's own narrative protagonist.
+The book is calibrated to a specific reader rather than an abstract
+"beginner": a master's student or working developer who knows some Python,
+has written scripts and notebooks, but has not yet operated a service,
+debugged a transaction, or designed authority boundaries. Independent learner
+sessions shaped which explanations stayed and which were rewritten.
 
-That second point is worth being precise about, because the book also has a
-fictional protagonist, and the two are not the same person. **Lucy**, who
-runs the ice cream shop every chapter returns to, is fiction: the running
-example the book uses to make each mechanism concrete. **Andrea** is real:
-the calibration target whose actual sessions shaped which explanations
-stayed and which were rewritten. If you are reading this book, you are
-reading it as Andrea's stand-in — not as Lucy, who owns no laptop and runs no
-`pytest`.
+Lucy, who runs the ice cream shop every chapter returns to, is fictional. She
+is the running case that makes each mechanism concrete. You are the engineer
+building the organization on her behalf.
 
 If you are comfortable with Python classes, can read a `pydantic` model, and
 have never had to explain why a status field can lie: this book is written
@@ -131,12 +119,10 @@ of failure.
 
 ## What this book is not
 
-It is not a claim of Manning acceptance, a stated page count, a certified
-learning outcome, or a claim of finished visual publication quality. It
-establishes manuscript structure and pedagogy for a real, executable
-thirteen-chapter curriculum; `book/CONTENT-SOURCE.md` states exactly what is
-mechanically guaranteed by `scripts/verify_curriculum.py`, and — just as
-importantly — what is deliberately not.
+It is not a catalogue of prompt patterns or a wrapper around one model vendor.
+It does not claim that a green test suite proves a deployment safe. It teaches
+how to state a narrower claim, preserve the evidence for it, and refuse to
+promote that claim when the evidence or authority is insufficient.
 
 Continue to [Chapter 0 — Lucy's first shift](ch00_first_shift/README.md), or
 read [`CONVENTIONS.md`](CONVENTIONS.md) first for the notation and the

--- a/book/README.md
+++ b/book/README.md
@@ -22,6 +22,12 @@ six compact, production-shaped lessons in isolation, unattended schedules,
 context compaction, session incarnations, progressive tool discovery, and
 hybrid memory retrieval.
 
+The chapters are organized into three parts:
+
+- [Part 1: Durable foundations](parts/part-1-durable-foundations.md), Chapters 0–3
+- [Part 2: Bounded autonomy](parts/part-2-bounded-autonomy.md), Chapters 4–7
+- [Part 3: Proof at scale](parts/part-3-proof-at-scale.md), Chapters 8–12
+
 - [Chapter 0: Lucy's first shift](ch00_first_shift/README.md) — run one
   complete piece of work and learn that `ACCEPTED` is a proved claim
 - [Chapter 1: The organization remembers](ch01_organization_remembers/README.md) —
@@ -56,35 +62,20 @@ hybrid memory retrieval.
   the pilot-start mechanism, exercised against a disposable identity, and
   what "started" does and does not mean
 
-## What is not here yet
+## Where the book goes
 
-Pulse — the organization waking itself up — was Unit 9's own future territory
-when Chapters 0-3 were written. Nothing in Chapters 0-3 simulates a Pulse
-event, and their store demo is explicitly manually dispatched. A chapter that
-promised proactive behaviour before the code could do it would be the same
-kind of lie this book spends Chapter 2 teaching you to catch. That claim is
-still true of Chapters 0-3 today, and is mechanically enforced: this
-project's own curriculum checker refuses any of them from claiming Pulse
-fired.
+Chapters 0–3 are manually dispatched because durable memory and governed work
+must exist before proactive execution can be honest. Chapters 4–6 add
+containment, fencing, and recovery. Chapter 7 is the first chapter in which a
+durable signal creates governed work without a human prompt. Chapters 8–12
+then add the second product, retries, causal attribution, and a pilot-start
+receipt that states exactly what has and has not been proven.
 
-**Added, Unit 9:** Pulse became real production code (`sovereign-agent pulse
---once`; see `docs/v1-unit9-pulse-proactive-work.md`).
-
-**Added, Unit 10:** Chapter 7 is where this book exercises it — the first and
-only chapter allowed to claim the organization wakes itself, and only because
-its own exercise genuinely invokes the mechanism and leaves durable,
-structured evidence behind, mechanically checked, not merely asserted in
-prose. Chapters 0-3 remain exactly as they were: manually dispatched, and
-truthful about it. Chapters 4-6 (workspace lifecycle, fencing, recovery)
-teach real, ACCEPTED Units 7 and 8 behavior that was already true before Unit
-10; they were simply not yet chapters.
-
-**Added, Unit 11:** Chapters 8 through 12 land alongside the Store's own
-expansion into a genuine multi-SKU catalog and the pilot-start mechanism.
-Chapter 12's own exercise runs against a disposable, exercise-scoped pilot
-identity — the real 30-day Store pilot has not started; that is a separate,
-later, separately-authorized act outside this book's own scope. See
-`docs/v1-unit11-store-expansion-pilot-start.md` for the full contract.
+After the main sequence, use the
+[field guide to the agent ecosystem](AGENT_ECOSYSTEM_MAP.md) to map the book's
+mechanisms to MCP, A2A, OpenTelemetry, OWASP agentic threats, and NIST AI risk
+practice. The map translates interfaces; it does not treat protocol support as
+proof of authority or outcome.
 
 ## Every chapter contains
 

--- a/book/ch00_first_shift/README.md
+++ b/book/ch00_first_shift/README.md
@@ -46,6 +46,8 @@ flowchart LR
     A -. refuses if false .-> P
 ```
 
+**Figure:** A governed shift begins with a world fact and may reach acceptance only after host validation, durable evidence, independent review, and a fresh check.
+
 Read the arrow labels as changes of epistemic status—changes in what the
 organization is entitled to claim. A signal says *something happened*. A SOW
 says *someone has specified work*. A receipt says *an execution ended*. Evidence
@@ -98,6 +100,8 @@ flowchart LR
     C -->|false or stale| R[Repair or new governed work]
     C -->|true| A[Acceptance may be recorded]
 ```
+
+**Figure:** The provider proposes an action; the host alone admits and executes it, and a later verifier may still send the work back for repair.
 
 This diagram also tells you where to debug. If the provider proposes the wrong
 action, inspect the assignment and model boundary. If the proposal is right but
@@ -169,6 +173,8 @@ A `replenishment.committed` event sits between `assignment.finished` and
 
 Here is the exercise that earns this chapter its place. One command checks that
 the accepted outcome is *actually true*:
+
+**Listing:** Verify the store outcome against current state
 
 ```bash
 uv run python scripts/verify_store_outcome.py /tmp/first-shift
@@ -253,22 +259,22 @@ re-run the demo into a fresh `--root` to get a clean `0` again.)
 
 ## Summary
 
-This chapter built nothing yet — it ran the finished mechanism once, end to
+This first shift builds nothing yet. It runs the finished mechanism once, end to
 end, so every later chapter has a shape to recognize pieces of. The
 mechanism you watched was one sale traveling through five distinct proof
 roles (signal, SOW, receipt, evidence, acceptance) rather than collapsing
 into a single `status="done"` field.
 
-The invariant it establishes is that `ACCEPTED` is checked against the
+The governing rule is that `ACCEPTED` is checked against the
 world at the moment you ask, not trusted from history: `verify_store_outcome.py`
 re-reads the database rather than the status string.
 
-The failure it prevents is the ordinary one — paperwork that says done while
+The failure made visible here is ordinary: paperwork says done while
 the shelf is empty — and you produced that exact failure by hand, by
 editing `on_hand` directly under an already-`ACCEPTED` outcome, and watched
 the checker refuse it with the precise row that no longer holds.
 
-Back at Lucy's shop: if a supplier's invoice says delivered and the freezer
+For Lucy, if a supplier's invoice says delivered and the freezer
 is still empty, the invoice is not evidence, and neither is this book's
 `ACCEPTED` unless something re-checked the freezer after the invoice was
 filed.

--- a/book/ch01_organization_remembers/README.md
+++ b/book/ch01_organization_remembers/README.md
@@ -45,6 +45,8 @@ flowchart TB
     Q -->|mismatch means stale or edited| C
 ```
 
+**Figure:** Canonical rows, append-only history, and human-readable projections serve different guarantees; only the canonical database may feed a regenerated projection.
+
 | Memory | Question it answers | Principal guarantee | Deliberate limit |
 | --- | --- | --- | --- |
 | Canonical rows | What is true now? | Related writes commit or roll back together. | Most operational rows are mutable. |
@@ -78,6 +80,8 @@ sequenceDiagram
     end
 ```
 
+**Figure:** Inventory, cash, and event history become one fact only when the transaction commits all three statements or rolls all three back.
+
 Durability is a separate axis: after SQLite acknowledges the commit, its journal
 mode and filesystem decide what survives a crash. Atomicity answers "all or
 none"; durability answers "does the chosen one survive?" Keeping those words
@@ -98,6 +102,8 @@ flowchart LR
     H -. compare, never import .-> V[Projection verifier]
     V --> C
 ```
+
+**Figure:** Human-readable memory is a deterministic view of canonical rows and events, and verification compares that view with a fresh render rather than importing it.
 
 This is the same principle that makes filesystem handoffs safe only when their
 authority is explicit. A file can be an excellent transport and a terrible
@@ -186,6 +192,8 @@ A restock has to change three things together: inventory goes up, cash goes down
 and an event records it. If only some of those land, the organization is lying to
 itself — a full shelf with no money spent, or money spent with no stock. The tool
 that makes "all or nothing" real is a transaction.
+
+**Listing:** Commit inventory, cash, and event history as one transaction
 
 ```python
 def restock(db, sku, units, unit_cost):
@@ -739,6 +747,8 @@ flowchart LR
     M --> H[Hits with score provenance]
 ```
 
+**Figure:** Retrieval first enforces SQL visibility, then combines lexical, semantic, recency, and importance scores before a diversity pass returns traceable hits.
+
 The first arrow is the important one. Suppose Bob's private supplier note is a
 perfect semantic match for Alice's query. If code ranks every row and removes
 Bob's note only before display, its content has already influenced selection,
@@ -1013,7 +1023,7 @@ its history.
 
 ## Summary
 
-This chapter built the three-part memory split — canonical SQLite rows,
+Memory now has three distinct forms: canonical SQLite rows,
 append-only events enforced by database triggers, and regenerable Markdown
 projections — plus a migration runner that keeps the schema change and its
 version stamp inside one explicit transaction.
@@ -1022,18 +1032,18 @@ It also built a transparent retrieval policy over durable memory: SQL removes
 rows the actor may not see before lexical, optional semantic, recency, and
 importance signals are combined, then MMR avoids spending context on duplicates.
 
-The invariant it establishes is that only one thing is ever the authority
+One authority rule governs them: only one thing is ever the authority
 for a given fact, and every other representation is either derived from it
 or provably stale against it: a projection that disagrees with the ledger is
 wrong by definition, never the other way around.
 
-The failure it prevents is silent, permanent data loss disguised as a
+The chapter catches silent, permanent data loss disguised as a
 successful upgrade — the migration that half-applies outside its
 transaction and poisons the database forever, and the "helpful" verifier
 that overwrites tampered evidence instead of reporting it. Both are built
 and caught in this chapter, not merely described.
 
-Back at Lucy's shop: this is the difference between "we ordered the cones"
+For Lucy, this is the difference between "we ordered the cones"
 and a signed invoice you can still produce six months later. A memory that
 can half-happen is not a memory Lucy's business can be held to.
 

--- a/book/ch02_work_needs_governance/README.md
+++ b/book/ch02_work_needs_governance/README.md
@@ -62,6 +62,8 @@ flowchart LR
     S --> A
 ```
 
+**Figure:** Acceptance is the terminal claim of a connected proof graph: outcome, scope, assignment, receipt, evidence, fresh verification, and independent review must agree.
+
 Acceptance is permitted only when the necessary paths converge at `A`. A receipt
 without evidence proves an execution ended, not that it worked. Evidence without
 an execution binding may have been borrowed from another run. A review by the
@@ -98,6 +100,8 @@ flowchart LR
     O -->|"cut here: stale check"| A
     S --> A
 ```
+
+**Figure:** Cutting any proof edge admits a distinct lie, from paperwork-only completion and borrowed evidence to self-review and a stale world check.
 
 **What this figure shows:** each labeled edge is the exact relation a weaker
 `accept()` forgot to check, taken from the table above — this is the same ten
@@ -570,9 +574,13 @@ sequenceDiagram
     end
 ```
 
+**Figure:** Acceptance re-reads the world and compares its current digest with recorded evidence, refusing when the verified state has changed.
+
 The check can still return `PASS` in both worlds. The digest rejects the
 stronger lie: that today's passing state is the same state an independent
 reviewer actually examined.
+
+**Listing:** Recheck evidence against the current world before acceptance
 
 ```python
 def accept_v7(db, outcome_id, accepter):
@@ -665,6 +673,8 @@ flowchart TB
     V7 -. refuses back to .-> VERIFYING
     VERIFYING -->|"Exercise 7: repair, new assignment, new batch"| V2
 ```
+
+**Figure:** Seven successive implementations close seven different false-acceptance paths; every refusal returns to new governed work rather than forcing the old evidence through.
 
 **What this figure shows:** each rung's refusal edge names a specific lie a
 weaker `accept` would let through, and the dashed edges share one thing —
@@ -1029,25 +1039,25 @@ have actually caused the effect it claims.
 
 ## Summary
 
-This chapter built `accept()` as seven composed layers, each one closing a
+Acceptance now consists of seven composed layers, each one closing a
 specific lie the layer before it still let through: re-reading the world,
 recording evidence, binding that evidence to the right outcome and
 execution, requiring a distinct reviewer, requiring the credited execution
 to have actually produced the required effect, and refusing evidence whose
 observed world has since moved.
 
-The invariant it establishes is that `ACCEPTED` is a proof graph that must
+The governing rule is that `ACCEPTED` is a proof graph that must
 fully converge, not a workflow status: an outcome, its SOW (a **statement of
 work**, this book's own term for the deliverable and its acceptance checks),
 its evidence, and its review all have to point at each other correctly, or
 acceptance refuses.
 
-The failure it prevents is not one bug but a family: paperwork-only
+The refused cases form a family: paperwork-only
 acceptance, stale evidence, borrowed evidence, self-review, and crediting an
 execution for a condition that became true for unrelated reasons — five
 distinct attacks, five distinct refusals, each with its own failing test.
 
-Back at Lucy's shop: this is why a restock actually has to happen before the
+For Lucy, this is why a restock actually has to happen before the
 freezer counts as "handled" — and why the person who did the restock is
 never the same person who signs off that it was done correctly.
 

--- a/book/ch03_actor_is_not_a_model/README.md
+++ b/book/ch03_actor_is_not_a_model/README.md
@@ -67,6 +67,8 @@ sequenceDiagram
     end
 ```
 
+**Figure:** Role policy and host validation surround the provider call, so a model response remains a proposal until authorized host code commits it.
+
 This is a capability-security idea expressed with ordinary Python. The provider
 does not receive "authority" as prose in a prompt; it receives inputs and can
 return data. The host looks up `ROLE_AUTHORITY`, validates the report schema, and
@@ -88,6 +90,8 @@ flowchart LR
     W -->|admit| X[Host-side execution]
     X --> R[Receipt plus evidence]
 ```
+
+**Figure:** A provider-neutral envelope can reach different models or scripts without transferring execution authority out of the host's schema, policy, and workspace checks.
 
 The provider never receives a Python function reference that carries authority
 by itself. It receives JSON describing an assignment and returns JSON describing
@@ -187,6 +191,8 @@ authority is actually decided.
 
 Here is the real source of authority: a table mapping each role to the actions it
 may take. (This mirrors `ROLE_AUTHORITY` in `sovereign_agent.policy`.)
+
+**Listing:** Grant authority by role without consulting the provider
 
 ```python
 ROLE_AUTHORITY = {
@@ -472,6 +478,8 @@ sequenceDiagram
     A-->>H: parsed proposal or explicit failure
 ```
 
+**Figure:** The adapter treats help text, streams, and exit status as untrusted observations and exposes only capabilities it has actually probed.
+
 Notice the asymmetry: an unknown capability becomes absent, while an unknown
 output shape becomes failure. Neither becomes a guessed success. This is why
 `run_spec` uses an argv list with `shell=False`, why provider-specific code owns
@@ -607,6 +615,8 @@ flowchart TB
     A2 --> V
 ```
 
+**Figure:** Compaction changes the rendered context while preserving every source message; the summary is a cache boundary, not permission to rewrite history.
+
 Only an eligible assistant/tool exchange is summarized. System and user turns
 stay verbatim, while a configurable head and tail remain in full. If the
 summarizer raises or returns empty text, no marker is committed and the cursor
@@ -668,6 +678,8 @@ sequenceDiagram
     H-->>P: REFUSED (deny wins)
     Note over P,T: The tool is never invoked
 ```
+
+**Figure:** Discovery may reveal a destructive tool, but deny-first host policy refuses authorization before the tool can be invoked.
 
 `ToolCatalog.discover()` scores overlap with the name, description, and
 keywords, sorts ties by tool name, caps the caller's limit at ten, and returns
@@ -812,13 +824,13 @@ shell strings.
 
 ## Summary
 
-This chapter built the actor/provider split: an **actor** carries its
+Actor identity is now separate from provider choice: an **actor** carries its
 swappable `provider` as a field, alongside its fixed `role` and `authority`,
 and rebinding that field — reserved to ruling roles, recorded as an
 `actor.provider_rebound` event — changes only the proposal generator, never
 the actor's identity (`identity_unchanged: true`).
 
-The invariant it establishes is that **authority is granted by role, through
+The authority rule is that **authority is granted by role, through
 a role-to-actions policy (`ROLE_AUTHORITY`), never by the model behind the
 actor**. `require_authority` looks the role up in that table; it never
 inspects `provider` at all.
@@ -833,7 +845,7 @@ matter which model it is bound to, because `accept` was never in the
 operator role's action set to begin with, and swapping `scripted` for
 `ollama` or `claude` cannot add an entry the check never reads.
 
-Back at Lucy's shop, this is the literal answer to her friend's question: a
+At Lucy's shop, this answers her friend's question directly: a
 sharper model behind the operator proposes better restock quantities, but it
 never gets a longer leash, because the leash was never attached to the
 model.

--- a/book/ch04_work_stays_inside_its_boundary/README.md
+++ b/book/ch04_work_stays_inside_its_boundary/README.md
@@ -69,6 +69,8 @@ flowchart TB
     T -->|before/after SHA-256 map| B[BoundaryReport]
 ```
 
+**Figure:** A workspace snapshot can detect tracked writes outside the assignment, but database files and paths beyond the organization root remain explicit blind regions.
+
 The dashed arrows are not claims that the provider *will* write there. They
 name what is possible without OS isolation. The snapshot hashes `T`, excluding
 the authorized workspace and SQLite files because both legitimately change
@@ -144,6 +146,8 @@ left. The string check happened to catch it here, but the join itself
 silently became an absolute escape.
 
 ### The join that refuses by shape
+
+**Listing:** Resolve a candidate path before admitting it
 
 ```python
 def safe_join(root, relative):
@@ -375,6 +379,8 @@ flowchart TB
     D -->|no| N[Narrow claim: no visible boundary change]
 ```
 
+**Figure:** Typed parsing, resolved-path checks, shell-free execution, and before/after snapshots narrow the claim from “sandboxed” to “no visible tracked change escaped.”
+
 The last box is deliberately not “the provider was contained.”
 `snapshot_boundary` hashes files under the organization root while excluding
 the assignment workspace and the SQLite ledger. It cannot see a network call,
@@ -440,6 +446,8 @@ flowchart LR
     T --> D
     O --> D
 ```
+
+**Figure:** Path, network, credential, tool, and process isolation require separate normalization and checks; passing one plane says nothing about the others.
 
 | Plane | Native mechanism in this project | Honest limit |
 | --- | --- | --- |
@@ -629,12 +637,12 @@ misreported as one.
 
 ## Summary
 
-This chapter built two mechanisms that are easy to confuse: `safe_join`, a
+The boundary now has two mechanisms that are easy to confuse: `safe_join`, a
 preventive check that refuses a path by its resolved shape before any write
 is attempted, and `snapshot_boundary`/`diff_boundary`, a detective check
 that compares tracked files before and after a provider runs.
 
-The invariant it establishes is honesty about scope: a clean boundary report
+Its governing discipline is honesty about scope: a clean boundary report
 means nothing changed inside `organization_root_excluding_workspace_and_ledger`
 — never an unqualified claim that the provider was contained, and never a
 claim about files outside that scope.
@@ -643,14 +651,14 @@ The chapter also decomposed isolation into five independently reported planes.
 Application allowlists can refuse named paths, hosts, credentials, and tools;
 process isolation remains unavailable until a behavioral host probe proves it.
 
-The failure it prevents is trusting a provider's own good behavior, or
+The exercise rejects trust in a provider's own good behavior, or
 worse, trusting a docstring's claim about what a check covers: the exercise
 plants a real write outside the workspace and shows it caught, and plants a
 real write outside the boundary's own observed scope and shows it invisible
 — both facts recorded honestly rather than one asserted and the other
 ignored.
 
-Back at Lucy's shop: this is the difference between following a contractor
+For Lucy, this is the difference between following a contractor
 around the shop (which nobody does) and checking the till afterward (which
 Lucy always can) — detection instead of a promise you cannot keep.
 

--- a/book/ch05_authority_needs_a_fence/README.md
+++ b/book/ch05_authority_needs_a_fence/README.md
@@ -63,6 +63,8 @@ sequenceDiagram
     DB-->>A: zero rows changed → refused
 ```
 
+**Figure:** A monotonically increasing fencing token lets the database reject Process A's late commit after Process B has acquired newer authority.
+
 The safety property comes from the `WHERE` clause at the terminal write, not
 from comparing wall clocks in Python. Time tells the system when takeover is
 allowed; monotonic tokens tell the protected resource which generation is
@@ -200,6 +202,8 @@ serializes the two. Note the claim also stamped a **fencing token** — number
 the owner's name.
 
 ### Completing under the token, not the name
+
+**Listing:** Complete work only under the current fencing token
 
 ```python
 def complete(db, message_id, actor_id, fencing_token):
@@ -437,6 +441,8 @@ sequenceDiagram
     DB-->>A: zero rows updated, stale writer refused
 ```
 
+**Figure:** Lease expiry permits takeover, while the token predicate prevents the superseded worker from completing the same message afterward.
+
 Checking only `claim_owner == actor_id` fails when both processes host the same
 durable actor. Checking only time fails because clocks do not revoke a process's
 memory or file descriptors. The monotonically increasing token makes each
@@ -516,6 +522,8 @@ sequenceDiagram
     B->>DB: finish incarnation 2
     DB-->>B: committed
 ```
+
+**Figure:** A session incarnation distinguishes successive claims even when the session name repeats, making a delayed completion from the prior incarnation harmless.
 
 `finish_session()` re-reads both rows inside one immediate transaction. It
 requires the current session host, exact incarnation, unexpired session lease,
@@ -651,7 +659,7 @@ cannot bypass either.
 
 ## Summary
 
-This chapter built a fencing token drawn from one shared, strictly
+Authority now carries a fencing token drawn from one shared, strictly
 increasing counter, layered under an actor lease: every claim's terminal
 write is a compare-and-set (CAS) whose `WHERE` clause checks the caller's
 token in the same statement that performs the write, never a value read
@@ -661,18 +669,18 @@ For resumable conversations, the same idea appears as a session incarnation:
 completion checks the host, generation, session lease, and host lease in the
 same transaction that records the result.
 
-The invariant it establishes is that a worker who no longer holds the
+The resulting invariant is that a worker who no longer holds the
 current lease may still be running, but its writes can never become
 canonical — the resource, not the worker's good behavior, is what refuses a
 stale token.
 
-The failure it prevents is two processes both believing they are the same
+This closes the case where two processes both believe they are the same
 actor — the ordinary shape of a crash-and-restart, not an attack — which the
 naive read-then-write claim let through silently, and which the CAS with a
 monotonic token refuses by construction, even when the stale process is
 still alive and finishes its work.
 
-Back at Lucy's shop: this is the numbered key that only turns for the
+At Lucy's shop, this is the numbered key that only turns for the
 current holder, so two staff who each believe they are closing tonight can
 never both count the till, no matter which one actually still has a key in
 hand.

--- a/book/ch06_the_organization_recovers/README.md
+++ b/book/ch06_the_organization_recovers/README.md
@@ -49,6 +49,8 @@ stateDiagram-v2
     TERMINAL --> [*]
 ```
 
+**Figure:** After a deadline, worker and supervisor race through compare-and-set; exactly one terminal state wins and both outcomes remain explainable.
+
 The apparent fork at `EXPIRED` is intentional. Expiry makes recovery eligible;
 it does not itself prove the worker is dead. A late worker and the supervisor may
 race. The ledger's compare-and-set on `current_execution_attempt` selects one
@@ -162,6 +164,8 @@ the lie a governed ledger exists to make unwritable.
 The honest version writes the only thing that is actually known — *we don't
 know it finished, so it didn't* — and does all of its writes in **one
 transaction**:
+
+**Listing:** Reconcile an expired attempt without guessing success
 
 ```python
 def recover(db, assignment_id, now):
@@ -337,6 +341,8 @@ flowchart TD
     W -->|persistent| K[Keep workspace inspectable]
 ```
 
+**Figure:** Recovery first commits failure evidence and clears current work atomically, then reclaims only temporary workspaces while preserving persistent ones for inspection.
+
 There are two compare-and-set moments hidden in that flow. The first is the
 re-read of the assignment after the expired-attempt scan: the worker may have
 finished between observation and decision. The second is the guarded update
@@ -483,24 +489,24 @@ only after the recovery transaction is durable.
 
 ## Summary
 
-This chapter built the supervisor's recovery path: a compare-and-set on
+The supervisor now recovers through a compare-and-set on
 `state = 'RUNNING' AND attempt_expires_at <= now` that writes a `FAILED`
 receipt with `failure_category="worker_lost"`, clears the fence, and only
 afterward applies workspace reclamation — all in the order that makes a
 second tick, or a second supervisor, find nothing left to do.
 
-The invariant it establishes is that unknown is never success: a genuinely
+The recovery rule is that unknown is never success: a genuinely
 `SIGKILL`ed worker's ledger stays honestly `RUNNING` until the supervisor
 says otherwise, and what it says is always `worker_lost`, never a guess
 based on whatever the dead process happened to leave behind.
 
-The failure it prevents is the tempting, more "diligent"-looking recovery
+The rejected design is the tempting, more "diligent"-looking recovery
 logic that checks for a `report.json` claiming `completed` and honors it —
 built and shown converting a real hard-kill into a false success on the
 strength of a file that could have been preplanted, half-written, or left
 by a process that was never going to finish correctly.
 
-Back at Lucy's shop: this is someone else walking in on a collapsed
+At Lucy's shop, this is someone else walking in on a collapsed
 worker's half-counted till and writing down "we don't know it was
 finished," not "looked done to me" — because the second sentence is how
 real money goes missing.

--- a/book/ch07_the_organization_wakes_itself/README.md
+++ b/book/ch07_the_organization_wakes_itself/README.md
@@ -58,6 +58,8 @@ flowchart LR
     G -->|do not fire| N[Nothing recorded\nre-evaluated next pass]
 ```
 
+**Figure:** A durable signal is evaluated by a pure gate; only a firing decision atomically creates one governed work chain, while a non-fire creates no false work record.
+
 The signal is not a task. It records that the world crossed a meaningful
 boundary. The gate is not a worker. It decides whether that signal still merits
 work and specifies the governed work shape. Pulse is not a scheduler. One call
@@ -114,6 +116,8 @@ Note the `UNIQUE` on `wake_decisions.source_signal_id`. It looks like a
 detail. It is the entire chapter.
 
 ### The gate decides WHAT — and nothing else
+
+**Listing:** Decide whether one durable signal still deserves work
 
 ```python
 def wake_gate(db, signal_sku):
@@ -350,6 +354,8 @@ flowchart TD
     Zero -->|2+| None2[Ambiguous ownership\ngate returns None]
 ```
 
+**Figure:** The wake gate fires only when exactly one active outcome governs the signal's subject, refusing both missing and ambiguous ownership.
+
 *Figure — the Store's outcome-disambiguation check inside `store_wake_gate`.
 The stock-level check from the section above narrows signals to real
 candidates; this second, independent check narrows candidates to signals
@@ -455,6 +461,8 @@ flowchart TD
     Bound -->|yes| Disable[Disable automation]
     Bound -->|no| Retry[Remain eligible for a later due slot]
 ```
+
+**Figure:** A scheduler records observations without inventing runs, uniquely claims each due slot, and commits new condition state only after successful payload execution.
 
 The condition is a pure function from prior JSON state to
 `WatchDecision(fire, message, state)`. Its serialized state is capped at 16
@@ -662,6 +670,8 @@ flowchart LR
     R2 -->|resumes SAME assignment| Done[assignment.state = COMPLETED\nledger: 1 SOW, 1 assignment]
 ```
 
+**Figure:** A process death after work creation leaves a resumable assignment; the next pulse completes that same identity instead of duplicating the SOW and assignment.
+
 *Figure — the crash window `_resumable_signals` closes. A hard kill between
 canonical creation and provider execution leaves an assignment stuck at
 `CREATED`; the next ordinary `run_pulse_once` pass — no special "resume"
@@ -781,7 +791,7 @@ this repository's own suite will otherwise fail on the next `make verify`.
 
 ## Summary
 
-This chapter built `run_pulse_once`'s wake gate and wake decision: a pure
+The organization can now wake itself through `run_pulse_once`: a pure
 gate that decides what work a signal warrants, and a `UNIQUE(source_signal_id)`
 claim, made inside one transaction with the SOW and origin rows it creates,
 that lets exactly one canonical decision exist per signal.
@@ -791,18 +801,18 @@ condition persists observation state without inventing a run, a firing slot is
 claimed once by `(automation_id, due_at)`, and payload failure never commits a
 false checkpoint.
 
-The invariant it establishes is that self-generated work is provable only
+The governing condition is that self-generated work is provable only
 positively — a real `pulse.work_created` event and a `pulse_origins` row
 naming a real signal — never inferred from the absence of a manual
 dispatch call, which this chapter's own curriculum checker enforces by
 re-deriving the claim from the database rather than trusting the prose.
 
-The failure it prevents is the naive tick's double-order: retried or
+The naive tick's double-order is now refused: retried or
 re-run against the same signal, it created two replenishment SOWs from one
 sale, and nothing about that retry was unreasonable — ticks get retried
 constantly. The claimed decision closes it structurally, at the database.
 
-Back at Lucy's shop: this is the freezer alarm that fires exactly once per
+For Lucy, this is the freezer alarm that fires exactly once per
 low-stock sale, however many times the alarm system itself gets restarted
 or double-checks its own work.
 

--- a/book/ch08_the_store_becomes_a_catalog/README.md
+++ b/book/ch08_the_store_becomes_a_catalog/README.md
@@ -58,6 +58,8 @@ erDiagram
     }
 ```
 
+**Figure:** Stable SKU identity binds products to inventory, signals, and effects even though each table owns a different part of the product's state.
+
 **What this figure shows:** three logical subject relationships, all keyed
 by the same opaque `sku`. The schema does not enforce a foreign key or a
 one-to-one relationship between `products.sku` and `inventory.sku` — SQLite
@@ -145,6 +147,8 @@ Three separate concerns get three separate homes: identity (`sku`, the
 primary key — opaque, stable, never shown to customers), the display name
 (mutable prose *about* the identity), and quantities (their own row, with a
 constraint that makes negative stock unrepresentable):
+
+**Listing:** Migrate live singleton data into a catalog transactionally
 
 ```python
 def migrate_to_catalog(db):
@@ -292,6 +296,8 @@ flowchart TD
     W2 --> W3[INSERT OR REPLACE\ncash_entries, once]
     W3 --> COMMIT[COMMIT]
 ```
+
+**Figure:** The entire catalog batch is validated before the transaction begins, so a short or duplicate batch touches no rows and an admitted batch commits every dependent table together.
 
 **What this figure shows:** both refusal paths (`C1`, `C2`) exit *before*
 `BEGIN transaction`, so a refused call and a call that never happened are
@@ -527,6 +533,8 @@ flowchart LR
     Before --> After
 ```
 
+**Figure:** Renaming a product changes its presentation while the stable SKU preserves its event history and every relationship keyed to that identity.
+
 **What this figure shows:** the `UPDATE` above changed exactly one column
 (`name`) on exactly one row. `sku` never appeared on the left side of that
 `UPDATE`, so every `events` row that references `SKU-TEA` stays correctly
@@ -636,19 +644,19 @@ isolation the next chapters rely on starts here, at the schema.
 
 ## Summary
 
-This chapter built the migration from a `CHECK (id = 1)` singleton shop to a
+The store has moved from a `CHECK (id = 1)` singleton to a
 real multi-SKU catalog: separate `products` and `inventory` tables keyed by
 a stable, opaque `sku`, plus `seed_catalog`, a validated batch write that
 refuses fewer than two SKUs, duplicate SKUs, and negative opening stock
 before it ever opens its transaction.
 
-The invariant it establishes is that identity and display name are
+The schema now makes identity and display name
 different concerns: the ledger binds to `sku`, so renaming a product never
 orphans a single row of its history, and every migration proof obligation
 from Chapter 1 — preservation, identity, totality, atomicity — applies to a
 populated shop, not an empty one.
 
-The failure it prevents is the migration that strands a shop mid-schema:
+The principal failure case is a migration that strands a shop mid-schema:
 built and crashed on purpose, after `products` existed but before
 `inventory` was copied and the old table dropped, and shown to leave the
 original singleton row completely untouched rather than half-migrated. A
@@ -660,7 +668,7 @@ gone. `products` and `inventory` have no database-level append-only guard
 the way `events` does; the Python check this chapter traces is the entire
 guarantee against that specific loss.
 
-Back at Lucy's shop: this is vanilla and chocolate finally getting their own
+At Lucy's shop, vanilla and chocolate finally get their own
 rows instead of sharing one, so a run on one flavor can never quietly change
 the other's count — the schema-level guarantee the rest of the book from
 here on depends on.

--- a/book/ch09_each_product_has_its_own_threshold/README.md
+++ b/book/ch09_each_product_has_its_own_threshold/README.md
@@ -48,6 +48,8 @@ flowchart LR
     E --> K
 ```
 
+**Figure:** One sale transaction derives availability and the SKU-specific reorder decision, then commits inventory, cash, signal, and event effects together or none at all.
+
 `available` and `total` are derived inside the toy operation rather than passed
 as precomputed values. The unit price is still caller-supplied; a stronger
 production contract would look it up from the product record. The inventory row
@@ -121,6 +123,8 @@ db.commit()
 ```
 
 ### One exact sale, traced through every write
+
+**Listing:** Record a sale and its five effects atomically
 
 ```python
 def record_sale(db, sku, quantity, unit_price_cents):
@@ -358,6 +362,8 @@ sequenceDiagram
     B->>DB: validate against the committed value
 ```
 
+**Figure:** `BEGIN IMMEDIATE` serializes competing sales so the second writer validates against the first writer's committed inventory rather than a stale read.
+
 The lock is not protecting subtraction as a CPU operation. It protects the
 relationship between the read, the decision, and all five writes. Move the read
 above the transaction and both sellers can observe the same stock. Move cash or
@@ -503,24 +509,24 @@ Expected: all pass.
 
 ## Summary
 
-This chapter built `record_sale` as five writes inside one transaction —
+A sale now enters `record_sale` as five writes inside one transaction:
 inventory down, cash up, a severity-judged signal, a committed event, and a
 derived total — with the read of current stock happening *inside* the same
 `BEGIN IMMEDIATE` block as the decrement, and the reorder-point comparison
 evaluated per SKU, against that SKU's own row.
 
-The invariant it establishes is that severity is a property of where a SKU
+The governing rule is that severity is a property of where a SKU
 lands relative to its *own* threshold, never a property of how much sold:
 two genuinely identical two-unit sales on tea and coffee produced a
 `warning` and an `info` signal respectively, because the two SKUs' reorder
 points differ.
 
-The failure it prevents is the oversell — a check-then-act race where two
+The prevented failure is an oversell: a check-then-act race where two
 sales both read "2 available" before either writes, and the naive version
 built here drove `on_hand` to `-2`, promising ice cream that does not exist.
 Moving the read inside the transaction closes it.
 
-Back at Lucy's shop: this is why vanilla (which flies off the shelf) and
+For Lucy, this is why vanilla, which flies off the shelf, and
 lavender-honey (which nobody buys) each get their own reorder line instead
 of one shared number — and why a sale of either one is checked against
 reality at the instant it happens, not against what the till believed a

--- a/book/ch10_one_signal_wakes_one_need/README.md
+++ b/book/ch10_one_signal_wakes_one_need/README.md
@@ -48,6 +48,8 @@ flowchart LR
     A -->|re-read| I[(Inventory\nSKU-VANILLA)]
 ```
 
+**Figure:** Subject identity must survive every edge from signal through outcome, work, execution, effect, and fresh inventory verification for acceptance to be causal.
+
 At each arrow, ask whether identity is **derived** from the preceding durable
 record or supplied again by a caller. Re-supplying `sku="vanilla"` at acceptance
 creates a confused-deputy opportunity: a caller can present a real effect for
@@ -264,6 +266,8 @@ caller simply pointed the whole apparatus at the wrong subject.
 
 ### Generation 5: the caller supplies one fact only
 
+**Listing:** Derive causal acceptance from the statement of work
+
 ```python
 def accept_v5(db, sow_id):
     outcome_id, required_kind = db.execute(
@@ -350,6 +354,8 @@ flowchart TD
     C -->|1| FIRE[WakeDecision\noutcome_id = the one match]
     C -->|2 or more| REFUSE2[return None\nno durable rule disambiguates more than one]
 ```
+
+**Figure:** The caller supplies only the SKU fact; durable outcomes determine ownership, and any cardinality other than exactly one produces refusal rather than a guess.
 
 **What this figure shows:** the gate has exactly one branch that fires,
 flanked by two refusal branches that look nothing alike in cause — one is
@@ -539,6 +545,8 @@ sequenceDiagram
     Gate-->>Gate: refuse, return None
     Note over Sig: severity still says "warning" --<br/>the field itself never changes
 ```
+
+**Figure:** A signal preserves the historical warning, while the gate re-reads live inventory and refuses obsolete work after an off-path restock.
 
 **What this figure shows:** everything the gate reads from the signal
 object — `kind`, `source`, `subject_ref` — is identity and provenance, set

--- a/book/ch11_replenishment_scales_without_losing_governance/README.md
+++ b/book/ch11_replenishment_scales_without_losing_governance/README.md
@@ -60,6 +60,8 @@ sequenceDiagram
     end
 ```
 
+**Figure:** Competing attempts may both execute, but a unique effect key admits one transactional winner and makes every retry return the same canonical result.
+
 The idempotency key names the **logical operation**, not the process attempt. In
 production it is `(assignment_id, kind, subject)`. A retry of the same
 assignment and SKU is the same operation and must return the canonical result. A
@@ -175,6 +177,8 @@ oversell race, mirrored: there stale reads sold stock twice; here they
 Everything that decides — the idempotency claim, the authorization, the cash
 check — moves **inside** the transaction that acts, and the claim itself
 becomes an insert under the `UNIQUE` constraint:
+
+**Listing:** Converge retries on one canonical restock effect
 
 ```python
 db.execute("UPDATE inventory SET on_hand = 2 WHERE sku = 'SKU-TEA'")
@@ -326,6 +330,8 @@ flowchart LR
     A -->|invalid| F[Refuse with no writes]
     C -->|invalid| F
 ```
+
+**Figure:** Authorization and business checks precede the unique effect claim; a winner commits inventory, cash, and event changes together, while repeats converge on its stored payload.
 
 Returning the prior payload matters. A duplicate response that merely says
 “already done” forces the caller to guess what done means. Returning the
@@ -490,24 +496,24 @@ exercise cannot demonstrate by itself.
 
 ## Summary
 
-This chapter built `apply_restock`'s idempotency key — `UNIQUE(assignment_id,
+Restocking now depends on `apply_restock`'s idempotency key: `UNIQUE(assignment_id,
 kind, subject)` on the `effects` table — and ran two complete governed
 replenishment chains, each restocked twice under the same assignment id, to
 show every guarantee from Chapters 0-10 composes at more than one SKU
 without exception.
 
-The invariant it establishes is that "exactly once" is a ledger property,
+The resulting invariant is that "exactly once" is a ledger property,
 not an execution count: a retry of the same logical operation returns the
 canonical prior result rather than failing or repeating it, because the key
 names the operation's stable identity (this assignment, this kind, this
 subject), never a per-attempt value like a timestamp or a fresh id.
 
-The failure it prevents is the double-order this chapter reproduces to the
+The chapter reproduces and prevents the double-order to the
 digit — `on_hand=14, purchase_entries=2` from one intended restock — by
 building the naive "scan first, then act" version and watching two retries
 that each saw "not done yet" both place the order.
 
-Back at Lucy's shop: this is the guarantee that survives past the demo —
+At Lucy's shop, this guarantee survives past the demo:
 two restocks in flight, one for vanilla and one for chocolate, and neither
 a retried order nor a busy Saturday can make either SKU's effect land on the
 other or get charged twice.

--- a/book/ch12_the_pilot_begins_with_a_receipt/README.md
+++ b/book/ch12_the_pilot_begins_with_a_receipt/README.md
@@ -62,6 +62,8 @@ flowchart LR
     V --> I[Internal consistency claim]
 ```
 
+**Figure:** Pilot-start uniqueness and proof-pack consistency are separate boundaries: one governs the live slot, while the other proves only that declared artifacts agree internally.
+
 The left side is a compare-and-set state machine. Replay equality covers the
 whole request identity, not only `pilot_id`; otherwise a colliding customer can
 receive another customer's canonical record. The single active slot makes
@@ -110,6 +112,8 @@ flowchart LR
     L -. does not prove .-> H
     H -. does not prove .-> R
 ```
+
+**Figure:** Each release environment adds evidence the rung below cannot supply; no deterministic suite, provider evaluation, or reviewed pilot silently proves wider rollout.
 
 The arrows are promotions of evidence, not automatic transitions. A scripted
 provider is ideal for reproducibility and fault injection, but cannot prove a
@@ -214,6 +218,8 @@ Same-id-different-request is not a retry; it is a different customer
 holding the same ticket number.
 
 ### Replay on exact identity; refuse everything else
+
+**Listing:** Start or replay one pilot identity atomically
 
 ```python
 def start_pilot(db, pilot_id, store_org, profile):
@@ -513,7 +519,7 @@ one slice of that proof matrix, running.
 
 ## Summary
 
-This chapter built `start_pilot` as a compare-and-set state machine — exact
+The final mechanism makes `start_pilot` a compare-and-set state machine: exact
 identity replay returns the canonical row, a colliding id with a different
 request refuses outright, a singleton `active_pilot` slot enforces one
 pilot at a time as a schema constraint, and a refused start strands nothing
@@ -521,19 +527,19 @@ because the pilot row and the active-slot claim share one transaction — and
 a proof-pack verifier that checks a manifest's digests and status
 vocabulary for internal consistency.
 
-The invariant it establishes is the sharpest one in the book: internal
+Its sharpest invariant is that internal
 consistency is not authenticity. A forged pack that rewrites both an
 artifact and its manifest digest together passes every check this
 verifier can run, and the chapter proves that by forging one and watching
 it pass.
 
-The failure it prevents, where it can, is the confident half-truth — "pilot
+Where it can, it prevents the confident half-truth: "pilot
 started" standing in for "pilot finished," or a `NOT_RUN` status dressed in
 success-shaped prose — and it prevents the failure it cannot yet check
 (a completion protocol does not exist) by refusing to claim it can, which is
 itself the load-bearing act.
 
-Back at Lucy's shop: this is the difference between a receipt that says the
+For Lucy, this is the difference between a receipt that says the
 delivery truck left the warehouse and a receipt that says the ice cream
 arrived — the book ends by handing you the first receipt, honestly labeled,
 and refusing to forge the second.

--- a/book/parts/part-1-durable-foundations.md
+++ b/book/parts/part-1-durable-foundations.md
@@ -1,0 +1,18 @@
+# Part 1: Durable foundations
+
+An agent can produce a plausible answer before it can be trusted with a business. This
+part builds the substrate that makes later autonomy inspectable: canonical state,
+transactional history, governed work, and a hard boundary between a provider's proposal
+and the host's authority.
+
+By the end of Chapter 3, you will have run one complete shift, separated canonical facts
+from projections, built acceptance as a proof graph, and treated model output as untrusted
+data. The system is still manually dispatched. That limitation is deliberate: an
+organization should not wake itself until its memory and authority are durable enough to
+survive the attempt.
+
+The failures this part closes are foundational ones: a status that says more than the
+world supports, a migration that records half a fact, evidence borrowed from another
+outcome, and a provider response that crosses into execution without host validation.
+
+Continue to [Chapter 0: Lucy's first shift](../ch00_first_shift/README.md).

--- a/book/parts/part-2-bounded-autonomy.md
+++ b/book/parts/part-2-bounded-autonomy.md
@@ -1,0 +1,17 @@
+# Part 2: Bounded autonomy
+
+Durable state is necessary, but it is not enough. Work must stay inside its assigned
+boundary, authority must expire without allowing a stale writer to return, and recovery
+must reconcile evidence rather than guess what a dead process accomplished.
+
+Chapters 4 through 7 turn those constraints into mechanisms. You will qualify five
+different isolation planes, fence late writers, recover a process killed between intent
+and completion, and finally let a durable signal create governed work without a human
+prompt. The sequence matters. Proactive execution arrives last because it amplifies every
+boundary mistake that came before it.
+
+The result is bounded autonomy: the organization may wake and act, while the host can
+still show which authority admitted the action, which workspace contained it, and which
+evidence survived a crash.
+
+Continue to [Chapter 4: Work stays inside its boundary](../ch04_work_stays_inside_its_boundary/README.md).

--- a/book/parts/part-3-proof-at-scale.md
+++ b/book/parts/part-3-proof-at-scale.md
@@ -1,0 +1,17 @@
+# Part 3: Proof at scale
+
+A mechanism that works for one product can still hide identity, concurrency, and
+attribution bugs. This part adds the second instance that forces those assumptions into
+the open.
+
+Chapters 8 through 12 replace the single-product fixture with a catalog, make stock and
+reorder policy independent per SKU, trace one signal to one governed need, and make retry
+converge on one canonical effect. The final chapter assembles release evidence and then
+demonstrates the limit of that evidence: internal consistency is not the same claim as
+truth in the world.
+
+By the end, the reader has a pilot-start receipt and a ladder for moving from deterministic
+local checks toward credentialed evaluation, human review, canary rollout, and wider
+release. Each rung proves something new; none inherits the claim of the rung above it.
+
+Continue to [Chapter 8: The Store becomes a catalog](../ch08_the_store_becomes_a_catalog/README.md).

--- a/scripts/verify_book_structure_v1.py
+++ b/scripts/verify_book_structure_v1.py
@@ -2,7 +2,7 @@
 
 PROVES: BOOK.json names one existing path per surface and partitions chapters 0-12 once.
 PAID-FAILURE: front matter and appendices existed upstream but were invisible to consumers.
-proven-at: profrodai/sovereign-agent@pending
+proven-at: profrodai/sovereign-agent@ab7028465d4eccf2809b24c238de8578ab96c498
 """
 
 from __future__ import annotations

--- a/scripts/verify_book_structure_v1.py
+++ b/scripts/verify_book_structure_v1.py
@@ -1,0 +1,117 @@
+"""Validate the source-owned book, part, front-matter, and resource manifest.
+
+PROVES: BOOK.json names one existing path per surface and partitions chapters 0-12 once.
+PAID-FAILURE: front matter and appendices existed upstream but were invisible to consumers.
+proven-at: profrodai/sovereign-agent@pending
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOK = ROOT / "book"
+MANIFEST = BOOK / "BOOK.json"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"verify_book_structure_v1: {message}")
+
+
+def records(value: Any, field: str) -> list[dict[str, Any]]:
+    require(isinstance(value, list), f"{field} must be a list")
+    require(all(isinstance(item, dict) for item in value), f"{field} entries must be objects")
+    return value
+
+
+def main() -> None:
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    require(data.get("schemaVersion") == 1, "schemaVersion must be 1")
+    require(data.get("title") == "Building Zero Employee Organizations", "title drifted")
+    require(data.get("author", {}).get("name") == "Rod Rivera", "author is missing")
+
+    surfaces: list[tuple[str, dict[str, Any]]] = []
+    for field in ("frontMatter", "parts", "appendices", "resources"):
+        surfaces.extend((field, item) for item in records(data.get(field), field))
+
+    slugs: set[str] = set()
+    paths: set[str] = set()
+    for field, item in surfaces:
+        slug = item.get("slug")
+        relative = item.get("path")
+        require(isinstance(slug, str) and slug, f"{field} entry has no slug")
+        require(isinstance(relative, str) and relative, f"{field}/{slug} has no path")
+        require(slug not in slugs, f"duplicate surface slug {slug}")
+        require(relative not in paths, f"duplicate surface path {relative}")
+        slugs.add(slug)
+        paths.add(relative)
+        target = BOOK / relative
+        require(target.is_file(), f"{field}/{slug} path does not exist: {relative}")
+        require(target.read_text(encoding="utf-8").startswith("# "), f"{relative} needs one H1")
+
+    part_chapters = [
+        chapter
+        for part in records(data.get("parts"), "parts")
+        for chapter in part.get("chapters", [])
+    ]
+    require(part_chapters == list(range(13)), "parts must partition chapters 0 through 12 in order")
+
+    source_chapters = sorted(
+        int(path.parent.name[2:4]) for path in BOOK.glob("ch[0-9][0-9]_*/README.md")
+    )
+    require(source_chapters == list(range(13)), "source chapter directories must be 0 through 12")
+
+    captions: list[str] = []
+    listing_titles: list[str] = []
+    diagram_count = 0
+    for chapter_path in sorted(BOOK.glob("ch[0-9][0-9]_*/README.md")):
+        chapter = chapter_path.read_text(encoding="utf-8")
+        diagrams = re.findall(
+            r"^```mermaid\n.*?^```\n\n\*\*Figure:\*\* ([^\n]+)$",
+            chapter,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        raw_count = len(re.findall(r"^```mermaid$", chapter, flags=re.MULTILINE))
+        require(
+            len(diagrams) == raw_count,
+            f"{chapter_path.relative_to(ROOT)} has {raw_count} diagrams but "
+            f"{len(diagrams)} immediate captions",
+        )
+        require(
+            all(len(caption) >= 60 for caption in diagrams),
+            f"{chapter_path.relative_to(ROOT)} has a caption shorter than 60 characters",
+        )
+        captions.extend(diagrams)
+        diagram_count += raw_count
+
+        listings = re.findall(
+            r"^\*\*Listing:\*\* ([^\n]+)\n\n```(?:python|bash)\n",
+            chapter,
+            flags=re.MULTILINE,
+        )
+        require(
+            len(listings) >= 1,
+            f"{chapter_path.relative_to(ROOT)} needs an authored key-listing title",
+        )
+        listing_titles.extend(listings)
+
+    require(diagram_count == 39, f"expected 39 diagrams, found {diagram_count}")
+    require(len(set(captions)) == len(captions), "figure captions must be unique")
+    require(
+        len(set(listing_titles)) == len(listing_titles),
+        "key-listing titles must be unique",
+    )
+
+    print(
+        "verify_book_structure_v1: "
+        f"{len(surfaces)} surfaces, {len(source_chapters)} chapters, "
+        f"{diagram_count} captions, and {len(listing_titles)} key listings are coherent"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Outcome

Makes publication structure and meaning source-owned rather than reconstructed by profrod-site.

- adds `book/BOOK.json` with front matter, three parts, chapters, appendices, and labs
- adds three part openers and an agent-ecosystem map grounded in MCP, A2A, OpenTelemetry, OWASP, and NIST primary sources
- adds 39 source-authored figure captions and 13 source-authored key-listing titles
- removes repetitive drafting scaffolds and internal production notes from reader-facing prose
- adds a fail-closed structure verifier and wires it into `make verify`

## Proof

`make verify` passed at `3f7634e`: 476 tests, 102 executed Python snippets, 92 expected-output pairs, 13 deterministic labs, 39 caption checks, 13 listing checks, source budget, typing, lint, and clean-room README onboarding. The pre-push hook reran the complete gate and passed.

The first onboarding attempt encountered a transient PyPI network outage. RETRY after connectivity returned passed; the complete gate then passed twice.

## Chain

- Principal decision: https://github.com/rodriveracom/org-profrodai/issues/52#issuecomment-5557210459
- Reader correctness and payload prerequisite: https://github.com/rodriveracom/profrod-site/pull/57

No site source pin changes in this PR. profrod-site will consume the exact accepted source commit in a separate packet.

Closes the source/editorial portion of org-profrodai#52.