### PR TITLE
Preserve successive reports and resolve uncertain orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Repository: [`profrodai/sovereign-agent`](https://github.com/profrodai/sovereign
 
 ## Unreleased
 
+- Address current elder review counterexamples: migration 26 records immutable
+  report revisions with independent delivery receipts; late acknowledgements
+  cannot suppress a newer result. Interrupted immediate transactions roll back
+  on BaseException and retain the original error when lock acquisition fails.
+  Saturated clock jobs defer without creating rejected report floods.
+
+- Add explicit renewal of an uncertain exact order for a matching idempotent
+  supplier and operator-attested conclusive receipt resolution. Retain uncertain
+  reservations when proof is absent; reject cancelled or revoked retry authority.
+  Chapter 2 and 3 learner files now contain the constructed dispatcher, loop and
+  HTTP response adapter, and the live checkpoint loads that reader-owned code.
+
 - Add a current operating report from one consistent SQLite snapshot, with
   explicit uncertainty, accounting mismatches, retained-history scope and model
   estimate limits. Complete sixteen construction drafts and an accelerated day

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ verify: lint test
 	$(UV) run --python 3.14 python scripts/verify_book_depth.py
 	$(UV) run --python 3.14 python scripts/verify_book_structure_v1.py
 	$(UV) run --python 3.14 python scripts/verify_always_on_v1.py
-	$(UV) run --python 3.14 python scripts/verify_publication_v1.py
+	$(UV) run --python 3.14 python scripts/verify_publication_v2.py
 	$(UV) run --python 3.14 python scripts/verify_book_labs.py
 	$(UV) run --python 3.14 sovereign-agent --help >/dev/null
 	$(UV) run --python 3.14 sovereign-agent doctor

--- a/book/always_on/CONVENTIONS.md
+++ b/book/always_on/CONVENTIONS.md
@@ -9,15 +9,15 @@ Read in order. The chapters form one cumulative implementation, with one executa
 Use the exact source commit linked by the edition you are reading. A moving branch can contain later behavior than a printed listing. From the repository root, install the committed environment and run the first checkpoint:
 
 ```bash
-uv sync --frozen --python 3.14
+uv sync --frozen --python 3.14 --group dev
 uv run --python 3.14 python book/always_on/checkpoints/ch01.py
 ```
 
-Run another checkpoint by replacing the chapter number. The [checkpoint index](CHECKPOINTS.md) links all sixteen files. Chapter 1 explains the setup before asking for the first live model call. Do not use the published PyPI version as a substitute for an unreleased edition checkout.
+Use Python 3.14 throughout, including the inline examples. Some later listings use Python 3.14's unparenthesized multiple-exception syntax; on older interpreters those statements are syntax errors. Run inline examples and checkpoints from the repository root, because relative fixture paths start there. Chapters 2 and 3 give exact instructions for saving the reader-built definitions in `book/always_on/learner/`. Run another checkpoint by replacing the chapter number. The [checkpoint index](CHECKPOINTS.md) links all sixteen files. Chapter 1 explains the setup before asking for the first live model call. Do not use the published PyPI version as a substitute for an unreleased edition checkout.
 
 ## Read the evidence labels literally
 
-A Python listing introduces code you can inspect. A selected listing title identifies a passage discussed in the surrounding prose; it does not imply that every code fence is a standalone program. Adjacent text output records the shown experiment. The construction instrument executes marked Python examples and compares paired output. Bash commands may require the stated host, model or credentials; their presence in a fence is not a claim that a portable test executed them.
+A Python listing introduces code you can inspect. The website numbers figures and listings within each chapter from source order; the source captions intentionally keep their stable descriptive text. A selected listing title identifies a passage discussed in the surrounding prose; it does not imply that every code fence is a standalone program. Adjacent text output records the shown experiment. The construction instrument executes marked Python examples and compares paired output. Bash commands may require the stated host, model or credentials; their presence in a fence is not a claim that a portable test executed them.
 
 | Evidence | What it establishes | What still needs inspection |
 | --- | --- | --- |

--- a/book/always_on/PREFACE.md
+++ b/book/always_on/PREFACE.md
@@ -35,3 +35,5 @@ The manuscript is a construction draft. Executed tests, Linux experiments and li
 OpenClaw, NanoClaw and Hermes appear when their code illuminates a particular decision. Every finished comparison names a commit and distinguishes documented rationale from our interpretation. We do not infer that a project lacks a feature because a short inspection did not find it. The decisions organize the book; the projects are dated illustrations.
 
 Sovereign Agent is the educational implementation. Zeocore is an optional path to maintained integrations in a separate environment. The [integration appendix](appendices/zeocore-interop-v2.md) demonstrates a real, bounded protocol connection without making it a prerequisite for understanding the chapters. Start with [the reader conventions](CONVENTIONS.md), then make Lucy's [first model call](ch01_first_model_call/README.md).
+
+Continue with [How to use this book](CONVENTIONS.md), then [Chapter 1](ch01_first_model_call/README.md).

--- a/book/always_on/PUBLICATION.json
+++ b/book/always_on/PUBLICATION.json
@@ -102,5 +102,5 @@
     }
   ],
   "expectedFigures": 52,
-  "expectedListings": 97
+  "expectedListings": 99
 }

--- a/book/always_on/ch01_first_model_call/README.md
+++ b/book/always_on/ch01_first_model_call/README.md
@@ -2,9 +2,11 @@
 
 Lucy opens her ice cream shop at nine. Before the first customer arrives, she checks the freezer, checks yesterday's notes, and decides what needs attention. Vanilla is running low. Chocolate is plentiful. Strawberry has almost gone. She would like a short briefing before opening, and eventually she would like help preparing the orders that follow.
 
-You are the developer building that assistant. Lucy is your customer. She supplies the business rules and decides what the assistant may do; you turn those decisions into a system whose behavior she can inspect. You will not ask her to understand a database lease before she can use the shop's stock report.
+You are the developer building that assistant. Lucy is your customer. She supplies the business rules and decides what the assistant may do; you turn those decisions into a system whose behavior she can inspect. Her first observable result is the shop's stock report.
 
 This chapter ends with a small Python program that sends real shop data to a model and reads a morning brief. An offline response fixture makes the surrounding Python reproducible without a model server. A separate live command proves the model connection. Keep those two observations separate: a fixture proves how your program handles known bytes; a live response demonstrates what a configured model returned on that run.
+
+In this book, a **model** generates a response, the **loop** decides which validated tool calls to execute next, and the **runtime** is the Python program that keeps the loop, tools and saved records working together. A **fixture** is synthetic input or an authored response used to reproduce an experiment.
 
 ## Learning objectives
 
@@ -60,7 +62,7 @@ The companion repository uses Python 3.14 and `uv`. Its lockfile pins the develo
 From a fresh checkout, run:
 
 ```bash
-uv sync --python 3.14 --group dev
+uv sync --frozen --python 3.14 --group dev
 uv run --python 3.14 python --version
 uv run --python 3.14 python book/always_on/checkpoints/ch01.py
 ```

--- a/book/always_on/ch02_shop_tools/README.md
+++ b/book/always_on/ch02_shop_tools/README.md
@@ -43,7 +43,7 @@ flowchart LR
 
 ## Reuse the shop fixture
 
-We continue with the same three products from Chapter 1. The standalone checkpoint keeps its stock in memory so that the dispatch mechanism can be inspected without first teaching database transactions. Chapter 4 will replace this storage boundary with persistent records. The cumulative installed agent already has that SQLite adapter; it applies the same contract to current records.
+We continue with the same three products from Chapter 1. The standalone checkpoint keeps its stock in memory so that the dispatch mechanism can be inspected without first teaching database transactions. Chapter 4 will replace this storage boundary with persistent records. For now, the complete tool layer uses only Python and Pydantic.
 
 For the examples below, load only the preceding checkpoint's fixture. `run_path` executes the module definitions without running its `main` function. No model request occurs.
 
@@ -316,7 +316,7 @@ The `schemas` method returns only allowed tools. Hiding unavailable operations m
 
 Expected failures become small error codes. We do not copy exception messages into the model's context: validation errors may include raw arguments, and network exceptions can include sensitive addresses or credentials. During development, you can reproduce a failure with the deterministic request and inspect its handler locally. A public observation need not expose every internal detail to be useful.
 
-The exception list is deliberate. It covers expected input, permission, timeout, and operating-system failures. It does not catch every possible programming defect or interrupt. A misspelled variable should fail visibly during development instead of being disguised as a routine tool refusal. Later, the work runner will record failed turns so that an unexpected exception does not erase the assignment.
+The exception list is deliberate. It covers expected input, permission, timeout, and operating-system failures. It does not catch every possible programming defect or interrupt. A misspelled variable should fail visibly during development instead of being disguised as a routine tool refusal. In Chapter 10 we will save unfinished tasks so another process can recover them after a failure.
 
 The result limit counts encoded bytes, not Python characters. A character may require several UTF-8 bytes. `allow_nan=False` also rejects values such as floating-point infinity that do not belong in a strict JSON observation. These checks keep a completed tool result from flooding the next model request or violating its data format.
 
@@ -367,7 +367,7 @@ print(read_only.invoke(request))
 {'ok': False, 'error': 'tool_not_allowed'}
 ```
 
-The name `read_only` describes this particular selection. Our draft tool also has no external effect, so excluding it here is an example of narrowing an interface rather than a claim that drafting is purchasing. In later chapters, separate roles will receive the operations needed for their assignments.
+The name `read_only` describes this particular selection. Our draft tool also has no external effect, so excluding it here is an example of narrowing an interface rather than a claim that drafting is purchasing. In later chapters, we will choose an allowlist for each kind of task.
 
 ```mermaid
 sequenceDiagram
@@ -406,6 +406,71 @@ tool_failed
 ```
 
 This experiment explains why a saved recommendation is not a permanent authorization. The world can change between recommendation and execution. The handler checks the fixture at invocation time. When multiple processes can update persistent stock, checking and reserving quantities will require a transaction or equivalent coordination; this in-memory example makes no concurrency guarantee.
+
+## Save the tool layer for Chapter 3
+
+Run all examples from the repository root. Create `book/always_on/learner/ch02.py`. Save the imports, class and function definitions shown in this chapter, together with the assignments to `SHOP`, `PRICES`, `products` and `tools`. Keep the print statements and failure experiments in your interactive session. The checked-in file is the completed version of exactly those definitions; it imports no agent runtime.
+
+The functions above share one module-level product dictionary. Chapter 3 needs a fresh fixture for each experiment. The following factory moves the same calculations inside a function, where each handler closes over its own copied rows. It returns the dispatcher we already built; no hidden factory is supplied by the runtime.
+
+**Listing:** Assemble an independent shop dispatcher from the functions you have built.
+
+```python
+def build_tools(shop):
+    rows = {row["sku"]: copy.deepcopy(row) for row in shop["products"]}
+    if len(rows) != len(shop["products"]):
+        raise ValueError("duplicate product identity")
+
+    def stock(_):
+        return [
+            {**row, "needed": max(0, row["reorder_point"] - row["on_hand"])}
+            for _, row in sorted(rows.items())
+        ]
+
+    def quote(args):
+        if args.sku not in rows:
+            raise KeyError("unknown product")
+        return {
+            "sku": args.sku,
+            "supplier": "lucy-local",
+            "currency": "GBP",
+            "unit_cost_pence": PRICES[args.sku],
+        }
+
+    def draft(args):
+        row = rows[args.sku]
+        needed = max(0, row["reorder_point"] - row["on_hand"])
+        if args.quantity != needed:
+            raise ValueError("quantity differs from the replenishment need")
+        price = quote(ProductArguments(sku=args.sku))
+        return {
+            **price,
+            "quantity": args.quantity,
+            "total_pence": args.quantity * price["unit_cost_pence"],
+            "status": "DRAFT",
+        }
+
+    registered = [
+        ExecutableTool("list_stock", "Read stock and calculated need.", NoArguments, stock),
+        ExecutableTool("supplier", "Read supplier price in GBP pence.", ProductArguments, quote),
+        ExecutableTool("draft_order", "Calculate a draft; never purchases.", DraftArguments, draft),
+    ]
+    return Dispatcher(registered, allowed=frozenset(tool.name for tool in registered))
+
+
+fresh = build_tools(SHOP)
+print(
+    fresh.invoke(
+        ToolCall(id="check", name="draft_order", arguments={"sku": "SKU-VANILLA", "quantity": 6})
+    )["value"]["total_pence"]
+)
+```
+
+```text
+1500
+```
+
+Copy `build_tools` into the same learner file. Importing that file defines code and loads the synthetic fixture; it does not run the failure experiments or contact a model. Try two dispatchers with different stock dictionaries to verify that one experiment cannot change the other's fixture.
 
 ## Prove that a write check runs first
 
@@ -479,6 +544,14 @@ From the repository root, run the checkpoint using the environment established i
 ```bash
 uv run python book/always_on/checkpoints/ch02.py
 uv run python scripts/verify_always_on_v1.py
+```
+
+The first command prints the following output:
+
+```text
+[('SKU-CHOCOLATE', 0), ('SKU-STRAWBERRY', 4), ('SKU-VANILLA', 6)]
+{"ok": true, "value": {"currency": "GBP", "quantity": 6, "sku": "SKU-VANILLA", "status": "DRAFT", "supplier": "lucy-local", "total_pence": 1500, "unit_cost_pence": 250}}
+{"error": "invalid_arguments", "ok": false}
 ```
 
 The first command prints the three calculated needs, a successful vanilla draft, and an invalid-argument refusal. The second executes the drafted chapters' Python examples and compares their printed output with the adjacent expected-output blocks. It also runs each standalone checkpoint. Its construction report identifies chapters that remain planned; it does not certify unwritten chapters.

--- a/book/always_on/ch03_agent_loop/README.md
+++ b/book/always_on/ch03_agent_loop/README.md
@@ -12,6 +12,12 @@ Build the model–tool–observation cycle in Python, retain an inspectable tran
 
 Your first successful run will execute three model calls and three tool calls, producing vanilla and strawberry drafts totalling 2,600 pence. You will then provoke repeated identifiers, exhausted budgets, and a model failure. Each experiment must end with a specific status instead of hanging or silently pretending to finish Lucy's task.
 
+## Keep your implementation in a file
+
+Continue from the repository root. Create `book/always_on/learner/ch03.py` and save this chapter's imports, class and function definitions, plus the assignments to `shop_tools`, `ToolCall`, `first` and `messages`. Run the print statements and failure experiments separately. Chapter 2's learner file supplies the dispatcher and request type you constructed. The completed learner files are included for comparison, and the Chapter 3 checkpoint loads your learner file, so changing its loop changes both the offline and live commands.
+
+The only supplied runtime component used by the live path is the bounded HTTP transport, identified and explained below. The loop, request parsing, tool schemas and tool dispatcher are all code you write in Chapters 2 and 3.
+
 ## Give one model call a precise contract
 
 A model call is one request to a provider. A model turn may contain an answer, one or more tool requests, or both explanatory text and requests. A whole agent run can contain several such turns. Keeping these units separate prevents a provider adapter from quietly taking control of the entire task.
@@ -30,9 +36,12 @@ import runpy
 import time
 from dataclasses import dataclass
 
-from sovereign_agent.model_turn import ModelError, ToolCall
+shop_tools = runpy.run_path("book/always_on/learner/ch02.py")
+ToolCall = shop_tools["ToolCall"]
 
-shop_tools = runpy.run_path("book/always_on/checkpoints/ch02.py")
+
+class ModelError(RuntimeError):
+    """A sanitized model transport or response failure."""
 
 
 @dataclass(frozen=True)
@@ -486,9 +495,9 @@ sequenceDiagram
 
 **Figure:** The client bounds how long it waits and how much it reads. Terminating the client cannot cancel remote generation or billing already underway.
 
-The complete transport lives in `src/sovereign_agent/http_transport.py`; the provider-specific payload and response parser live in `src/sovereign_agent/model_turn.py`. Inspect the calls to `subprocess.run`, `response.read(maximum + 1)`, and the redirect handler together. They control elapsed waiting, response size, and unexpected credential forwarding respectively. None of them makes the remote service trustworthy.
+The supplied transport lives in `src/sovereign_agent/http_transport.py`. We build the provider-specific payload and response parser in the next section; `src/sovereign_agent/model_turn.py` is the installed adapter for comparison after you finish. Inspect the calls to `subprocess.run`, `response.read(maximum + 1)`, and the redirect handler together. They control elapsed waiting, response size, and unexpected credential forwarding respectively. None of them makes the remote service trustworthy.
 
-Credentials pass through the child's standard input rather than command-line arguments. Its environment includes only the explicitly selected path and certificate settings, and raw request errors are not copied into the model transcript. Redirects are refused instead of allowing an endpoint to forward an authorization header elsewhere. The configured endpoint is operator-owned; generated text cannot replace it.
+Credentials pass through the child's standard input rather than command-line arguments. Its environment includes only the explicitly selected path and certificate settings; proxy variables and `PYTHONPATH` are not inherited. This teaching path needs direct network access and the `uv sync` installation from Chapter 1, and raw request errors are not copied into the model transcript. Redirects are refused instead of allowing an endpoint to forward an authorization header elsewhere. The configured endpoint is operator-owned; generated text cannot replace it.
 
 Process creation and operating-system scheduling are not hard real-time services. The timeout bounds the waiting strategy; it is not a promise that a host under arbitrary load will report a result at an exact millisecond. Similarly, a provider that continues after client termination may still have an unknown billed outcome. Later chapters reuse this distinction when the remote operation is an order.
 
@@ -516,6 +525,106 @@ STOP_REQUESTED 0
 ```
 
 The stop callback is cooperative. It prevents another step at the loop's check points; it does not undo an operation already in flight. When we install a long-running service, a termination signal will set this stop state, and the worker will preserve any uncertain external outcome for recovery.
+
+## Build the tool-capable HTTP adapter
+
+Chapter 1 sent text and read text. Our adapter must now send the schemas and preserve generated tool identities. Add this class to your learner file. Its optional `request` argument accepts a transport function; an authored response can therefore exercise the parser without a model server. When omitted, it uses the bounded transport discussed above. It deliberately targets the one local endpoint from Chapter 1; remote endpoint validation and credentials belong to the provider extension appendix.
+
+**Listing:** Translate one HTTP response into a model turn without executing its requests.
+
+```python
+class HTTPModel:
+    """One local Ollama response; never executes tools itself."""
+
+    def __init__(self, model="qwen3", request=None):
+        self.model, self.request = model, request
+
+    def complete(self, messages, tools, *, timeout, max_output_tokens):
+        transport = self.request
+        if transport is None:
+            from sovereign_agent.http_transport import request
+
+            transport = request
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "tools": tools,
+            "stream": False,
+            "max_tokens": max_output_tokens,
+            "temperature": 0,
+            "reasoning_effort": "none",
+        }
+        try:
+            response = transport(
+                "http://localhost:11434/v1/chat/completions",
+                data=json.dumps(payload).encode(),
+                headers={"Content-Type": "application/json"},
+                timeout=timeout,
+            )
+            if response.status != 200:
+                raise ModelError("model HTTP request failed")
+            envelope = json.loads(response.body)
+            choices, usage = envelope["choices"], envelope["usage"]
+            if not isinstance(choices, list) or len(choices) != 1:
+                raise ModelError("one complete choice required")
+            choice = choices[0]
+            message = choice["message"]
+            if choice["finish_reason"] not in {"stop", "tool_calls"} or message.get("refusal"):
+                raise ModelError("incomplete or refused response")
+            requested = message.get("tool_calls", [])
+            if not isinstance(requested, list) or len(requested) > 32:
+                raise ModelError("bounded tool-call array required")
+            calls = tuple(
+                ToolCall(
+                    id=item["id"],
+                    name=item["function"]["name"],
+                    arguments=json.loads(item["function"]["arguments"]),
+                )
+                for item in requested
+            )
+            content = message.get("content")
+            content = "" if content is None else content
+            tokens = usage["completion_tokens"]
+            if (
+                not isinstance(content, str)
+                or type(tokens) is not int
+                or not 0 <= tokens <= max_output_tokens
+            ):
+                raise ModelError("invalid content or usage")
+            return ModelTurn(content, calls, tokens)
+        except OSError, ValueError, KeyError, IndexError, TypeError, AttributeError:
+            raise ModelError("model transport or response validation failed") from None
+
+
+from types import SimpleNamespace
+
+payloads = []
+
+
+def authored_http(url, *, data, headers, timeout):
+    payloads.append(json.loads(data))
+    return SimpleNamespace(
+        status=200,
+        body=json.dumps(
+            {
+                "choices": [{"finish_reason": "tool_calls", "message": first.message()}],
+                "usage": {"completion_tokens": 12},
+            }
+        ).encode(),
+    )
+
+
+parsed = HTTPModel(request=authored_http).complete(
+    messages, dispatcher.schemas(), timeout=2, max_output_tokens=100
+)
+print(parsed.calls[0].name, parsed.output_tokens, len(payloads[0]["tools"]))
+```
+
+```text
+list_stock 12 3
+```
+
+The response's `arguments` string is decoded before `ToolCall` validates the envelope. The dispatcher still validates operation-specific arguments before invoking the handler. A truncated completion, a non-object argument value, or an impossible usage count fails at this boundary. Replace `"{}"` with `"broken JSON"` in an authored call and observe `MODEL_FAILED` through your loop with zero handler invocations. Then supply a complete final answer to demonstrate that the parser can finish a run without a tool request.
 
 ## Replace the replay with a live model
 

--- a/book/always_on/ch06_messaging/README.md
+++ b/book/always_on/ch06_messaging/README.md
@@ -609,6 +609,14 @@ phone results: 2
 
 The offline model does not interpret the formatting preference; it supplies authored responses to test the data flow. We checked that the selected context contained the preference, while the transcript checker verifies the draft operations. Only a live model run and a reading of its answer can assess how well it follows the requested format. Avoid collapsing those observations into a single claim that the agent “understands Lucy.”
 
+## Give each report its own identity
+
+A single request may produce an approval report and, later, a confirmed-order report. They need separate delivery records. If we keep one `delivery` flag on the work row, sending the first report sets it to `SENT`; replacing the text with the final result can then suppress that result forever. Resetting the flag is also unsafe: an acknowledgement still in flight for the old text could mark the new text sent.
+
+The installed schema therefore has an `assistant_reports` outbox. Each row stores an increasing `id`, its `work_id`, the work status at publication, an immutable `body`, channel and recipient, and its own delivery state and receipt. The `assistant_report_finish` trigger appends a row in the same transaction that records a changed terminal result. Identical consecutive blocked reports reuse the last report instead of generating a message on every reconciliation pass. A database trigger refuses edits to the report identity, body or destination.
+
+Inspect migration 26 in `src/sovereign_agent/assistant_schema.py` alongside `finish`: the outbox insert and finished work commit together. New rejected intake and cancellation also create reports. The old `assistant_work.delivery` column is now only a projection of the newest report; delivery code and health accounting read the outbox. Historical uncertain reports remain visible even after a later report succeeds. Migration preserves existing delivery states; it cannot reconstruct reports that an older version already overwrote.
+
 ## Treat report delivery as an external effect
 
 There are two state machines in this chapter: execution of the work and delivery of its result. A work record can be `DONE` while its report is still `PENDING`. A report can become `UNKNOWN` even though the stock calculation completed correctly. Keeping those states separate helps the operator distinguish “the agent did not finish” from “the agent finished, but I may not have received its answer.”
@@ -630,22 +638,23 @@ def deliver_one(db: Database, bot: Bot, operators: frozenset[int]) -> str | None
     _check_operators(operators)
     with db.immediate() as connection:
         row = connection.execute(
-            "SELECT * FROM assistant_work WHERE channel=? AND "
-            "status IN ('DONE','BLOCKED','CANCELLED','REJECTED') AND delivery='PENDING' "
-            "ORDER BY created LIMIT 1",
+            "SELECT * FROM assistant_reports WHERE channel=? AND delivery='PENDING' "
+            "ORDER BY id LIMIT 1",
             ("telegram:" + bot.account,),
         ).fetchone()
         if row is None:
             return None
         if not row["recipient"].isdigit() or int(row["recipient"]) not in operators:
             connection.execute(
-                "UPDATE assistant_work SET delivery='DENIED' WHERE id=?", (row["id"],)
+                "UPDATE assistant_reports SET delivery='DENIED' WHERE id=?", (row["id"],)
             )
             return "DENIED"
         # A crash after this commit is ambiguous, even if no HTTP call happened.
-        connection.execute("UPDATE assistant_work SET delivery='SENDING' WHERE id=?", (row["id"],))
+        connection.execute(
+            "UPDATE assistant_reports SET delivery='SENDING' WHERE id=?", (row["id"],)
+        )
     try:
-        text = row["result"] or "Work ended without a report."
+        text = row["body"]
         if len(text) > 3900:
             text = text[:3800] + "\n[Report truncated; request a shorter report.]"
         result = bot.call("sendMessage", {"chat_id": int(row["recipient"]), "text": text})
@@ -660,8 +669,12 @@ def deliver_one(db: Database, bot: Bot, operators: frozenset[int]) -> str | None
         status = "UNKNOWN"
     with db.immediate() as connection:
         updated = connection.execute(
-            "UPDATE assistant_work SET delivery=? WHERE id=? AND delivery='SENDING'",
-            (status, row["id"]),
+            "UPDATE assistant_reports SET delivery=?,receipt=? WHERE id=? AND delivery='SENDING'",
+            (
+                status,
+                json.dumps({"message_id": result["message_id"]}) if status == "SENT" else None,
+                row["id"],
+            ),
         )
         if not updated.rowcount:
             return "UNKNOWN"
@@ -670,7 +683,8 @@ def deliver_one(db: Database, bot: Bot, operators: frozenset[int]) -> str | None
                 db,
                 "assistant.channel.sent",
                 {
-                    "work": row["id"],
+                    "work": row["work_id"],
+                    "report": row["id"],
                     "channel": row["channel"],
                     "recipient": row["recipient"],
                     "message_id": result["message_id"],
@@ -698,11 +712,11 @@ further automatic delivery: None
 recorded successful message: 902
 ```
 
-The fixture accepted the first report before losing the reply. We know that because we control the local bot's list. The runtime only sees the timeout, so it correctly records `UNKNOWN`. The second report belongs to the second request and receives a valid receipt. It is not a retry of the first report. This distinction is why a global count of sent messages cannot substitute for per-work delivery state.
+The fixture accepted the first report before losing the reply. We know that because we control the local bot's list. The runtime only sees the timeout, so it correctly records `UNKNOWN`. The second report belongs to the second request and receives a valid receipt. It is not a retry of the first report. This distinction is why a global count of sent messages cannot substitute for per-report delivery state.
 
 The update to `SENT` and the receipt event share a transaction. If recording the event fails, the earlier `SENDING` admission remains, leaving the attempt visibly uncertain. If restore or another recovery action changed the delivery state before this completion arrived, the conditional update affects no row and no stale success event is appended. An old network response does not get to overwrite a new local decision.
 
-Our event retains only the work identifier, channel, requested recipient and message identifier. It does not copy the raw server response or bot credential. The message identifier is a delivery receipt from the service; it is not proof that Lucy read the report. A handset observation remains necessary for the user-facing result, and natural-language correctness still needs its own evaluation.
+Our event retains the work and report identifiers, channel, requested recipient and message identifier. It does not copy the raw server response or bot credential. The message identifier is a delivery receipt from the service; it is not proof that Lucy read the report. A handset observation remains necessary for the user-facing result, and natural-language correctness still needs its own evaluation.
 
 ```mermaid
 stateDiagram-v2
@@ -842,6 +856,14 @@ Hold the first work claim while a second request arrives in the same private ses
 ### Exercise 4: Delivery after local state changes
 
 Change an admitted report's delivery state to `UNKNOWN` before a late successful API response returns. Confirm that the old completion does not append a new success event or overwrite the changed state. Explain what the fixture knows about remote acceptance, what the runtime can record safely, and why the operator may still need to inspect the actual conversation.
+
+## Operating limits of the teaching channel
+
+Use one bot account with one active installation database. The poller lease coordinates processes sharing that database; it cannot coordinate two independent installations using the same token. Stop the other installation if Telegram reports a competing poller or webhook conflict. Never try to solve that conflict by deleting the local cursor.
+
+A malformed batch is refused atomically and retried with bounded backoff. If the same malformed payload persists, intake stays blocked until the provider or adapter is repaired. This teaching implementation deliberately does not skip a whole batch after a retry count: that would silently discard valid messages alongside the malformed member. Stop polling, preserve the cursor and diagnostic context without the token, correct the parser against a retained synthetic reproduction, and resume at the same cursor. Local status, approval and receipt commands remain available during this channel outage.
+
+An outbound `UNKNOWN` or interrupted `SENDING` report is not automatically replayed, and this version has no operator resend command. Inspect the actual conversation and use `agent report` locally for the current account state. A later changed business result gets a new report identity; it does not erase the earlier uncertainty or pretend that Lucy read it. This conservative policy favors avoiding duplicate unsolicited messages over guaranteed delivery.
 
 ## Active recall
 

--- a/book/always_on/ch07_scheduling/README.md
+++ b/book/always_on/ch07_scheduling/README.md
@@ -221,20 +221,29 @@ def tick(db: Database, *, now: float | None = None, maximum: int = 100) -> list[
             (now, maximum),
         ).fetchall()
         for row in rows:
-            identifier = _enqueue(
-                connection,
-                f"job:{row['id']}:{row['next_due']!r}",
-                row["session"],
-                row["prompt"],
-                now,
-                row["channel"],
-                row["recipient"],
-            )
+            try:
+                identifier = _enqueue(
+                    connection,
+                    f"job:{row['id']}:{row['next_due']!r}",
+                    row["session"],
+                    row["prompt"],
+                    now,
+                    row["channel"],
+                    row["recipient"],
+                    require_admission=True,
+                )
+            except IntakeLimitError:
+                if not row["deferred"]:
+                    append_event(db, "assistant.job.deferred", {"job": row["id"]})
+                    connection.execute(
+                        "UPDATE assistant_jobs SET deferred=1 WHERE id=?", (row["id"],)
+                    )
+                continue
             created.append(identifier)
             skipped = math.floor((now - row["next_due"]) / row["interval_seconds"])
             next_due = row["next_due"] + (skipped + 1) * row["interval_seconds"]
             connection.execute(
-                "UPDATE assistant_jobs SET next_due=? WHERE id=?", (next_due, row["id"])
+                "UPDATE assistant_jobs SET next_due=?,deferred=0 WHERE id=?", (next_due, row["id"])
             )
             append_event(
                 db,
@@ -298,9 +307,9 @@ Disabled pass: []
 Earlier work retained: 2
 ```
 
-The current intake policy allows twenty pending ordinary items and fifty ordinary admissions per session per UTC day. A periodic tick that exceeds admission capacity records a `REJECTED` work item and still advances its schedule. This avoids retrying the same morning report indefinitely; the next scheduled occurrence is another opportunity. Therefore a returned identifier means a work record exists, not necessarily that it is eligible to run.
+The current intake policy allows twenty pending ordinary items and fifty ordinary admissions per session per UTC day. A saturated periodic tick requests strict admission, leaves its due time unchanged and records one `assistant.job.deferred` event. Repeated passes create neither rejected work nor repeated phone notices. When capacity returns, the scheduler admits one current report, coalesces missed occurrences and advances from the original due time.
 
-Stock conditions use a different choice shortly: a capacity refusal leaves the condition armed so it can be admitted later. The distinction is deliberate. “Give me this morning's brief” can be overtaken by the next brief. “This SKU still needs attention” remains relevant until its observed condition changes. In both cases the operator can inspect stored state instead of inferring success from a quiet terminal.
+Stock conditions use strict admission too: a capacity refusal leaves the condition armed for a later pass. Clock jobs retain their earliest due time, while stock conditions retain their observed need. Both preserve pending work without manufacturing a queue of rejection reports.
 
 ## Turn a stock shortage into one episode
 
@@ -688,7 +697,7 @@ Create a job due at 100 with interval ten and observe it at 140. Predict the coa
 
 ### Exercise 2 — Fill the intake queue
 
-Fill a session to the pending-work limit and run both a due clock job and an armed vanilla condition. Inspect the rejected clock record, its advanced due time and the still-armed condition. Free capacity through a legitimate terminal transition, then rescan. Explain why only one new condition episode should be admitted. Repeat the observation without freeing capacity and confirm that the scanner does not generate rejected rows on every pass.
+Fill a session to the pending-work limit and run both a due clock job and an armed vanilla condition. Inspect the absence of a rejected clock record, its unchanged due time and the still-armed condition. Free capacity through a legitimate terminal transition, then rescan. Explain why one coalesced clock occurrence and one new condition episode should be admitted when enough capacity is available. Repeat the observation without freeing capacity and confirm that the scanner does not generate rejected rows on every pass.
 
 ### Exercise 3 — Hide an intermediate stock recovery
 

--- a/book/always_on/ch09_ambiguous_order/README.md
+++ b/book/always_on/ch09_ambiguous_order/README.md
@@ -46,6 +46,7 @@ Our local states describe both progress and knowledge. `SENDING` means the agent
 | `SENDING` | Transmission admitted durably | Reserved |
 | `UNKNOWN` | Remote outcome not conclusively known | Reserved |
 | `CONFIRMED` | Matching supplier acceptance recorded | Spent |
+| `DELIVERED` | Acceptance plus a separately observed stock delivery | Spent; physical stock credited once |
 | `REJECTED` | Matching conclusive rejection recorded | Reservation released |
 
 There is also `REVOKED` for an eligible proposal whose permission was withdrawn before sending. Revoking an uncertain order prevents a newly authorized send; it does not erase the possibility that the supplier already accepted the earlier one. We still need to discover its outcome and settle the accounts accordingly.
@@ -223,7 +224,9 @@ def record_receipt(db, work, identifier, receipt):
             raise ValueError("receipt does not match the exact intent")
         if receipt.get("status") not in {"ACCEPTED", "REJECTED"}:
             raise ValueError("supplier outcome is not conclusive")
-        if row["status"] in {"CONFIRMED", "REJECTED"}:
+        if row["status"] in {"CONFIRMED", "DELIVERED", "REJECTED"}:
+            if receipt["status"] != json.loads(row["receipt"])["status"]:
+                raise ValueError("receipt contradicts the recorded outcome")
             return json.loads(row["receipt"])
         if row["status"] not in {"SENDING", "UNKNOWN"}:
             raise PermissionError("order was not admitted for transmission")
@@ -267,7 +270,7 @@ def execute_order(db, work, identifier, supplier, *, policy):
     assert_current(db.connection, work)
     if row["target"] != supplier.identity:
         raise PermissionError("supplier destination differs from approved proposal")
-    if row["status"] in {"CONFIRMED", "REJECTED"}:
+    if row["status"] in {"CONFIRMED", "DELIVERED", "REJECTED"}:
         return json.loads(row["receipt"])
     if row["status"] in {"SENDING", "UNKNOWN"}:
         try:
@@ -375,6 +378,12 @@ print(
     ],
 )
 print("same receipt", execute_order(db, work, identifier, supplier, policy=policy) == recovered)
+print(
+    "settlement events",
+    db.connection.execute(
+        "SELECT count(*) FROM events WHERE kind='assistant.order.reconciled'"
+    ).fetchone()[0],
+)
 ```
 
 ```text
@@ -384,11 +393,22 @@ reserved and spent (1500, 0)
 ACCEPTED sends 1 lookups 1
 reserved and spent (0, 1500)
 same receipt True
+settlement events 1
 ```
 
 The second execution performed a lookup, not another send. The third returned the stored receipt. The accepted purchase consumed 1,500 pence once, and the reservation is now zero. A second settlement would incorrectly subtract the reservation again or double the spent total; the terminal-state check prevents that transition.
 
 The supplier's accepted order does not mean six tubs physically arrived at the shop. Confirmation belongs to order accounting. Receiving stock is a separate observed business event. Until a delivery is recorded, physical inventory remains unchanged and the confirmed order represents incoming stock.
+
+## Give uncertainty an operator path
+
+An expired approval forbids a new send; it does not erase an earlier send. For an `UNKNOWN` order or a `SENDING` order left by a crash at our idempotent supplier, Lucy can renew the exact existing approval with `agent approve ORDER --digest DIGEST --supplier ENDPOINT`. The approval code checks the configured supplier identity and idempotency contract, the current operator, cancellation, revocation and cumulative ceiling. It retains the same operation ID, proposal, digest and reservation, and retains that uncertain state so the next execution must still look up the old operation first. Automatic policy cannot renew an uncertain order.
+
+When discovery cannot establish the result, obtain a conclusive receipt from the supplier through a separate operator interaction. The ordinary local `agent resolve-order` command accepts a receipt JSON file containing the original `operation`, exact `proposal` and `status` of `ACCEPTED` or `REJECTED`. Supply `--digest`, the exact stored target through `--supplier`, `--actor`, `--receipt` and a bounded `--evidence` reference. The command checks those values in one transaction, uses the same receipt settlement logic and records who supplied the evidence. Repeating the same resolution makes no second accounting transition.
+
+`REJECTED` means the supplier has irrevocably closed that operation, including any delayed request; “not found” does not meet that contract. A support search result, an expired local lease or an operator's guess is insufficient. If the supplier cannot provide conclusive evidence or safely close the operation, retain `UNKNOWN` and its reservation. The system cannot manufacture a truthful resolution. This path trusts an explicitly authorized operator's attestation; it does not cryptographically authenticate a pasted document and is never exposed as a model tool.
+
+Revoked or cancelled uncertain work can still receive a conclusive receipt, because it may describe an effect already committed. It cannot acquire fresh retry authority. A mismatched or contradictory receipt is refused with the reservation or prior outcome unchanged. A restored database remains subject to Chapter 15's separate account-wide recovery; the ordinary resolution command cannot bypass that pause.
 
 ## Refuse an unjustified retry
 
@@ -454,7 +474,7 @@ flowchart TD
     A -->|Yes| S[Resend same identity and proposal]
 ```
 
-**Figure:** An empty lookup becomes a retry opportunity only under an explicit provider guarantee and current authority. It never justifies a new operation identity.
+**Figure:** An empty lookup becomes a retry opportunity only under an explicit provider guarantee and current authority. Failed authority checks raise `PermissionError` while the durable row remains `UNKNOWN`; they do not create a replacement identity.
 
 ### Failure experiment: a plausible but mismatched receipt
 
@@ -487,6 +507,8 @@ Keeping physical stock at two is part of the expected result. An order receipt p
 ## Run the independent HTTP failure experiment
 
 The standalone checkpoint in `book/always_on/checkpoints/ch09.py` uses the cumulative `assistant_orders` implementation, whose admission and reconciliation mechanism you have built above. It starts the simulated supplier as a separate Python process, with a separate SQLite file and an operating-system-assigned loopback port.
+
+An HTTP 409 from the fixture signals a conflicting identity or supplier authority. The adapter conservatively exposes it as a transport failure, leaving local uncertainty; inspect the supplier account and exact proposal instead of changing the operation ID to evade the conflict.
 
 The supplier's `--drop-first-response` option closes the connection after committing the first receipt for each new operation. Looking up that operation still returns the persisted receipt, and resubmitting the same identity returns the existing outcome. The failure is placed after the database commit, so this is an actual lost-response experiment rather than a timeout raised before any effect happened.
 

--- a/book/always_on/ch15_operation/README.md
+++ b/book/always_on/ch15_operation/README.md
@@ -343,6 +343,8 @@ sequenceDiagram
 
 **Figure:** A restored snapshot remains paused until external receipts and current observations establish a new operating state.
 
+If the final SQLite copy fails after the authority marker changes, the active database remains paused and its marker may disagree with its stored epoch. Stop the service, repair the underlying disk or lock problem, then rerun `agent restore` with the same checked snapshot. Restore does not require an active matching epoch and can safely prepare a fresh paused image on retry. Never delete the marker or manually unpause to bypass the mismatch; old holders must remain fenced. Complete the account reconciliation described below after the retry succeeds.
+
 The restore function constructs a prepared image before disturbing active state. It requires the same migration set as the current database. An older snapshot must be migrated as a copy with reviewed current code; preserve the original as evidence. Removing migration stamps to force compatibility would conceal the very fact the precondition is checking.
 
 ```python

--- a/book/always_on/checkpoints/ch01.py
+++ b/book/always_on/checkpoints/ch01.py
@@ -92,7 +92,14 @@ def main():
     parser.add_argument("--model", default="qwen3")
     args = parser.parse_args()
     body = payload(SHOP, args.model)
-    document = live_call(body) if args.live else OFFLINE_RESPONSE
+    try:
+        document = live_call(body) if args.live else OFFLINE_RESPONSE
+    except OSError, ValueError:
+        parser.exit(
+            1,
+            "Model call failed. Start Ollama and pull the selected model; "
+            "check the Chapter 1 setup, then retry. No order was sent.\n",
+        )
     print("LIVE MODEL RESPONSE" if args.live else "OFFLINE RESPONSE FIXTURE")
     print(read_brief(document))
 

--- a/book/always_on/checkpoints/ch03.py
+++ b/book/always_on/checkpoints/ch03.py
@@ -5,10 +5,12 @@ import json
 import runpy
 from pathlib import Path
 
-from sovereign_agent.agent_loop import Limits, run_loop
-from sovereign_agent.model_turn import HTTPModel, ModelError, ModelTurn, ToolCall
+LEARNER = runpy.run_path(str(Path(__file__).resolve().parents[1] / "learner/ch03.py"))
+Limits, run_loop = LEARNER["Limits"], LEARNER["run_loop"]
+HTTPModel, ModelError = LEARNER["HTTPModel"], LEARNER["ModelError"]
+ModelTurn, ToolCall = LEARNER["ModelTurn"], LEARNER["ToolCall"]
 
-SHOP_TOOLS = runpy.run_path(str(Path(__file__).with_name("ch02.py")))
+SHOP_TOOLS = LEARNER["shop_tools"]
 MESSAGES = [
     {
         "role": "system",
@@ -90,11 +92,7 @@ def main():
     parser.add_argument("--model", default="qwen3")
     parser.add_argument("--transcript", action="store_true")
     args = parser.parse_args()
-    model = (
-        HTTPModel(model=args.model, reasoning_effort="none")
-        if args.live
-        else ReplayModel(opening_turns())
-    )
+    model = HTTPModel(model=args.model) if args.live else ReplayModel(opening_turns())
     dispatcher = SHOP_TOOLS["build_tools"](SHOP_TOOLS["SHOP"])
     result = run_loop(model, dispatcher, MESSAGES, limits=Limits())
     print(result.status, result.model_calls, result.tool_calls)

--- a/book/always_on/learner/ch02.py
+++ b/book/always_on/learner/ch02.py
@@ -1,0 +1,177 @@
+"""Definitions constructed in Chapter 2; experiments remain in the chapter."""
+
+import copy
+import json
+import runpy
+from collections.abc import Callable
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+SHOP = runpy.run_path("book/always_on/checkpoints/ch01.py")["SHOP"]
+
+
+PRICES = {"SKU-VANILLA": 250, "SKU-CHOCOLATE": 300, "SKU-STRAWBERRY": 275}
+
+
+products = {row["sku"]: copy.deepcopy(row) for row in SHOP["products"]}
+
+
+class NoArguments(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class ProductArguments(NoArguments):
+    sku: str = Field(min_length=1, max_length=100)
+
+
+class DraftArguments(ProductArguments):
+    quantity: int = Field(gt=0, le=1000)
+
+
+def list_stock(_):
+    return [
+        {**row, "needed": max(0, row["reorder_point"] - row["on_hand"])}
+        for _, row in sorted(products.items())
+    ]
+
+
+def supplier(args):
+    if args.sku not in products:
+        raise KeyError("unknown product")
+    return {
+        "sku": args.sku,
+        "supplier": "lucy-local",
+        "currency": "GBP",
+        "unit_cost_pence": PRICES[args.sku],
+    }
+
+
+def draft_order(args):
+    row = products[args.sku]
+    needed = max(0, row["reorder_point"] - row["on_hand"])
+    if args.quantity != needed:
+        raise ValueError("quantity differs from the replenishment need")
+    quote = supplier(ProductArguments(sku=args.sku))
+    return {
+        **quote,
+        "quantity": args.quantity,
+        "total_pence": args.quantity * quote["unit_cost_pence"],
+        "status": "DRAFT",
+    }
+
+
+@dataclass(frozen=True)
+class ExecutableTool:
+    name: str
+    description: str
+    arguments: type[BaseModel]
+    handler: Callable[[Any], Any]
+    consequential: bool = False
+
+    def schema(self):
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.arguments.model_json_schema(),
+            },
+        }
+
+
+tools = [
+    ExecutableTool(
+        "list_stock", "Read stock and calculated replenishment need.", NoArguments, list_stock
+    ),
+    ExecutableTool("supplier", "Read a supplier quote in GBP pence.", ProductArguments, supplier),
+    ExecutableTool(
+        "draft_order", "Calculate a draft; never purchases.", DraftArguments, draft_order
+    ),
+]
+
+
+class ToolCall(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+    id: str = Field(min_length=1, max_length=200)
+    name: str = Field(min_length=1, max_length=100, pattern=r"^[a-zA-Z0-9_-]+$")
+    arguments: dict[str, Any]
+
+
+class Dispatcher:
+    def __init__(self, tools, *, allowed, before_write=None, max_result_bytes=16_384):
+        self.tools = MappingProxyType({tool.name: tool for tool in tools})
+        if len(self.tools) != len(tools):
+            raise ValueError("tool names must be unique")
+        if not 128 <= max_result_bytes <= 1_048_576:
+            raise ValueError("invalid tool result byte limit")
+        self.allowed, self.before_write = allowed, before_write
+        self.max_result_bytes = max_result_bytes
+
+    def schemas(self):
+        return [tool.schema() for name, tool in sorted(self.tools.items()) if name in self.allowed]
+
+    def invoke(self, call):
+        tool = self.tools.get(call.name)
+        if tool is None or call.name not in self.allowed:
+            return {"ok": False, "error": "tool_not_allowed"}
+        try:
+            arguments = tool.arguments.model_validate(call.arguments, strict=True)
+        except ValidationError:
+            return {"ok": False, "error": "invalid_arguments"}
+        if tool.consequential and self.before_write is None:
+            return {"ok": False, "error": "write_authority_required"}
+        try:
+            if tool.consequential:
+                self.before_write(call)
+            value = tool.handler(arguments)
+            encoded = json.dumps(value, allow_nan=False)
+            if len(encoded.encode()) > self.max_result_bytes:
+                return {"ok": False, "error": "result_too_large"}
+            return {"ok": True, "value": value}
+        except ValueError, TypeError, KeyError, PermissionError, TimeoutError, OSError:
+            return {"ok": False, "error": "tool_failed"}
+
+
+def build_tools(shop):
+    rows = {row["sku"]: copy.deepcopy(row) for row in shop["products"]}
+    if len(rows) != len(shop["products"]):
+        raise ValueError("duplicate product identity")
+
+    def stock(_):
+        return [
+            {**row, "needed": max(0, row["reorder_point"] - row["on_hand"])}
+            for _, row in sorted(rows.items())
+        ]
+
+    def quote(args):
+        if args.sku not in rows:
+            raise KeyError("unknown product")
+        return {
+            "sku": args.sku,
+            "supplier": "lucy-local",
+            "currency": "GBP",
+            "unit_cost_pence": PRICES[args.sku],
+        }
+
+    def draft(args):
+        row = rows[args.sku]
+        needed = max(0, row["reorder_point"] - row["on_hand"])
+        if args.quantity != needed:
+            raise ValueError("quantity differs from the replenishment need")
+        price = quote(ProductArguments(sku=args.sku))
+        return {
+            **price,
+            "quantity": args.quantity,
+            "total_pence": args.quantity * price["unit_cost_pence"],
+            "status": "DRAFT",
+        }
+
+    registered = [
+        ExecutableTool("list_stock", "Read stock and calculated need.", NoArguments, stock),
+        ExecutableTool("supplier", "Read supplier price in GBP pence.", ProductArguments, quote),
+        ExecutableTool("draft_order", "Calculate a draft; never purchases.", DraftArguments, draft),
+    ]
+    return Dispatcher(registered, allowed=frozenset(tool.name for tool in registered))

--- a/book/always_on/learner/ch03.py
+++ b/book/always_on/learner/ch03.py
@@ -1,0 +1,283 @@
+"""Definitions constructed in Chapter 3; experiments remain in the chapter."""
+
+import copy
+import json
+import math
+import runpy
+import time
+from dataclasses import dataclass
+
+shop_tools = runpy.run_path("book/always_on/learner/ch02.py")
+
+
+ToolCall = shop_tools["ToolCall"]
+
+
+class ModelError(RuntimeError):
+    """A sanitized model transport or response failure."""
+
+
+@dataclass(frozen=True)
+class ModelTurn:
+    content: str = ""
+    calls: tuple[ToolCall, ...] = ()
+    output_tokens: int = 0
+
+    def message(self):
+        result = {"role": "assistant", "content": self.content}
+        if self.calls:
+            result["tool_calls"] = [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {"name": call.name, "arguments": json.dumps(call.arguments)},
+                }
+                for call in self.calls
+            ]
+        return result
+
+
+first = ModelTurn(calls=(ToolCall(id="stock-1", name="list_stock", arguments={}),))
+
+
+messages = [
+    {
+        "role": "system",
+        "content": "Help Lucy prepare replenishment drafts. First call list_stock. "
+        "For each product with needed > 0, call draft_order with exactly that quantity. "
+        "Do not draft products with needed = 0. Summarize the tool results in GBP pence. "
+        "A verbal recommendation does not replace creating the draft through the tool. "
+        "Drafts are proposals, never purchases.",
+    },
+    {
+        "role": "user",
+        "content": "Prepare replenishment drafts from current stock. State GBP amounts.",
+    },
+]
+
+
+@dataclass(frozen=True)
+class Limits:
+    model_calls: int = 8
+    tool_calls: int = 16
+    seconds: float = 60
+    context_bytes: int = 32_768
+    output_tokens: int = 1_024
+    total_output_tokens: int = 4_096
+    estimated_call_pence: int = 0
+    model_budget_pence: int = 100
+
+    def __post_init__(self):
+        integers = (
+            self.model_calls,
+            self.tool_calls,
+            self.context_bytes,
+            self.output_tokens,
+            self.total_output_tokens,
+            self.model_budget_pence,
+        )
+        if any(type(value) is not int or value <= 0 for value in integers):
+            raise ValueError("positive integral limits required")
+        if not math.isfinite(self.seconds) or self.seconds <= 0:
+            raise ValueError("positive finite duration required")
+        if type(self.estimated_call_pence) is not int or self.estimated_call_pence < 0:
+            raise ValueError("nonnegative integral model estimate required")
+
+
+@dataclass(frozen=True)
+class LoopResult:
+    status: str
+    answer: str
+    messages: list
+    model_calls: int
+    tool_calls: int
+    output_tokens: int
+    estimated_cost_pence: int
+
+
+def run_loop(
+    model, dispatcher, messages, *, limits=None, clock=time.monotonic, should_stop=lambda: False
+):
+    limits = limits or Limits()
+    transcript = copy.deepcopy(messages)
+    deadline = clock() + limits.seconds
+    model_count = tool_count = tokens = exposure = 0
+    seen = set()
+
+    def finish(status, answer=""):
+        return LoopResult(status, answer, transcript, model_count, tool_count, tokens, exposure)
+
+    while model_count < limits.model_calls:
+        if should_stop():
+            return finish("STOP_REQUESTED")
+        if clock() >= deadline:
+            return finish("TIME_LIMIT")
+        schemas = dispatcher.schemas()
+        if len(json.dumps([transcript, schemas]).encode()) > limits.context_bytes:
+            return finish("CONTEXT_LIMIT")
+        remaining = min(limits.output_tokens, limits.total_output_tokens - tokens)
+        if remaining <= 0:
+            return finish("TOKEN_LIMIT")
+        try:
+            if exposure + limits.estimated_call_pence > limits.model_budget_pence:
+                return finish("MODEL_COST_LIMIT")
+            exposure += limits.estimated_call_pence
+            model_count += 1
+            turn = model.complete(
+                copy.deepcopy(transcript),
+                schemas,
+                timeout=deadline - clock(),
+                max_output_tokens=remaining,
+            )
+        except ModelError, TimeoutError, OSError:
+            return finish("MODEL_FAILED")
+        if clock() >= deadline:
+            return finish("TIME_LIMIT")
+        if type(turn.output_tokens) is not int or not 0 <= turn.output_tokens <= remaining:
+            return finish("INVALID_USAGE")
+        tokens += turn.output_tokens
+        ids = [call.id for call in turn.calls]
+        if len(ids) != len(set(ids)) or seen.intersection(ids):
+            return finish("REPEATED_CALL_ID")
+        if tool_count + len(ids) > limits.tool_calls:
+            return finish("TOOL_LIMIT")
+        seen.update(ids)
+        transcript.append(turn.message())
+        if not turn.calls:
+            return (
+                finish("COMPLETED", turn.content) if turn.content.strip() else finish("EMPTY_REPLY")
+            )
+        for call in turn.calls:
+            if should_stop():
+                return finish("STOP_REQUESTED")
+            if clock() >= deadline:
+                return finish("TIME_LIMIT")
+            tool_count += 1
+            result = dispatcher.invoke(call)
+            transcript.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": json.dumps(result, allow_nan=False),
+                }
+            )
+    return finish("MODEL_CALL_LIMIT")
+
+
+class ReplayModel:
+    def __init__(self, turns):
+        self.turns = iter(turns)
+
+    def complete(self, messages, tools, *, timeout, max_output_tokens):
+        try:
+            return next(self.turns)
+        except StopIteration:
+            raise ModelError("response fixture exhausted") from None
+
+
+def opening_turns():
+    return [
+        first,
+        ModelTurn(
+            calls=(
+                ToolCall(
+                    id="draft-v",
+                    name="draft_order",
+                    arguments={"sku": "SKU-VANILLA", "quantity": 6},
+                ),
+                ToolCall(
+                    id="draft-s",
+                    name="draft_order",
+                    arguments={"sku": "SKU-STRAWBERRY", "quantity": 4},
+                ),
+            )
+        ),
+        ModelTurn("Drafts: vanilla 6 tubs, strawberry 4 tubs; total 2600 pence GBP. No purchase."),
+    ]
+
+
+class HTTPModel:
+    """One local Ollama response; never executes tools itself."""
+
+    def __init__(self, model="qwen3", request=None):
+        self.model, self.request = model, request
+
+    def complete(self, messages, tools, *, timeout, max_output_tokens):
+        transport = self.request
+        if transport is None:
+            from sovereign_agent.http_transport import request
+
+            transport = request
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "tools": tools,
+            "stream": False,
+            "max_tokens": max_output_tokens,
+            "temperature": 0,
+            "reasoning_effort": "none",
+        }
+        try:
+            response = transport(
+                "http://localhost:11434/v1/chat/completions",
+                data=json.dumps(payload).encode(),
+                headers={"Content-Type": "application/json"},
+                timeout=timeout,
+            )
+            if response.status != 200:
+                raise ModelError("model HTTP request failed")
+            envelope = json.loads(response.body)
+            choices, usage = envelope["choices"], envelope["usage"]
+            if not isinstance(choices, list) or len(choices) != 1:
+                raise ModelError("one complete choice required")
+            choice = choices[0]
+            message = choice["message"]
+            if choice["finish_reason"] not in {"stop", "tool_calls"} or message.get("refusal"):
+                raise ModelError("incomplete or refused response")
+            requested = message.get("tool_calls", [])
+            if not isinstance(requested, list) or len(requested) > 32:
+                raise ModelError("bounded tool-call array required")
+            calls = tuple(
+                ToolCall(
+                    id=item["id"],
+                    name=item["function"]["name"],
+                    arguments=json.loads(item["function"]["arguments"]),
+                )
+                for item in requested
+            )
+            content = message.get("content")
+            content = "" if content is None else content
+            tokens = usage["completion_tokens"]
+            if (
+                not isinstance(content, str)
+                or type(tokens) is not int
+                or not 0 <= tokens <= max_output_tokens
+            ):
+                raise ModelError("invalid content or usage")
+            return ModelTurn(content, calls, tokens)
+        except OSError, ValueError, KeyError, IndexError, TypeError, AttributeError:
+            raise ModelError("model transport or response validation failed") from None
+
+
+def draft_evidence(result):
+    names = {
+        call["id"]: call["function"]["name"]
+        for message in result.messages
+        for call in message.get("tool_calls", [])
+    }
+    observed = []
+    for message in result.messages:
+        if message["role"] != "tool":
+            continue
+        value = json.loads(message["content"])
+        if value.get("ok") is not True:
+            return False
+        if names.get(message["tool_call_id"]) == "draft_order":
+            draft = value["value"]
+            observed.append(
+                (draft["sku"], draft["quantity"], draft["total_pence"], draft["currency"])
+            )
+    return sorted(observed) == [
+        ("SKU-STRAWBERRY", 4, 1100, "GBP"),
+        ("SKU-VANILLA", 6, 1500, "GBP"),
+    ]

--- a/scripts/verify_publication_v2.py
+++ b/scripts/verify_publication_v2.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Check the source-owned sixteen-chapter publication contract, not editorial quality."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def verify(book: Path) -> None:
+    index = json.loads((book / "BOOK.json").read_text())
+    manifest = json.loads((book / "PUBLICATION.json").read_text())
+    assert manifest["schemaVersion"] == 1 and manifest["edition"] == "always-on-2026"
+    assert manifest["status"] in {"DRAFT", "READY"}
+    assert manifest["title"] == index["title"] and manifest["subtitle"] == index["subtitle"]
+    assert [p["number"] for p in manifest["parts"]] == [1, 2, 3, 4]
+    assert [n for p in manifest["parts"] for n in p["chapters"]] == list(range(1, 17))
+    assert [c["number"] for c in index["chapters"]] == list(range(1, 17))
+    if manifest["status"] == "READY":
+        assert all(c["status"] == "READY" for c in index["chapters"])
+    surfaces = [
+        item
+        for kind in ("frontMatter", "parts", "appendices", "resources")
+        for item in manifest[kind]
+    ]
+    paths: set[str] = set()
+    slugs: set[str] = set()
+    for item in [*index["chapters"], *surfaces]:
+        relative = item["path"]
+        assert re.fullmatch(r"[A-Za-z0-9_./-]+", relative)
+        assert not relative.startswith("/") and not {"", ".", ".."} & set(relative.split("/"))
+        source = book / relative
+        assert source.is_file() and not source.is_symlink(), relative
+        assert source.resolve().is_relative_to(book.resolve()), relative
+        assert relative not in paths, relative
+        paths.add(relative)
+        slug = item.get("slug", relative.split("/")[0].replace("_", "-"))
+        assert re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", slug) and slug not in slugs, slug
+        slugs.add(slug)
+        assert re.search(r"^# .+", source.read_text(), re.M), relative
+    text = "\n".join((book / c["path"]).read_text() for c in index["chapters"])
+    assert text.count("**Figure:**") == manifest["expectedFigures"] == 52
+    assert text.count("**Listing:**") == manifest["expectedListings"] == 99
+
+
+if __name__ == "__main__":
+    verify(ROOT / "book" / "always_on")
+    print("PUBLICATION CONTRACT: 16 chapters, 4 parts, declared surfaces and furniture checked.")
+    print("DRAFT remains draft; this is not editorial acceptance.")

--- a/src/reference_organizations/store/account_recovery.py
+++ b/src/reference_organizations/store/account_recovery.py
@@ -337,7 +337,8 @@ def recover(
             "owner=NULL,expires=NULL WHERE status IN ('READY','RUNNING','BLOCKED')"
         )
         connection.execute(
-            "UPDATE assistant_work SET delivery='UNKNOWN' WHERE delivery IN ('PENDING','SENDING')"
+            "UPDATE assistant_reports SET delivery='UNKNOWN' "
+            "WHERE delivery IN ('PENDING','SENDING')"
         )
         connection.execute("UPDATE assistant_orders SET revoked=1,approved_until=0")
         connection.execute("UPDATE assistant_stock_conditions SET armed=1")

--- a/src/reference_organizations/store/assistant.py
+++ b/src/reference_organizations/store/assistant.py
@@ -77,6 +77,13 @@ def _orders(
         lines.append(f"Order {row['id']}: {row['status']}, {row['amount']} pence.")
         if row["status"] == "DRAFT":
             lines.append(f"Approval required: /approve {row['id']} {row['digest']}")
+        elif row["status"] in {"SENDING", "UNKNOWN"}:
+            lines.append(
+                "Supplier outcome unresolved; spending remains reserved. "
+                "Obtain a conclusive supplier receipt and use agent resolve-order."
+            )
+            if supplier.idempotent and not row["revoked"] and not cancelled:
+                lines.append(f"Renew the same operation only: /approve {row['id']} {row['digest']}")
     answer = "\n".join(lines)
     assistant_work.finish(db, work, state, answer)
     return {"status": state, "work": work.id, "answer": answer}
@@ -118,6 +125,7 @@ def run_once(
                     actor=row["recipient"],
                     policy=policy,
                     expires=row["created"] + 3600,
+                    supplier=supplier,
                 )
                 with db.immediate() as connection:
                     connection.execute(

--- a/src/reference_organizations/store/operating_report.py
+++ b/src/reference_organizations/store/operating_report.py
@@ -70,7 +70,7 @@ def operating_report(db: Database) -> dict[str, Any]:
         ]
         deliveries = dict(
             connection.execute(
-                "SELECT delivery,count(*) FROM assistant_work "
+                "SELECT delivery,count(*) FROM assistant_reports "
                 "WHERE channel LIKE 'telegram:%' GROUP BY delivery"
             )
         )

--- a/src/sovereign_agent/assistant_cli.py
+++ b/src/sovereign_agent/assistant_cli.py
@@ -53,7 +53,15 @@ def handle(args: argparse.Namespace) -> int:
         if endpoint
         and not args.research_worker
         and args.action
-        in {"ask", "work", "serve", "bind-supplier", "inspect-account", "recover-account"}
+        in {
+            "ask",
+            "work",
+            "serve",
+            "approve",
+            "bind-supplier",
+            "inspect-account",
+            "recover-account",
+        }
         else None
     )
     limits = Limits(
@@ -191,6 +199,7 @@ def handle(args: argparse.Namespace) -> int:
                 actor=actor,
                 policy=policy,
                 expires=time.time() + args.approval_seconds,
+                supplier=supplier,
             )
             with db.immediate() as connection:
                 connection.execute(
@@ -202,6 +211,21 @@ def handle(args: argparse.Namespace) -> int:
         else:
             assistant_orders.revoke(db, args.value, actor=actor, policy=policy)
         result = {"status": action.upper(), "order": args.value}
+    elif action == "resolve-order":
+        with Path(args.receipt).open("rb") as stream:
+            raw = stream.read(65_537)
+        if len(raw) > 65_536:
+            raise ValueError("receipt exceeds 64 KiB")
+        result = assistant_orders.resolve(
+            db,
+            args.value,
+            args.digest,
+            json.loads(raw),
+            target=args.supplier,
+            evidence=args.evidence,
+            actor=args.actor or "lucy",
+            policy=policy,
+        )
     elif action == "retry":
         with db.immediate() as connection:
             changed = connection.execute(
@@ -373,6 +397,7 @@ def register(subparsers: Any, shared: argparse.ArgumentParser) -> None:
             "report",
             "approve",
             "revoke",
+            "resolve-order",
             "retry",
             "cancel",
             "remember",
@@ -413,6 +438,8 @@ def register(subparsers: Any, shared: argparse.ArgumentParser) -> None:
     parser.add_argument("--actor", default="")
     parser.add_argument("--digest", default="")
     parser.add_argument("--delivery-ref", default="")
+    parser.add_argument("--receipt", default="")
+    parser.add_argument("--evidence", default="")
     parser.add_argument("--approval-seconds", type=int, default=3600)
     parser.add_argument("--total-pence", type=int, default=20_000)
     parser.add_argument("--automatic-pence", type=int, default=0)

--- a/src/sovereign_agent/assistant_orders.py
+++ b/src/sovereign_agent/assistant_orders.py
@@ -120,6 +120,7 @@ def approve(
     policy: SpendingPolicy,
     expires: float,
     automatic: bool = False,
+    supplier: Supplier | None = None,
     now: float | None = None,
 ) -> None:
     now = time.time() if now is None else now
@@ -136,10 +137,25 @@ def approve(
         if (
             order is None
             or order["digest"] != digest
-            or order["status"] not in {"DRAFT", "APPROVED"}
+            or order["status"] not in {"DRAFT", "APPROVED", "SENDING", "UNKNOWN"}
             or order["revoked"]
         ):
             raise PermissionError("approval does not match an eligible exact proposal")
+        _operator_state(db)
+        work = connection.execute(
+            "SELECT cancelled FROM assistant_work WHERE id=?", (order["work_id"],)
+        ).fetchone()
+        if work["cancelled"]:
+            raise PermissionError("cancelled work cannot gain new approval")
+        if order["status"] in {"SENDING", "UNKNOWN"} and (
+            automatic
+            or supplier is None
+            or not supplier.idempotent
+            or supplier.identity != order["target"]
+        ):
+            raise PermissionError(
+                "uncertain retry needs explicit approval and matching idempotent supplier"
+            )
         if automatic and order["amount"] > policy.automatic_order_pence:
             raise PermissionError("exact proposal needs operator approval")
         connection.execute(
@@ -158,7 +174,9 @@ def approve(
             "UPDATE assistant_spending SET reserved_pence=reserved_pence+? WHERE id=1", (addition,)
         )
         connection.execute(
-            "UPDATE assistant_orders SET status='APPROVED',approved_by=?,approved_until=?,"
+            "UPDATE assistant_orders SET status=CASE WHEN status IN ('SENDING','UNKNOWN') "
+            "THEN status "
+            "ELSE 'APPROVED' END,approved_by=?,approved_until=?,"
             "approval_basis=? WHERE id=?",
             (actor, expires, "AUTOMATIC" if automatic else "OPERATOR", identifier),
         )
@@ -195,6 +213,47 @@ def revoke(db: Database, identifier: str, *, actor: str, policy: SpendingPolicy)
         append_event(db, "assistant.order.revoked", {"order": identifier, "actor": actor})
 
 
+def _operator_state(db: Database) -> None:
+    control = db.connection.execute("SELECT * FROM assistant_control WHERE id=1").fetchone()
+    if control["paused"] or db.path.with_suffix(".authority").read_text() != control["epoch"]:
+        raise PermissionError("paused or replaced state requires account recovery")
+
+
+def _settle(db: Database, row: Any, receipt: dict[str, Any]) -> dict[str, Any]:
+    connection = db.connection
+    identifier = row["id"]
+    if (
+        receipt.get("operation") != identifier
+        or json.dumps(
+            receipt.get("proposal"), sort_keys=True, separators=(",", ":"), allow_nan=False
+        )
+        != row["proposal"]
+    ):
+        raise ValueError("supplier receipt does not match the exact intent")
+    if receipt.get("status") not in {"ACCEPTED", "REJECTED"}:
+        raise ValueError("supplier outcome is not conclusive")
+    if row["status"] in {"CONFIRMED", "DELIVERED", "REJECTED"}:
+        if receipt["status"] != json.loads(row["receipt"])["status"]:
+            raise ValueError("supplier receipt contradicts the recorded outcome")
+        return dict(json.loads(row["receipt"]))
+    if row["status"] not in {"SENDING", "UNKNOWN"}:
+        raise PermissionError("order was not admitted for transmission")
+    accepted = receipt["status"] == "ACCEPTED"
+    connection.execute(
+        "UPDATE assistant_orders SET status=?,receipt=? WHERE id=?",
+        ("CONFIRMED" if accepted else "REJECTED", json.dumps(receipt), identifier),
+    )
+    connection.execute(
+        "UPDATE assistant_spending SET reserved_pence=reserved_pence-?,"
+        "spent_pence=spent_pence+? WHERE id=1",
+        (row["amount"], row["amount"] if accepted else 0),
+    )
+    append_event(
+        db, "assistant.order.reconciled", {"order": identifier, "status": receipt["status"]}
+    )
+    return receipt
+
+
 def _record(db: Database, work: Claim, identifier: str, receipt: dict[str, Any]) -> dict[str, Any]:
     with db.immediate() as connection:
         assert_current(connection, work)
@@ -202,34 +261,56 @@ def _record(db: Database, work: Claim, identifier: str, receipt: dict[str, Any])
             "SELECT * FROM assistant_orders WHERE id=? AND work_id=?", (identifier, work.id)
         ).fetchone()
         assert row
-        if (
-            receipt.get("operation") != identifier
-            or json.dumps(
-                receipt.get("proposal"), sort_keys=True, separators=(",", ":"), allow_nan=False
+        return _settle(db, row, receipt)
+
+
+def resolve(
+    db: Database,
+    identifier: str,
+    digest: str,
+    receipt: dict[str, Any],
+    *,
+    target: str,
+    evidence: str,
+    actor: str,
+    policy: SpendingPolicy,
+) -> dict[str, Any]:
+    """Operator-attested conclusive supplier receipt, never an absent lookup.
+
+    REJECTED must irrevocably close this operation at the supplier, including
+    delayed requests. This trusts the operator's evidence, not a model's claim.
+    """
+    if actor not in policy.operators:
+        raise PermissionError("operator is not allowlisted")
+    if not evidence.strip() or len(evidence) > 500 or not isinstance(receipt, dict):
+        raise ValueError("bounded supplier evidence and an exact receipt are required")
+    with db.immediate() as connection:
+        _operator_state(db)
+        row = connection.execute(
+            "SELECT * FROM assistant_orders WHERE id=?", (identifier,)
+        ).fetchone()
+        if row is None or row["digest"] != digest or row["target"] != target:
+            raise PermissionError("resolution differs from the exact supplier intent")
+        terminal = row["status"] in {"CONFIRMED", "DELIVERED", "REJECTED"}
+        result = _settle(db, row, receipt)
+        if not terminal:
+            append_event(
+                db,
+                "assistant.order.resolved",
+                {
+                    "order": identifier,
+                    "actor": actor,
+                    "evidence": evidence,
+                    "target": target,
+                    "digest": digest,
+                },
             )
-            != row["proposal"]
-        ):
-            raise ValueError("supplier receipt does not match the exact intent")
-        if receipt.get("status") not in {"ACCEPTED", "REJECTED"}:
-            raise ValueError("supplier outcome is not conclusive")
-        if row["status"] in {"CONFIRMED", "DELIVERED", "REJECTED"}:
-            return dict(json.loads(row["receipt"]))
-        if row["status"] not in {"SENDING", "UNKNOWN"}:
-            raise PermissionError("order was not admitted for transmission")
-        accepted = receipt["status"] == "ACCEPTED"
-        connection.execute(
-            "UPDATE assistant_orders SET status=?,receipt=? WHERE id=?",
-            ("CONFIRMED" if accepted else "REJECTED", json.dumps(receipt), identifier),
-        )
-        connection.execute(
-            "UPDATE assistant_spending SET reserved_pence=reserved_pence-?,"
-            "spent_pence=spent_pence+? WHERE id=1",
-            (row["amount"], row["amount"] if accepted else 0),
-        )
-        append_event(
-            db, "assistant.order.reconciled", {"order": identifier, "status": receipt["status"]}
-        )
-    return receipt
+            connection.execute(
+                "UPDATE assistant_work SET status='READY',available_after=0 "
+                "WHERE id=? AND status IN ('BLOCKED','CANCELLED')",
+                (row["work_id"],),
+            )
+        return result
 
 
 def execute(
@@ -256,7 +337,7 @@ def execute(
             if receipt is not None:
                 return _record(db, work, identifier, receipt)
         except OSError, ValueError:
-            return {"status": "UNKNOWN", "operation": identifier}
+            return {"status": "UNKNOWN", "operation": identifier, "needs_operator": True}
         if not supplier.idempotent:
             return {"status": "UNKNOWN", "operation": identifier, "needs_operator": True}
     with db.immediate() as connection:

--- a/src/sovereign_agent/assistant_schema.py
+++ b/src/sovereign_agent/assistant_schema.py
@@ -140,3 +140,44 @@ SCHEMA_25 = """
 ALTER TABLE assistant_orders ADD COLUMN approval_basis TEXT NOT NULL DEFAULT 'UNKNOWN'
 CHECK(approval_basis IN ('UNKNOWN','OPERATOR','AUTOMATIC'));
 """
+
+
+SCHEMA_26 = """
+CREATE TABLE assistant_reports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    work_id TEXT NOT NULL REFERENCES assistant_work(id),
+    status TEXT NOT NULL, body TEXT NOT NULL,
+    channel TEXT NOT NULL, recipient TEXT NOT NULL,
+    delivery TEXT NOT NULL DEFAULT 'PENDING', receipt TEXT
+);
+CREATE INDEX assistant_reports_pending ON assistant_reports(channel, delivery, id);
+INSERT INTO assistant_reports(work_id,status,body,channel,recipient,delivery)
+SELECT id,status,coalesce(result,'Work ended without a report.'),channel,recipient,delivery
+FROM assistant_work WHERE status IN ('DONE','BLOCKED','CANCELLED','REJECTED');
+CREATE TRIGGER assistant_report_immutable
+BEFORE UPDATE OF id,work_id,status,body,channel,recipient ON assistant_reports
+BEGIN SELECT RAISE(ABORT, 'report identity and content are immutable'); END;
+CREATE TRIGGER assistant_report_insert AFTER INSERT ON assistant_work
+WHEN NEW.status IN ('DONE','BLOCKED','CANCELLED','REJECTED')
+BEGIN
+    INSERT INTO assistant_reports(work_id,status,body,channel,recipient,delivery)
+    VALUES (NEW.id,NEW.status,coalesce(NEW.result,'Work ended without a report.'),
+            NEW.channel,NEW.recipient,NEW.delivery);
+END;
+CREATE TRIGGER assistant_report_finish AFTER UPDATE OF status,result ON assistant_work
+WHEN NEW.status IN ('DONE','BLOCKED','CANCELLED','REJECTED') AND NOT EXISTS (
+    SELECT 1 FROM assistant_reports WHERE id=(
+        SELECT max(id) FROM assistant_reports WHERE work_id=NEW.id
+    ) AND status=NEW.status AND body=coalesce(NEW.result,'Work ended without a report.')
+)
+BEGIN
+    INSERT INTO assistant_reports(work_id,status,body,channel,recipient)
+    VALUES (NEW.id,NEW.status,coalesce(NEW.result,'Work ended without a report.'),
+            NEW.channel,NEW.recipient);
+    UPDATE assistant_work SET delivery='PENDING' WHERE id=NEW.id;
+END;
+CREATE TRIGGER assistant_report_delivery AFTER UPDATE OF delivery ON assistant_reports
+WHEN NEW.id=(SELECT max(id) FROM assistant_reports WHERE work_id=NEW.work_id)
+BEGIN UPDATE assistant_work SET delivery=NEW.delivery WHERE id=NEW.work_id; END;
+ALTER TABLE assistant_jobs ADD COLUMN deferred INTEGER NOT NULL DEFAULT 0;
+"""

--- a/src/sovereign_agent/assistant_service.py
+++ b/src/sovereign_agent/assistant_service.py
@@ -36,7 +36,7 @@ def health(db: Database) -> dict[str, Any]:
             "SELECT count(*) FROM assistant_orders WHERE status IN ('UNKNOWN','SENDING')"
         ).fetchone()[0],
         "uncertain_deliveries": db.connection.execute(
-            "SELECT count(*) FROM assistant_work WHERE channel LIKE 'telegram:%' "
+            "SELECT count(*) FROM assistant_reports WHERE channel LIKE 'telegram:%' "
             "AND delivery IN ('UNKNOWN','SENDING')"
         ).fetchone()[0],
     }

--- a/src/sovereign_agent/assistant_work.py
+++ b/src/sovereign_agent/assistant_work.py
@@ -238,20 +238,29 @@ def tick(db: Database, *, now: float | None = None, maximum: int = 100) -> list[
             (now, maximum),
         ).fetchall()
         for row in rows:
-            identifier = _enqueue(
-                connection,
-                f"job:{row['id']}:{row['next_due']!r}",
-                row["session"],
-                row["prompt"],
-                now,
-                row["channel"],
-                row["recipient"],
-            )
+            try:
+                identifier = _enqueue(
+                    connection,
+                    f"job:{row['id']}:{row['next_due']!r}",
+                    row["session"],
+                    row["prompt"],
+                    now,
+                    row["channel"],
+                    row["recipient"],
+                    require_admission=True,
+                )
+            except IntakeLimitError:
+                if not row["deferred"]:
+                    append_event(db, "assistant.job.deferred", {"job": row["id"]})
+                    connection.execute(
+                        "UPDATE assistant_jobs SET deferred=1 WHERE id=?", (row["id"],)
+                    )
+                continue
             created.append(identifier)
             skipped = math.floor((now - row["next_due"]) / row["interval_seconds"])
             next_due = row["next_due"] + (skipped + 1) * row["interval_seconds"]
             connection.execute(
-                "UPDATE assistant_jobs SET next_due=? WHERE id=?", (next_due, row["id"])
+                "UPDATE assistant_jobs SET next_due=?,deferred=0 WHERE id=?", (next_due, row["id"])
             )
             append_event(
                 db,
@@ -416,7 +425,8 @@ def cancel(db: Database, identifier: str) -> None:
             (identifier,),
         )
         changed = connection.execute(
-            "UPDATE assistant_work SET status='CANCELLED',cancelled=1,generation=generation+1 "
+            "UPDATE assistant_work SET status='CANCELLED',cancelled=1,generation=generation+1,"
+            "result='Cancellation recorded; transmitted orders still require reconciliation.' "
             "WHERE id=? AND status IN ('READY','RUNNING','BLOCKED')",
             (identifier,),
         ).rowcount

--- a/src/sovereign_agent/database.py
+++ b/src/sovereign_agent/database.py
@@ -16,6 +16,7 @@ from sovereign_agent.assistant_schema import SCHEMA_22 as MIGRATION_22
 from sovereign_agent.assistant_schema import SCHEMA_23 as MIGRATION_23
 from sovereign_agent.assistant_schema import SCHEMA_24 as MIGRATION_24
 from sovereign_agent.assistant_schema import SCHEMA_25 as MIGRATION_25
+from sovereign_agent.assistant_schema import SCHEMA_26 as MIGRATION_26
 
 MIGRATION_1 = """
 PRAGMA foreign_keys = ON;
@@ -830,6 +831,7 @@ MIGRATIONS: tuple[tuple[int, str], ...] = (
     (23, MIGRATION_23),
     (24, MIGRATION_24),
     (25, MIGRATION_25),
+    (26, MIGRATION_26),
 )
 
 
@@ -968,8 +970,9 @@ class Database:
             self.connection.execute("BEGIN IMMEDIATE")
             yield self.connection
             self.connection.execute("COMMIT")
-        except Exception:
-            self.connection.execute("ROLLBACK")
+        except BaseException:
+            if self.connection.in_transaction:
+                self.connection.execute("ROLLBACK")
             raise
         finally:
             self.connection.isolation_level = previous

--- a/src/sovereign_agent/telegram_channel.py
+++ b/src/sovereign_agent/telegram_channel.py
@@ -149,22 +149,23 @@ def deliver_one(db: Database, bot: Bot, operators: frozenset[int]) -> str | None
     _check_operators(operators)
     with db.immediate() as connection:
         row = connection.execute(
-            "SELECT * FROM assistant_work WHERE channel=? AND "
-            "status IN ('DONE','BLOCKED','CANCELLED','REJECTED') AND delivery='PENDING' "
-            "ORDER BY created LIMIT 1",
+            "SELECT * FROM assistant_reports WHERE channel=? AND delivery='PENDING' "
+            "ORDER BY id LIMIT 1",
             ("telegram:" + bot.account,),
         ).fetchone()
         if row is None:
             return None
         if not row["recipient"].isdigit() or int(row["recipient"]) not in operators:
             connection.execute(
-                "UPDATE assistant_work SET delivery='DENIED' WHERE id=?", (row["id"],)
+                "UPDATE assistant_reports SET delivery='DENIED' WHERE id=?", (row["id"],)
             )
             return "DENIED"
         # A crash after this commit is ambiguous, even if no HTTP call happened.
-        connection.execute("UPDATE assistant_work SET delivery='SENDING' WHERE id=?", (row["id"],))
+        connection.execute(
+            "UPDATE assistant_reports SET delivery='SENDING' WHERE id=?", (row["id"],)
+        )
     try:
-        text = row["result"] or "Work ended without a report."
+        text = row["body"]
         if len(text) > 3900:
             text = text[:3800] + "\n[Report truncated; request a shorter report.]"
         result = bot.call("sendMessage", {"chat_id": int(row["recipient"]), "text": text})
@@ -179,8 +180,12 @@ def deliver_one(db: Database, bot: Bot, operators: frozenset[int]) -> str | None
         status = "UNKNOWN"
     with db.immediate() as connection:
         updated = connection.execute(
-            "UPDATE assistant_work SET delivery=? WHERE id=? AND delivery='SENDING'",
-            (status, row["id"]),
+            "UPDATE assistant_reports SET delivery=?,receipt=? WHERE id=? AND delivery='SENDING'",
+            (
+                status,
+                json.dumps({"message_id": result["message_id"]}) if status == "SENT" else None,
+                row["id"],
+            ),
         )
         if not updated.rowcount:
             return "UNKNOWN"
@@ -189,7 +194,8 @@ def deliver_one(db: Database, bot: Bot, operators: frozenset[int]) -> str | None
                 db,
                 "assistant.channel.sent",
                 {
-                    "work": row["id"],
+                    "work": row["work_id"],
+                    "report": row["id"],
                     "channel": row["channel"],
                     "recipient": row["recipient"],
                     "message_id": result["message_id"],

--- a/tests/test_channel_receipts.py
+++ b/tests/test_channel_receipts.py
@@ -102,6 +102,7 @@ def test_successful_receipt_is_durable_once_and_contains_no_raw_response(tmp_pat
         "channel": "telegram:shape-test",
         "recipient": "123",
         "message_id": 901,
+        "report": 1,
     }
     assert len(bot.sent) == 1
     db.close()
@@ -133,7 +134,7 @@ def test_changed_delivery_state_cannot_gain_a_stale_success_event(tmp_path):
     def accepted_after_state_changed(*args):
         with other.immediate() as connection:
             connection.execute(
-                "UPDATE assistant_work SET delivery='UNKNOWN' WHERE id=?", (identifier,)
+                "UPDATE assistant_reports SET delivery='UNKNOWN' WHERE work_id=?", (identifier,)
             )
         return {"message_id": 901}
 

--- a/tests/test_elders_round_three.py
+++ b/tests/test_elders_round_three.py
@@ -1,0 +1,398 @@
+"""Current elder counterexamples: successive reports, interrupts and uncertain authority."""
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from reference_organizations.store.agent import seed_lucy
+from sovereign_agent import assistant_orders as orders
+from sovereign_agent import assistant_work as work
+from sovereign_agent.assistant_service import health
+from sovereign_agent.database import Database
+from sovereign_agent.telegram_channel import deliver_one
+
+
+@pytest.mark.parametrize("failure", [KeyboardInterrupt, SystemExit])
+def test_interrupted_transaction_cannot_later_commit(tmp_path, failure):
+    db = Database(tmp_path / "agent.sqlite")
+    with pytest.raises(failure):
+        with db.immediate() as connection:
+            connection.execute("UPDATE assistant_control SET paused=1")
+            raise failure()
+    assert not db.connection.in_transaction
+    db.connection.commit()
+    other = Database(db.path)
+    assert other.connection.execute("SELECT paused FROM assistant_control").fetchone()[0] == 0
+    other.close()
+    with db.immediate() as connection:
+        connection.execute("UPDATE assistant_control SET paused=1")
+    assert not db.connection.in_transaction
+
+
+def test_failed_begin_preserves_original_lock_error(tmp_path):
+    db = Database(tmp_path / "agent.sqlite")
+    other = Database(db.path)
+    other.connection.execute("PRAGMA busy_timeout=1")
+    with db.immediate():
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            with other.immediate():
+                pytest.fail("must not acquire an already held write lock")
+    assert not other.connection.in_transaction
+    with other.immediate():
+        pass
+
+
+def report_context(tmp_path):
+    db = Database(tmp_path / "agent.sqlite")
+    identifier = work.enqueue(db, "one", "lucy", "order", channel="telegram:123", recipient="123")
+    owner = work.claim(db, "first")
+    work.finish(db, owner, "BLOCKED", "Approve the exact draft.")
+    return db, identifier
+
+
+def next_report(db, identifier, status="DONE", text="Order confirmed."):
+    with db.immediate() as connection:
+        connection.execute(
+            "UPDATE assistant_work SET status='READY',available_after=0 WHERE id=?", (identifier,)
+        )
+    owner = work.claim(db, "next", identifier=identifier)
+    work.finish(db, owner, status, text)
+
+
+@pytest.mark.parametrize("late", [False, True])
+def test_approval_and_final_report_have_independent_receipts(tmp_path, late):
+    db, identifier = report_context(tmp_path)
+    other = Database(db.path)
+    sent = []
+
+    class Bot:
+        account = "123"
+
+        def call(self, method, data):
+            sent.append(data["text"])
+            if late and len(sent) == 1:
+                next_report(other, identifier)
+            return {"message_id": len(sent), "private_extra": "do not retain"}
+
+    assert deliver_one(db, Bot(), frozenset({123})) == "SENT"
+    if not late:
+        next_report(other, identifier)
+    rows = db.connection.execute("SELECT id,delivery FROM assistant_reports ORDER BY id").fetchall()
+    assert [tuple(row) for row in rows] == [(1, "SENT"), (2, "PENDING")]
+    assert deliver_one(other, Bot(), frozenset({123})) == "SENT"
+    assert deliver_one(db, Bot(), frozenset({123})) is None
+    assert sent == ["Approve the exact draft.", "Order confirmed."]
+    assert [
+        json.loads(row[0])
+        for row in db.connection.execute("SELECT receipt FROM assistant_reports ORDER BY id")
+    ] == [{"message_id": 1}, {"message_id": 2}]
+    events = [
+        json.loads(row[0])
+        for row in db.connection.execute(
+            "SELECT payload FROM events WHERE kind='assistant.channel.sent' ORDER BY seq"
+        )
+    ]
+    assert [event["report"] for event in events] == [1, 2]
+
+
+def test_unknown_report_does_not_prevent_new_report_or_replay_old_one(tmp_path):
+    db, identifier = report_context(tmp_path)
+
+    class Bot:
+        account = "123"
+
+        def call(self, *args):
+            raise TimeoutError()
+
+    assert deliver_one(db, Bot(), frozenset({123})) == "UNKNOWN"
+    next_report(db, identifier)
+    next_report(db, identifier)  # Unchanged reconciliation report does not spam.
+    assert db.connection.execute("SELECT count(*) FROM assistant_reports").fetchone()[0] == 2
+    assert health(db)["uncertain_deliveries"] == 1
+    assert deliver_one(db, Bot(), frozenset({123})) == "UNKNOWN"
+    assert deliver_one(db, Bot(), frozenset({123})) is None
+    assert health(db)["uncertain_deliveries"] == 2
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        db.connection.execute("UPDATE assistant_reports SET body='rewritten'")
+    db.connection.rollback()
+
+
+class Supplier:
+    idempotent = True
+    identity = "lucy-local"
+    timeout = 1
+    calls = 0
+    available = False
+
+    def lookup(self, operation):
+        return None
+
+    def order(self, operation, proposal):
+        self.calls += 1
+        if not self.available:
+            raise TimeoutError()
+        return {"operation": operation, "proposal": proposal, "status": "ACCEPTED"}
+
+
+def uncertain(tmp_path):
+    db = Database(tmp_path / "agent.sqlite")
+    seed_lucy(db)
+    work.enqueue(db, "first", "lucy", "order")
+    owner = work.claim(db, "worker")
+    identifier = orders.propose(db, owner, "SKU-VANILLA", 6)
+    row = db.connection.execute("SELECT * FROM assistant_orders").fetchone()
+    policy = orders.SpendingPolicy(frozenset({"lucy"}))
+    orders.approve(
+        db, identifier, row["digest"], actor="lucy", policy=policy, expires=time.time() + 60
+    )
+    supplier = Supplier()
+    assert orders.execute(db, owner, identifier, supplier, policy=policy)["status"] == "UNKNOWN"
+    with db.immediate() as connection:
+        connection.execute("UPDATE assistant_orders SET approved_until=0")
+    return db, owner, row, policy, supplier
+
+
+@pytest.mark.parametrize("uncertain_state", ["UNKNOWN", "SENDING"])
+def test_expired_unknown_can_renew_same_identity_without_double_reserving(
+    tmp_path, uncertain_state
+):
+    db, owner, row, policy, supplier = uncertain(tmp_path)
+    with db.immediate() as connection:
+        connection.execute("UPDATE assistant_orders SET status=?", (uncertain_state,))
+    with pytest.raises(PermissionError, match="approval required"):
+        orders.execute(db, owner, row["id"], supplier, policy=policy)
+    orders.approve(
+        db,
+        row["id"],
+        row["digest"],
+        actor="lucy",
+        policy=policy,
+        expires=time.time() + 60,
+        supplier=supplier,
+    )
+    assert (
+        db.connection.execute("SELECT status FROM assistant_orders").fetchone()[0]
+        == uncertain_state
+    )
+    assert (
+        db.connection.execute("SELECT reserved_pence FROM assistant_spending").fetchone()[0] == 1500
+    )
+    supplier.available = True
+    assert orders.execute(db, owner, row["id"], supplier, policy=policy)["status"] == "ACCEPTED"
+    assert supplier.calls == 2
+    assert tuple(
+        db.connection.execute(
+            "SELECT reserved_pence,spent_pence FROM assistant_spending"
+        ).fetchone()
+    ) == (0, 1500)
+
+
+@pytest.mark.parametrize(
+    "mutation", ["non_idempotent", "target", "revoked", "cancelled", "automatic"]
+)
+def test_unknown_renewal_cannot_expand_authority(tmp_path, mutation):
+    db, owner, row, policy, supplier = uncertain(tmp_path)
+    if mutation == "non_idempotent":
+        supplier.idempotent = False
+    elif mutation == "target":
+        supplier.identity = "other"
+    elif mutation == "revoked":
+        orders.revoke(db, row["id"], actor="lucy", policy=policy)
+    elif mutation == "cancelled":
+        work.cancel(db, owner.id)
+    with pytest.raises(PermissionError):
+        orders.approve(
+            db,
+            row["id"],
+            row["digest"],
+            actor="lucy",
+            policy=policy,
+            expires=time.time() + 60,
+            supplier=supplier,
+            automatic=mutation == "automatic",
+        )
+    assert (
+        db.connection.execute("SELECT reserved_pence FROM assistant_spending").fetchone()[0] == 1500
+    )
+
+
+@pytest.mark.parametrize("outcome", ["ACCEPTED", "REJECTED"])
+def test_operator_exact_receipt_resolves_cancelled_unknown_once(tmp_path, outcome):
+    db, owner, row, policy, supplier = uncertain(tmp_path)
+    work.cancel(db, owner.id)
+    receipt = {"operation": row["id"], "proposal": json.loads(row["proposal"]), "status": outcome}
+    kwargs = dict(
+        target=row["target"],
+        evidence="supplier signed closure reference 42",
+        actor="lucy",
+        policy=policy,
+    )
+    for _ in range(2):
+        assert orders.resolve(db, row["id"], row["digest"], receipt, **kwargs) == receipt
+    assert tuple(
+        db.connection.execute(
+            "SELECT reserved_pence,spent_pence FROM assistant_spending"
+        ).fetchone()
+    ) == (0, 1500 if outcome == "ACCEPTED" else 0)
+    for kind in ("assistant.order.resolved", "assistant.order.reconciled"):
+        assert (
+            db.connection.execute("SELECT count(*) FROM events WHERE kind=?", (kind,)).fetchone()[0]
+            == 1
+        )
+    with pytest.raises(ValueError, match="contradicts"):
+        orders.resolve(
+            db,
+            row["id"],
+            row["digest"],
+            {**receipt, "status": "REJECTED" if outcome == "ACCEPTED" else "ACCEPTED"},
+            **kwargs,
+        )
+    assert supplier.calls == 1
+
+
+@pytest.mark.parametrize(
+    "mutation", ["actor", "digest", "target", "proposal", "operation", "status"]
+)
+def test_operator_resolution_refuses_mismatched_or_inconclusive_evidence(tmp_path, mutation):
+    db, owner, row, policy, supplier = uncertain(tmp_path)
+    receipt = {
+        "operation": row["id"],
+        "proposal": json.loads(row["proposal"]),
+        "status": "REJECTED",
+    }
+    kwargs = dict(target=row["target"], evidence="supplier closure", actor="lucy", policy=policy)
+    digest = row["digest"]
+    if mutation in kwargs:
+        kwargs[mutation] = "untrusted"
+    elif mutation == "digest":
+        digest = "different"
+    else:
+        receipt[mutation] = "NOT_PLACED"
+    with pytest.raises((ValueError, PermissionError)):
+        orders.resolve(db, row["id"], digest, receipt, **kwargs)
+    assert (
+        db.connection.execute("SELECT reserved_pence FROM assistant_spending").fetchone()[0] == 1500
+    )
+
+
+def test_saturated_clock_defers_without_rejected_work_or_repeated_notice(tmp_path):
+    db = Database(tmp_path / "agent.sqlite")
+    for n in range(20):
+        work.enqueue(db, str(n), "lucy", "brief", now=10)
+    work.schedule(db, "morning", "lucy", "brief", first_due=10, interval_seconds=60)
+    assert work.tick(db, now=10) == work.tick(db, now=70) == []
+    assert db.connection.execute("SELECT count(*) FROM assistant_work").fetchone()[0] == 20
+    assert db.connection.execute("SELECT next_due FROM assistant_jobs").fetchone()[0] == 10
+    assert (
+        db.connection.execute(
+            "SELECT count(*) FROM events WHERE kind='assistant.job.deferred'"
+        ).fetchone()[0]
+        == 1
+    )
+    owner = work.claim(db, "worker", now=71)
+    work.finish(db, owner, "DONE", "done", now=72)
+    assert len(work.tick(db, now=73)) == 1
+    assert db.connection.execute("SELECT next_due FROM assistant_jobs").fetchone()[0] == 130
+
+
+def test_version_25_upgrade_preserves_sent_and_uncertain_report_states(tmp_path, monkeypatch):
+    import sovereign_agent.database as storage
+
+    migrations = storage.MIGRATIONS
+    monkeypatch.setattr(storage, "MIGRATIONS", tuple(item for item in migrations if item[0] < 26))
+    db = Database(tmp_path / "agent.sqlite")
+    for name, state in (("delivered", "SENT"), ("ambiguous", "UNKNOWN")):
+        with db.immediate() as connection:
+            connection.execute(
+                "INSERT INTO assistant_work(id,origin,session,prompt,created,status,result,"
+                "channel,recipient,delivery) VALUES (?,?,?,?,0,'DONE',?,'telegram:123','123',?)",
+                (name, name, name, "brief", name, state),
+            )
+    db.close()
+    monkeypatch.setattr(storage, "MIGRATIONS", migrations)
+    reopened = Database(db.path)
+    assert [
+        tuple(row)
+        for row in reopened.connection.execute(
+            "SELECT work_id,body,delivery FROM assistant_reports ORDER BY id"
+        )
+    ] == [("delivered", "delivered", "SENT"), ("ambiguous", "ambiguous", "UNKNOWN")]
+    assert 26 in reopened.applied_versions()
+    assert health(reopened)["uncertain_deliveries"] == 1
+
+
+def test_failed_restore_copy_can_retry_without_unfencing_old_worker(tmp_path, monkeypatch):
+    from sovereign_agent import assistant_service as service
+
+    db = Database(tmp_path / "agent.sqlite")
+    work.enqueue(db, "one", "lucy", "brief")
+    owner = work.claim(db, "old")
+    snapshot = service.backup(db, tmp_path / "snapshot.sqlite")
+    original = sqlite3.connect
+
+    class FailCopy(sqlite3.Connection):
+        def backup(self, target, **kwargs):
+            if target is db.connection:
+                raise sqlite3.OperationalError("injected disk copy failure")
+            return super().backup(target, **kwargs)
+
+    def connection(*args, **kwargs):
+        return original(*args, factory=FailCopy, **kwargs)
+
+    monkeypatch.setattr(service.sqlite3, "connect", connection)
+    with pytest.raises(sqlite3.OperationalError, match="disk copy"):
+        service.restore(db, snapshot)
+    with pytest.raises(PermissionError):
+        work.assert_current(db.connection, owner)
+    monkeypatch.setattr(service.sqlite3, "connect", original)
+    service.restore(db, snapshot)
+    assert health(db)["paused"]
+    assert (
+        db.path.with_suffix(".authority").read_text()
+        == db.connection.execute("SELECT epoch FROM assistant_control").fetchone()[0]
+    )
+    with pytest.raises(PermissionError):
+        work.assert_current(db.connection, owner)
+
+
+def test_two_product_phone_request_delivers_approval_then_final_report(tmp_path):
+    from reference_organizations.store.agent import OfflineShopModel
+    from reference_organizations.store.assistant import run_once
+
+    db = Database(tmp_path / "agent.sqlite")
+    seed_lucy(db)
+    identifier = work.enqueue(
+        db, "phone:1", "telegram:123:123", "replenish", channel="telegram:123", recipient="123"
+    )
+    policy = orders.SpendingPolicy(frozenset({"123"}))
+    supplier = Supplier()
+    supplier.available = True
+    sent = []
+
+    class Bot:
+        account = "123"
+
+        def call(self, method, data):
+            sent.append(data["text"])
+            return {"message_id": len(sent)}
+
+    assert run_once(db, OfflineShopModel(), supplier=supplier, policy=policy)["status"] == "BLOCKED"
+    assert deliver_one(db, Bot(), frozenset({123})) == "SENT"
+    for row in db.connection.execute("SELECT id,digest FROM assistant_orders").fetchall():
+        orders.approve(
+            db, row["id"], row["digest"], actor="123", policy=policy, expires=time.time() + 60
+        )
+    with db.immediate() as connection:
+        connection.execute(
+            "UPDATE assistant_work SET status='READY',available_after=0 WHERE id=?", (identifier,)
+        )
+    assert run_once(db, OfflineShopModel(), supplier=supplier, policy=policy)["status"] == "DONE"
+    assert deliver_one(db, Bot(), frozenset({123})) == "SENT"
+    assert (
+        len(sent) == 2
+        and sent[0].count("Approval required") == 2
+        and sent[1].count("CONFIRMED") == 2
+    )
+    assert supplier.calls == 2

--- a/tests/test_operating_report.py
+++ b/tests/test_operating_report.py
@@ -72,6 +72,7 @@ def test_unknown_effect_and_delivery_cannot_disappear_in_fluent_result(db):
         "UPDATE assistant_work SET status='BLOCKED',delivery='UNKNOWN',"
         "result='All complete. We spent nothing.'"
     )
+    db.connection.execute("UPDATE assistant_reports SET delivery='UNKNOWN'")
     db.connection.commit()
     result = operating_report(db)
     assert len(result["exceptions"]) == 3

--- a/tests/test_publication_contract.py
+++ b/tests/test_publication_contract.py
@@ -13,7 +13,7 @@ ROOT = Path(__file__).resolve().parent.parent
 @pytest.mark.parametrize("failure", ["duplicate", "missing", "escape", "ready", "figures"])
 def test_publication_contract_refuses_invalid_edition(tmp_path: Path, failure: str) -> None:
     spec = importlib.util.spec_from_file_location(
-        "publication", ROOT / "scripts" / "verify_publication_v1.py"
+        "publication", ROOT / "scripts" / "verify_publication_v2.py"
     )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)

--- a/tests/test_reader_construction.py
+++ b/tests/test_reader_construction.py
@@ -1,0 +1,142 @@
+"""Cold-start build: only the printed definitions, Pydantic and Python are available."""
+
+import ast
+import builtins
+import contextlib
+import io
+import json
+import re
+import runpy
+import shutil
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def saved_definitions(chapter, assignments):
+    """Apply the exact save instructions printed in Chapters 2 and 3."""
+    text = (ROOT / f"book/always_on/{chapter}/README.md").read_text()
+    nodes = []
+    for code in re.findall(r"^```python\n(.*?)^```", text, re.M | re.S):
+        for node in ast.parse(code).body:
+            if isinstance(node, ast.FunctionDef) and node.name in {"authored_http", "refuse_write"}:
+                continue
+            if isinstance(node, (ast.Import, ast.ImportFrom, ast.FunctionDef, ast.ClassDef)) or (
+                isinstance(node, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id in assignments for t in node.targets)
+            ):
+                nodes.append(node)
+    return ast.unparse(ast.Module(body=nodes, type_ignores=[]))
+
+
+@pytest.fixture
+def reader(tmp_path, monkeypatch):
+    learner = tmp_path / "book/always_on/learner"
+    learner.mkdir(parents=True)
+    checkpoints = learner.parent / "checkpoints"
+    checkpoints.mkdir()
+    shutil.copy(ROOT / "book/always_on/checkpoints/ch01.py", checkpoints / "ch01.py")
+    shutil.copy(ROOT / "book/always_on/checkpoints/ch03.py", checkpoints / "ch03.py")
+    for number, chapter, assignments in (
+        (2, "ch02_shop_tools", {"SHOP", "PRICES", "products", "tools"}),
+        (3, "ch03_agent_loop", {"shop_tools", "ToolCall", "first", "messages"}),
+    ):
+        (learner / f"ch{number:02}.py").write_text(saved_definitions(chapter, assignments))
+    monkeypatch.chdir(tmp_path)
+    original_import = builtins.__import__
+
+    def no_runtime(name, *args, **kwargs):
+        if name.startswith(("sovereign_agent", "reference_organizations")):
+            raise AssertionError("reader logic imported the installed runtime: " + name)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_runtime)
+    return runpy.run_path(str(learner / "ch03.py")), learner
+
+
+def test_printed_definitions_alone_construct_grounded_drafts(reader):
+    code, _ = reader
+    result = code["run_loop"](
+        code["ReplayModel"](code["opening_turns"]()),
+        code["shop_tools"]["build_tools"](code["shop_tools"]["SHOP"]),
+        code["messages"],
+    )
+    assert (result.status, result.model_calls, result.tool_calls) == ("COMPLETED", 3, 3)
+    assert code["draft_evidence"](result)
+
+
+@pytest.mark.parametrize("failure", [None, "arguments", "length", "shape"])
+def test_reader_http_parser_and_reader_loop_form_one_path(reader, failure):
+    code, _ = reader
+    envelopes = []
+    for turn in code["opening_turns"]():
+        envelopes.append(
+            {
+                "choices": [
+                    {
+                        "message": turn.message(),
+                        "finish_reason": "tool_calls" if turn.calls else "stop",
+                    }
+                ],
+                "usage": {"completion_tokens": 12},
+            }
+        )
+    if failure == "arguments":
+        envelopes[0]["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] = "not JSON"
+    elif failure == "length":
+        envelopes[0]["choices"][0]["finish_reason"] = "length"
+    elif failure == "shape":
+        envelopes[0]["choices"][0]["message"] = []
+    responses = iter(envelopes)
+    payloads = []
+
+    def transport(url, *, data, headers, timeout):
+        payloads.append(json.loads(data))
+        return SimpleNamespace(status=200, body=json.dumps(next(responses)).encode())
+
+    result = code["run_loop"](
+        code["HTTPModel"](request=transport),
+        code["shop_tools"]["build_tools"](code["shop_tools"]["SHOP"]),
+        code["messages"],
+    )
+    if failure:
+        assert (result.status, result.tool_calls) == ("MODEL_FAILED", 0)
+    else:
+        assert result.status == "COMPLETED" and code["draft_evidence"](result)
+        assert len(payloads[-1]["messages"]) == 7
+    assert len(payloads[0]["tools"]) == 3
+
+
+def test_checkpoint_observes_a_deliberate_reader_loop_edit(reader, monkeypatch):
+    _, learner = reader
+    path = learner / "ch03.py"
+    text = path.read_text()
+    assert text.count("'COMPLETED'") == 1
+    path.write_text(text.replace("'COMPLETED'", "'READER_EDIT'"))
+    monkeypatch.setattr(sys, "argv", ["ch03.py"])
+    checkpoint = runpy.run_path(str(learner.parent / "checkpoints/ch03.py"))
+    with contextlib.redirect_stdout(io.StringIO()) as output:
+        assert checkpoint["main"]() == 1
+    assert "READER_EDIT 3 3" in output.getvalue()
+
+
+def test_checked_in_reader_definitions_match_printed_construction():
+    for number, chapter, assignments in (
+        (2, "ch02_shop_tools", {"SHOP", "PRICES", "products", "tools"}),
+        (3, "ch03_agent_loop", {"shop_tools", "ToolCall", "first", "messages"}),
+    ):
+        printed = ast.parse(saved_definitions(chapter, assignments))
+        checked_in = ast.parse((ROOT / f"book/always_on/learner/ch{number:02}.py").read_text())
+
+        def definitions(tree):
+            return {
+                n.name: ast.dump(n, include_attributes=False)
+                for n in tree.body
+                if isinstance(n, (ast.ClassDef, ast.FunctionDef))
+            }
+
+        assert definitions(checked_in) == definitions(printed)


### PR DESCRIPTION
An approval report could mark a work item delivered and suppress its later confirmed-order report. Migration 26 gives each immutable report its own delivery identity and receipt, so a late acknowledgement cannot settle a newer result. Interrupted SQLite transactions now roll back, and saturated clock jobs defer without creating rejection messages.

Uncertain orders now support explicit approval renewal with the same idempotent supplier operation, plus operator-attested conclusive receipt resolution. Cancellation, revocation and unproven absence retain their spending protections. Chapters 2–3 construct the missing factory and HTTP adapter, and the live checkpoint uses the reader's loop. Chapter and operator instructions cover the reviewed limits.

Validation: full `make verify`, including 734 tests, clean archived installation, original curriculum/labs and 16 draft checkpoints with 141 Python examples / 133 output pairs. New tests reproduce successive reports, delayed acknowledgements, interrupted transactions, expired UNKNOWN/SENDING approvals, resolution boundaries, schema upgrade, failed restore retry and construction from printed definitions without installed agent imports. The book remains DRAFT; no live Telegram acceptance is claimed.

Responds to the current reviews in rodriveracom/org-zeroemployeeorg#603. Publish the matching book projection through the existing profrod-site `/book` route.
