### PR TITLE
Build the Chapter 3 exercise successor bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ labs:
 
 .PHONY: exercises
 exercises:
-	$(UV) run --python 3.14 --group authoring python scripts/build_exercise_release_v1.py
-	$(UV) run --python 3.14 python scripts/verify_exercise_release_v1.py
+	$(UV) run --python 3.14 --group authoring python scripts/build_exercise_release_v2.py
+	$(UV) run --python 3.14 python scripts/verify_exercise_release_v2.py
 
 .PHONY: verify
 verify: lint test
@@ -50,7 +50,7 @@ verify: lint test
 	$(UV) run --python 3.14 python scripts/verify_book_structure_v1.py
 	$(UV) run --python 3.14 python scripts/verify_always_on_v1.py
 	$(UV) run --python 3.14 python scripts/verify_publication_v2.py
-	$(UV) run --python 3.14 python scripts/verify_exercise_release_v1.py
+	$(UV) run --python 3.14 python scripts/verify_exercise_release_v2.py
 	$(UV) run --python 3.14 python scripts/verify_book_labs.py
 	$(UV) run --python 3.14 sovereign-agent --help >/dev/null
 	$(UV) run --python 3.14 sovereign-agent doctor

--- a/book/always_on/ch03_agent_loop/README.md
+++ b/book/always_on/ch03_agent_loop/README.md
@@ -2,6 +2,8 @@
 
 Lucy asks, “What needs ordering this morning?” Answering well requires more than a single generated paragraph. The program must obtain current stock, calculate useful drafts, and explain the results. In Chapter 2 you called the tools yourself. Now the model will select requests, your dispatcher will execute permitted operations, and the model will receive the observations before deciding what to do next.
 
+Practice this chapter with the [bounded-loop successor bundle](../exercises/ch03/unit-a-bounded-loop-v1.md). Unit A connects a learner-owned admission decision to the model/tool loop; Unit B mutates and repairs the real failed-call accounting in a temporary source copy. Solutions and holdouts remain separate from the student notebooks.
+
 That repeated exchange is the agent loop. It is small enough to write directly, but leaving it unbounded would create an expensive failure mode: the model could repeat a lookup indefinitely, request an oversized batch, or keep working after you asked the program to stop. The loop therefore needs an explicit result even when it does not produce a final answer.
 
 We will first use authored model responses so that each failure can be reproduced. Then we will run the same interface against the local HTTP model. The authored responses prove how the runtime reacts; the live run investigates whether a model chooses useful requests. Neither kind of evidence substitutes for the other.

--- a/book/always_on/exercises/README.md
+++ b/book/always_on/exercises/README.md
@@ -15,7 +15,12 @@ Chapter 1 is the first successor bundle:
 - [Unit B: Put prompts inside a harness](ch01/unit-b-prompt-and-harness-v1.md)
 - [Instructor guide](ch01/instructor-guide-v1.md)
 
+Chapter 3 is the second successor bundle:
+
+- [Unit A: Build a bounded model and tool loop](ch03/unit-a-bounded-loop-v1.md)
+- [Unit B: Repair failed-call accounting](ch03/unit-b-failure-accounting-v1.md)
+- [Instructor guide](ch03/instructor-guide-v1.md)
+
 Only the two Chapter 1 units are designed for Colab. Later chapters depend on local processes, files, containers, or service behavior. The full book is not a Colab course.
 
 Solutions and holdouts are separate from the student release. A notebook that executes supplied scaffolding has shown only that the artifact runs. Learning evidence comes from the learner's implementation, its connection to the cumulative behavior, and a transfer case that defeats a plausible shortcut.
-

--- a/book/always_on/exercises/ch01/holdouts/unit-a-holdout-v2.py
+++ b/book/always_on/exercises/ch01/holdouts/unit-a-holdout-v2.py
@@ -1,0 +1,55 @@
+"""Instructor-held checks appended after a submitted Unit A notebook."""
+
+# ruff: noqa: F821 - executed inside the submitted notebook namespace
+
+import copy
+import json
+
+
+def expect_refusal(document):
+    try:
+        read_brief(copy.deepcopy(document))
+    except ValueError:
+        return
+    raise AssertionError("hidden case was accepted")
+
+
+expect_refusal(None)
+expect_refusal({"choices": [{"finish_reason": "stop", "message": []}]})
+expect_refusal(
+    {
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "   ", "refusal": None},
+            }
+        ]
+    }
+)
+expect_refusal(
+    {
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "text", "refusal": "blocked"},
+            }
+        ]
+    }
+)
+
+hidden_shop = copy.deepcopy(SHOP)
+hidden_shop["products"] = [
+    {"sku": "SKU-MINT", "name": "Mint", "on_hand": 7, "reorder_point": 7},
+    *reversed(hidden_shop["products"]),
+]
+hidden_response = copy.deepcopy(GOOD_RESPONSE)
+hidden_response["choices"][0]["message"]["content"] = "A completed draft for review."
+hidden_connected = morning_brief(hidden_shop, hidden_response, read_brief)
+assert hidden_connected["shop_snapshot"] == snapshot_id(hidden_shop)
+assert next(row for row in hidden_connected["facts"] if row["sku"] == "SKU-MINT")["needed"] == 0
+assert hidden_connected["claim"] == "DRAFT_FOR_REVIEW"
+handoff_connected = morning_brief(SHOP, GOOD_RESPONSE, read_brief)
+Path("ch01-unit-a-handoff-v1.json").write_text(
+    json.dumps(handoff_connected, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+)
+print("HOLDOUT_RESULT=" + json.dumps({"unit": "ch01-a", "status": "PASSED"}, sort_keys=True))

--- a/book/always_on/exercises/ch03/holdouts/unit-a-holdout-v1.py
+++ b/book/always_on/exercises/ch03/holdouts/unit-a-holdout-v1.py
@@ -1,0 +1,45 @@
+"""Instructor-held checks appended after a submitted Chapter 3 Unit A notebook."""
+
+# ruff: noqa: F821 - executed inside the submitted notebook namespace
+
+import json
+
+assert (
+    decide_admission({"used_calls": 4, "max_calls": 4, "spent": 9, "next_cost": 3, "budget": 10})
+    == "MODEL_CALL_LIMIT"
+)
+assert (
+    decide_admission({"used_calls": 2, "max_calls": 4, "spent": 9, "next_cost": 3, "budget": 10})
+    == "MODEL_COST_LIMIT"
+)
+assert (
+    decide_admission({"used_calls": 2, "max_calls": 4, "spent": 7, "next_cost": 3, "budget": 10})
+    == "CALL"
+)
+
+
+class HiddenFailedModel:
+    def complete(self, messages, tools):
+        raise ModelError("hidden fixture failure")
+
+
+failed_hidden = run_loop(
+    HiddenFailedModel(),
+    dispatcher,
+    INITIAL_MESSAGES,
+    decide_admission,
+    max_calls=5,
+    call_cost=7,
+    budget=20,
+)
+assert failed_hidden["status"] == "MODEL_FAILED"
+assert failed_hidden["model_calls"] == 1
+assert failed_hidden["estimated_pence"] == 7
+handoff_connected = run_loop(
+    ReplayModel(OPENING_TURNS), dispatcher, INITIAL_MESSAGES, decide_admission
+)
+assert handoff_connected["status"] == "COMPLETED"
+Path("ch03-unit-a-handoff-v1.json").write_text(
+    json.dumps(handoff_connected, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+)
+print("HOLDOUT_RESULT=" + json.dumps({"unit": "ch03-a", "status": "PASSED"}, sort_keys=True))

--- a/book/always_on/exercises/ch03/holdouts/unit-b-holdout-v1.py
+++ b/book/always_on/exercises/ch03/holdouts/unit-b-holdout-v1.py
@@ -1,0 +1,24 @@
+"""Instructor-held checks appended after a submitted Chapter 3 Unit B notebook."""
+
+# ruff: noqa: F821 - executed inside the submitted notebook namespace
+
+import json
+
+hidden_lab = RuntimeLab(ROOT, 3)
+try:
+    original_probe = hidden_lab.probe.read_text(encoding="utf-8")
+    assert original_probe.count("estimated_call_pence=5") == 1
+    hidden_lab.probe.write_text(
+        original_probe.replace("estimated_call_pence=5", "estimated_call_pence=7"),
+        encoding="utf-8",
+    )
+    hidden_lab.break_source()
+    hidden_lab.repair(repair_fragment())
+    hidden_result = hidden_lab.run(
+        "HIDDEN_REPAIR",
+        expected={"estimated_pence": 7, "model_calls": 1, "stop_reason": "MODEL_FAILED"},
+    )
+finally:
+    hidden_lab.close()
+assert hidden_result["status"] == "PASS"
+print("HOLDOUT_RESULT=" + json.dumps({"unit": "ch03-b", "status": "PASSED"}, sort_keys=True))

--- a/book/always_on/exercises/ch03/instructor-guide-v1.md
+++ b/book/always_on/exercises/ch03/instructor-guide-v1.md
@@ -1,0 +1,48 @@
+# Teach Chapter 3 through bounded admission and real-source repair
+
+**Created:** 2026-09-09 · **Status:** DRAFT instructor edition v1
+
+Unit A constructs the admission boundary and connects it to a small model–tool–observation loop using the actual Chapter 2 dispatcher. Unit B then mutates a temporary copy of `book/always_on/learner/ch03.py` and repairs the actual failed-call exposure accounting.
+
+## Learning evidence
+
+A learner should be able to:
+
+1. predict assistant/tool transcript order and trace a tool-call identifier;
+2. implement call-count and cost admission before the next provider attempt;
+3. explain why a failed admitted call remains counted;
+4. distinguish final prose from retained tool evidence;
+5. reproduce a real-source accounting fault, repair it, and retain the before/after observation;
+6. explain repeated call identifiers and provider failure as distinct stop reasons;
+7. transfer the repair to an unseen configured estimate.
+
+## Schedule
+
+Use 75–90 minutes for Unit A and 60–75 for Unit B. Do not spend class time on a live model. The replay turns make control flow reproducible; a later optional experiment can compare live model decisions without changing the loop exercise.
+
+Require a prediction before each admission row, the successful replay, the broken exposure probe, the repeated identifier, and the failed provider. Use hints in order. Reveal the solution only after the learner retains an attempt and a falsifiable explanation.
+
+## Assessment
+
+| Criterion | Full evidence |
+| --- | --- |
+| Admission | novel call/cost cases pass without input mutation |
+| Connection | the learner decision controls every attempted model turn in the notebook loop |
+| Transcript | request and observation identifiers are traced; prose is not treated as draft evidence |
+| Repair | the real copied source returns the baseline result after mutation |
+| Transfer | the seven-pence hidden probe retains one call and seven pence after failure |
+
+Suggested progression is 8/10 with full marks on admission and failure accounting. Notebook execution alone is not a pass: the student starter deliberately reports `NEEDS_WORK`.
+
+## Worked answers
+
+Call-limit precedence makes an exhausted call allowance stop even when money is also exhausted. Equality at the money boundary is allowed. The loop increments the attempt and configured exposure before calling the provider, so an exception returns `MODEL_FAILED`, one attempted call, and the admitted exposure.
+
+The real-source mutation removes only exposure accounting. It does not change `model_count += 1`, so the pair of observations isolates the fault. The correct fragment is `exposure += limits.estimated_call_pence`. The hidden check changes five pence to seven; a printed constant or visible-output special case fails.
+
+The replay fixture proves the loop/dispatcher control flow. It does not prove a model would select those calls. The Chapter 2 dispatcher validates and computes drafts; the final explanation remains separate from its tool observations.
+
+## Operational boundary
+
+`RuntimeLab` copies reviewed source and runs a bounded local subprocess. It is not isolation for arbitrary code. The student should inspect the probe before running it. No credential, network call, supplier process, purchase, or hard kill is used in Chapter 3.
+

--- a/book/always_on/exercises/ch03/solutions/unit-a-solution-v1.py
+++ b/book/always_on/exercises/ch03/solutions/unit-a-solution-v1.py
@@ -1,0 +1,9 @@
+"""Instructor solution for Chapter 3 Unit A. Excluded from the student release."""
+
+
+def decide_admission(case):
+    if case["used_calls"] >= case["max_calls"]:
+        return "MODEL_CALL_LIMIT"
+    if case["spent"] + case["next_cost"] > case["budget"]:
+        return "MODEL_COST_LIMIT"
+    return "CALL"

--- a/book/always_on/exercises/ch03/solutions/unit-b-solution-v1.py
+++ b/book/always_on/exercises/ch03/solutions/unit-b-solution-v1.py
@@ -1,0 +1,5 @@
+"""Instructor solution for Chapter 3 Unit B. Excluded from the student release."""
+
+
+def repair_fragment():
+    return "exposure += limits.estimated_call_pence"

--- a/book/always_on/exercises/ch03/unit-a-bounded-loop-v1.ipynb
+++ b/book/always_on/exercises/ch03/unit-a-bounded-loop-v1.ipynb
@@ -1,0 +1,431 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9db95ae7df97c12e",
+   "metadata": {},
+   "source": [
+    "# Chapter 3, Unit A — Build a bounded model and tool loop\n",
+    "\n",
+    "**Student edition v1 · 2026-09-09 · 75–90 minutes**\n",
+    "\n",
+    "Lucy asks what needs ordering. One model turn requests stock, another requests two drafts, and a final turn explains the results. You will implement the admission decision that governs every model call, connect it to a real Chapter 2 tool dispatcher, and retain the transcript for Unit B.\n",
+    "\n",
+    "This unit requires the Sovereign Agent checkout and Python 3.14. It uses authored model turns and makes no network call or purchase.\n",
+    "\n",
+    "## 1. Locate the cumulative code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb44dd5195e7a2b2",
+   "metadata": {
+    "tags": [
+     "setup"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "import json\n",
+    "import os\n",
+    "import runpy\n",
+    "import sys\n",
+    "from dataclasses import dataclass\n",
+    "from pathlib import Path\n",
+    "\n",
+    "assert sys.version_info >= (3, 14)\n",
+    "start = Path(os.environ.get(\"SOVEREIGN_AGENT_REPO\", Path.cwd())).resolve()\n",
+    "ROOT = next(\n",
+    "    (\n",
+    "        path\n",
+    "        for path in (start, *start.parents)\n",
+    "        if (path / \"book/always_on/learner/ch02.py\").is_file()\n",
+    "    ),\n",
+    "    None,\n",
+    ")\n",
+    "if ROOT is None:\n",
+    "    raise RuntimeError(\"Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.\")\n",
+    "\n",
+    "\n",
+    "def run_book(relative):\n",
+    "    previous = Path.cwd()\n",
+    "    try:\n",
+    "        os.chdir(ROOT)\n",
+    "        return runpy.run_path(str(ROOT / relative))\n",
+    "    finally:\n",
+    "        os.chdir(previous)\n",
+    "\n",
+    "\n",
+    "chapter2 = run_book(\"book/always_on/learner/ch02.py\")\n",
+    "ToolCall = chapter2[\"ToolCall\"]\n",
+    "dispatcher = chapter2[\"build_tools\"](chapter2[\"SHOP\"])\n",
+    "print(\"tools\", [schema[\"function\"][\"name\"] for schema in dispatcher.schemas()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a81adb2e82813073",
+   "metadata": {},
+   "source": [
+    "Predict the transcript roles for stock lookup, two draft calls and a final answer. A tool observation must retain the request's call identifier.\n",
+    "\n",
+    "## 2. Represent authored model turns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd51ff6616e01a6d",
+   "metadata": {
+    "tags": [
+     "setup"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "class ModelError(RuntimeError):\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "@dataclass(frozen=True)\n",
+    "class ModelTurn:\n",
+    "    content: str = \"\"\n",
+    "    calls: tuple = ()\n",
+    "\n",
+    "    def message(self):\n",
+    "        message = {\"role\": \"assistant\", \"content\": self.content}\n",
+    "        if self.calls:\n",
+    "            message[\"tool_calls\"] = [\n",
+    "                {\n",
+    "                    \"id\": call.id,\n",
+    "                    \"type\": \"function\",\n",
+    "                    \"function\": {\n",
+    "                        \"name\": call.name,\n",
+    "                        \"arguments\": json.dumps(call.arguments, sort_keys=True),\n",
+    "                    },\n",
+    "                }\n",
+    "                for call in self.calls\n",
+    "            ]\n",
+    "        return message\n",
+    "\n",
+    "\n",
+    "class ReplayModel:\n",
+    "    def __init__(self, turns):\n",
+    "        self.turns = iter(turns)\n",
+    "\n",
+    "    def complete(self, messages, tools):\n",
+    "        try:\n",
+    "            return next(self.turns)\n",
+    "        except StopIteration:\n",
+    "            raise ModelError(\"fixture exhausted\") from None\n",
+    "\n",
+    "\n",
+    "OPENING_TURNS = [\n",
+    "    ModelTurn(calls=(ToolCall(id=\"stock-1\", name=\"list_stock\", arguments={}),)),\n",
+    "    ModelTurn(\n",
+    "        calls=(\n",
+    "            ToolCall(\n",
+    "                id=\"draft-v\", name=\"draft_order\", arguments={\"sku\": \"SKU-VANILLA\", \"quantity\": 6}\n",
+    "            ),\n",
+    "            ToolCall(\n",
+    "                id=\"draft-s\", name=\"draft_order\", arguments={\"sku\": \"SKU-STRAWBERRY\", \"quantity\": 4}\n",
+    "            ),\n",
+    "        )\n",
+    "    ),\n",
+    "    ModelTurn(\"Drafts total 2600 pence GBP. No purchase was made.\"),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d541ead97a057f46",
+   "metadata": {},
+   "source": [
+    "## 3. Construct model-call admission\n",
+    "\n",
+    "The starter always admits another call. Repair it so call count and configured estimated exposure both stop the loop before another provider attempt. Check the call limit first. Inputs are already validated nonnegative integers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3fd6e6c9b81dcc37",
+   "metadata": {
+    "tags": [
+     "exercise",
+     "learner-owned",
+     "ch03-admission"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def decide_admission(case):\n",
+    "    \"\"\"Return CALL, MODEL_CALL_LIMIT, or MODEL_COST_LIMIT.\"\"\"\n",
+    "    return \"CALL\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5edc2e7c72835a4f",
+   "metadata": {},
+   "source": [
+    "<details><summary>Hint 1 — the decision</summary>\n",
+    "\n",
+    "Admission asks whether the *next* call may begin. Used attempts never disappear because the previous provider failed.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 2 — the evidence</summary>\n",
+    "\n",
+    "Inspect `used_calls`, `max_calls`, `spent`, `next_cost`, and `budget`. Equality at the money boundary is allowed; exceeding it is not.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 3 — the structure</summary>\n",
+    "\n",
+    "Return `MODEL_CALL_LIMIT` when `used_calls >= max_calls`; otherwise return `MODEL_COST_LIMIT` when `spent + next_cost > budget`; otherwise return `CALL`.\n",
+    "\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bd6933b5fbe66dd",
+   "metadata": {
+    "tags": [
+     "assessment",
+     "visible"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "VISIBLE_CASES = [\n",
+    "    ({\"used_calls\": 0, \"max_calls\": 3, \"spent\": 0, \"next_cost\": 2, \"budget\": 6}, \"CALL\"),\n",
+    "    (\n",
+    "        {\"used_calls\": 3, \"max_calls\": 3, \"spent\": 0, \"next_cost\": 0, \"budget\": 6},\n",
+    "        \"MODEL_CALL_LIMIT\",\n",
+    "    ),\n",
+    "    (\n",
+    "        {\"used_calls\": 1, \"max_calls\": 3, \"spent\": 5, \"next_cost\": 2, \"budget\": 6},\n",
+    "        \"MODEL_COST_LIMIT\",\n",
+    "    ),\n",
+    "    ({\"used_calls\": 1, \"max_calls\": 3, \"spent\": 4, \"next_cost\": 2, \"budget\": 6}, \"CALL\"),\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def grade_admission(candidate, cases):\n",
+    "    rows = []\n",
+    "    for number, (case, expected) in enumerate(cases, 1):\n",
+    "        supplied = copy.deepcopy(case)\n",
+    "        try:\n",
+    "            observed = candidate(supplied)\n",
+    "        except Exception as error:\n",
+    "            observed = type(error).__name__\n",
+    "        rows.append(\n",
+    "            {\n",
+    "                \"case\": number,\n",
+    "                \"expected\": expected,\n",
+    "                \"observed\": observed,\n",
+    "                \"status\": \"PASS\" if observed == expected and supplied == case else \"FAIL\",\n",
+    "            }\n",
+    "        )\n",
+    "    return rows\n",
+    "\n",
+    "\n",
+    "visible_results = grade_admission(decide_admission, VISIBLE_CASES)\n",
+    "VISIBLE_PASSED = all(row[\"status\"] == \"PASS\" for row in visible_results)\n",
+    "print(json.dumps(visible_results, indent=2))\n",
+    "print(\"VISIBLE_CONTRACT\", \"PASSED\" if VISIBLE_PASSED else \"NEEDS_WORK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d51764e555495d48",
+   "metadata": {},
+   "source": [
+    "## 4. Connect admission to the loop\n",
+    "\n",
+    "The loop calls your decision before every model attempt. It increments calls and estimated exposure before invoking the provider, preserves assistant tool requests, invokes the real Chapter 2 dispatcher, and appends identified observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fdfc591e00d1f80",
+   "metadata": {
+    "tags": [
+     "integration",
+     "learner-path"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def run_loop(\n",
+    "    model, tool_dispatcher, initial_messages, admission, *, max_calls=4, call_cost=2, budget=8\n",
+    "):\n",
+    "    transcript = copy.deepcopy(initial_messages)\n",
+    "    model_calls = 0\n",
+    "    tool_calls = 0\n",
+    "    spent = 0\n",
+    "    seen = set()\n",
+    "    while True:\n",
+    "        decision = admission(\n",
+    "            {\n",
+    "                \"used_calls\": model_calls,\n",
+    "                \"max_calls\": max_calls,\n",
+    "                \"spent\": spent,\n",
+    "                \"next_cost\": call_cost,\n",
+    "                \"budget\": budget,\n",
+    "            }\n",
+    "        )\n",
+    "        if decision != \"CALL\":\n",
+    "            return {\n",
+    "                \"status\": decision,\n",
+    "                \"messages\": transcript,\n",
+    "                \"model_calls\": model_calls,\n",
+    "                \"tool_calls\": tool_calls,\n",
+    "                \"estimated_pence\": spent,\n",
+    "            }\n",
+    "        model_calls += 1\n",
+    "        spent += call_cost\n",
+    "        try:\n",
+    "            turn = model.complete(copy.deepcopy(transcript), tool_dispatcher.schemas())\n",
+    "        except ModelError:\n",
+    "            return {\n",
+    "                \"status\": \"MODEL_FAILED\",\n",
+    "                \"messages\": transcript,\n",
+    "                \"model_calls\": model_calls,\n",
+    "                \"tool_calls\": tool_calls,\n",
+    "                \"estimated_pence\": spent,\n",
+    "            }\n",
+    "        identifiers = [call.id for call in turn.calls]\n",
+    "        if len(identifiers) != len(set(identifiers)) or seen.intersection(identifiers):\n",
+    "            return {\n",
+    "                \"status\": \"REPEATED_CALL_ID\",\n",
+    "                \"messages\": transcript,\n",
+    "                \"model_calls\": model_calls,\n",
+    "                \"tool_calls\": tool_calls,\n",
+    "                \"estimated_pence\": spent,\n",
+    "            }\n",
+    "        seen.update(identifiers)\n",
+    "        transcript.append(turn.message())\n",
+    "        if not turn.calls:\n",
+    "            return {\n",
+    "                \"status\": \"COMPLETED\" if turn.content.strip() else \"EMPTY_REPLY\",\n",
+    "                \"messages\": transcript,\n",
+    "                \"model_calls\": model_calls,\n",
+    "                \"tool_calls\": tool_calls,\n",
+    "                \"estimated_pence\": spent,\n",
+    "                \"answer\": turn.content,\n",
+    "            }\n",
+    "        for call in turn.calls:\n",
+    "            tool_calls += 1\n",
+    "            result = tool_dispatcher.invoke(call)\n",
+    "            transcript.append(\n",
+    "                {\n",
+    "                    \"role\": \"tool\",\n",
+    "                    \"tool_call_id\": call.id,\n",
+    "                    \"content\": json.dumps(result, sort_keys=True),\n",
+    "                }\n",
+    "            )\n",
+    "\n",
+    "\n",
+    "INITIAL_MESSAGES = [\n",
+    "    {\"role\": \"system\", \"content\": \"Use stock tools to prepare drafts. Never purchase.\"},\n",
+    "    {\"role\": \"user\", \"content\": \"What needs ordering?\"},\n",
+    "]\n",
+    "connected = None\n",
+    "if VISIBLE_PASSED:\n",
+    "    connected = run_loop(\n",
+    "        ReplayModel(OPENING_TURNS),\n",
+    "        dispatcher,\n",
+    "        INITIAL_MESSAGES,\n",
+    "        decide_admission,\n",
+    "    )\n",
+    "    print(connected[\"status\"], connected[\"model_calls\"], connected[\"tool_calls\"])\n",
+    "    print([message[\"role\"] for message in connected[\"messages\"]])\n",
+    "    assert connected[\"status\"] == \"COMPLETED\"\n",
+    "    assert (connected[\"model_calls\"], connected[\"tool_calls\"]) == (3, 3)\n",
+    "else:\n",
+    "    print(\"CONNECTION_NOT_READY — repair decide_admission, then run again.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01e580d5363d5e88",
+   "metadata": {},
+   "source": [
+    "Trace one `tool_call_id` from assistant request to tool observation. Final prose alone does not prove the two draft tools returned valid results.\n",
+    "\n",
+    "## 5. Save the bounded transcript"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "712d4ec7a6079218",
+   "metadata": {
+    "tags": [
+     "handoff"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ARTIFACT_PATH = Path(\"ch03-unit-a-handoff-v1.json\")\n",
+    "artifact_status = \"NOT_WRITTEN\"\n",
+    "if connected is not None:\n",
+    "    encoded = json.dumps(connected, indent=2, sort_keys=True) + \"\\n\"\n",
+    "    ARTIFACT_PATH.write_text(encoded, encoding=\"utf-8\")\n",
+    "    artifact_status = \"WRITTEN\"\n",
+    "    print(ARTIFACT_PATH)\n",
+    "else:\n",
+    "    print(\"HANDOFF_NOT_WRITTEN\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab54f9cb1e612efc",
+   "metadata": {},
+   "source": [
+    "## Exit ticket\n",
+    "\n",
+    "Explain why failed provider attempts count, why call-limit precedence matters when two limits are exhausted, and which transcript observation proves each draft tool actually ran."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "603799febcf1c718",
+   "metadata": {
+    "tags": [
+     "exercise-report"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "exercise_report = {\n",
+    "    \"unit\": \"ch03-a\",\n",
+    "    \"attempted\": 1,\n",
+    "    \"completed\": int(VISIBLE_PASSED),\n",
+    "    \"failed\": int(not VISIBLE_PASSED),\n",
+    "    \"skipped\": 0,\n",
+    "    \"connection\": \"PASSED\" if connected else \"NOT_READY\",\n",
+    "    \"handoff\": artifact_status,\n",
+    "}\n",
+    "print(\"EXERCISE_REPORT=\" + json.dumps(exercise_report, sort_keys=True))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/book/always_on/exercises/ch03/unit-a-bounded-loop-v1.md
+++ b/book/always_on/exercises/ch03/unit-a-bounded-loop-v1.md
@@ -1,0 +1,314 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+# Chapter 3, Unit A — Build a bounded model and tool loop
+
+**Student edition v1 · 2026-09-09 · 75–90 minutes**
+
+Lucy asks what needs ordering. One model turn requests stock, another requests two drafts, and a final turn explains the results. You will implement the admission decision that governs every model call, connect it to a real Chapter 2 tool dispatcher, and retain the transcript for Unit B.
+
+This unit requires the Sovereign Agent checkout and Python 3.14. It uses authored model turns and makes no network call or purchase.
+
+## 1. Locate the cumulative code
+
+```python tags=["setup"]
+import copy
+import json
+import os
+import runpy
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+assert sys.version_info >= (3, 14)
+start = Path(os.environ.get("SOVEREIGN_AGENT_REPO", Path.cwd())).resolve()
+ROOT = next(
+    (
+        path
+        for path in (start, *start.parents)
+        if (path / "book/always_on/learner/ch02.py").is_file()
+    ),
+    None,
+)
+if ROOT is None:
+    raise RuntimeError("Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.")
+
+
+def run_book(relative):
+    previous = Path.cwd()
+    try:
+        os.chdir(ROOT)
+        return runpy.run_path(str(ROOT / relative))
+    finally:
+        os.chdir(previous)
+
+
+chapter2 = run_book("book/always_on/learner/ch02.py")
+ToolCall = chapter2["ToolCall"]
+dispatcher = chapter2["build_tools"](chapter2["SHOP"])
+print("tools", [schema["function"]["name"] for schema in dispatcher.schemas()])
+```
+
+Predict the transcript roles for stock lookup, two draft calls and a final answer. A tool observation must retain the request's call identifier.
+
+## 2. Represent authored model turns
+
+```python tags=["setup"]
+class ModelError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ModelTurn:
+    content: str = ""
+    calls: tuple = ()
+
+    def message(self):
+        message = {"role": "assistant", "content": self.content}
+        if self.calls:
+            message["tool_calls"] = [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {
+                        "name": call.name,
+                        "arguments": json.dumps(call.arguments, sort_keys=True),
+                    },
+                }
+                for call in self.calls
+            ]
+        return message
+
+
+class ReplayModel:
+    def __init__(self, turns):
+        self.turns = iter(turns)
+
+    def complete(self, messages, tools):
+        try:
+            return next(self.turns)
+        except StopIteration:
+            raise ModelError("fixture exhausted") from None
+
+
+OPENING_TURNS = [
+    ModelTurn(calls=(ToolCall(id="stock-1", name="list_stock", arguments={}),)),
+    ModelTurn(
+        calls=(
+            ToolCall(
+                id="draft-v", name="draft_order", arguments={"sku": "SKU-VANILLA", "quantity": 6}
+            ),
+            ToolCall(
+                id="draft-s", name="draft_order", arguments={"sku": "SKU-STRAWBERRY", "quantity": 4}
+            ),
+        )
+    ),
+    ModelTurn("Drafts total 2600 pence GBP. No purchase was made."),
+]
+```
+
+## 3. Construct model-call admission
+
+The starter always admits another call. Repair it so call count and configured estimated exposure both stop the loop before another provider attempt. Check the call limit first. Inputs are already validated nonnegative integers.
+
+```python tags=["exercise", "learner-owned", "ch03-admission"]
+def decide_admission(case):
+    """Return CALL, MODEL_CALL_LIMIT, or MODEL_COST_LIMIT."""
+    return "CALL"
+```
+
+<details><summary>Hint 1 — the decision</summary>
+
+Admission asks whether the *next* call may begin. Used attempts never disappear because the previous provider failed.
+
+</details>
+
+<details><summary>Hint 2 — the evidence</summary>
+
+Inspect `used_calls`, `max_calls`, `spent`, `next_cost`, and `budget`. Equality at the money boundary is allowed; exceeding it is not.
+
+</details>
+
+<details><summary>Hint 3 — the structure</summary>
+
+Return `MODEL_CALL_LIMIT` when `used_calls >= max_calls`; otherwise return `MODEL_COST_LIMIT` when `spent + next_cost > budget`; otherwise return `CALL`.
+
+</details>
+
+```python tags=["assessment", "visible"]
+VISIBLE_CASES = [
+    ({"used_calls": 0, "max_calls": 3, "spent": 0, "next_cost": 2, "budget": 6}, "CALL"),
+    (
+        {"used_calls": 3, "max_calls": 3, "spent": 0, "next_cost": 0, "budget": 6},
+        "MODEL_CALL_LIMIT",
+    ),
+    (
+        {"used_calls": 1, "max_calls": 3, "spent": 5, "next_cost": 2, "budget": 6},
+        "MODEL_COST_LIMIT",
+    ),
+    ({"used_calls": 1, "max_calls": 3, "spent": 4, "next_cost": 2, "budget": 6}, "CALL"),
+]
+
+
+def grade_admission(candidate, cases):
+    rows = []
+    for number, (case, expected) in enumerate(cases, 1):
+        supplied = copy.deepcopy(case)
+        try:
+            observed = candidate(supplied)
+        except Exception as error:
+            observed = type(error).__name__
+        rows.append(
+            {
+                "case": number,
+                "expected": expected,
+                "observed": observed,
+                "status": "PASS" if observed == expected and supplied == case else "FAIL",
+            }
+        )
+    return rows
+
+
+visible_results = grade_admission(decide_admission, VISIBLE_CASES)
+VISIBLE_PASSED = all(row["status"] == "PASS" for row in visible_results)
+print(json.dumps(visible_results, indent=2))
+print("VISIBLE_CONTRACT", "PASSED" if VISIBLE_PASSED else "NEEDS_WORK")
+```
+
+## 4. Connect admission to the loop
+
+The loop calls your decision before every model attempt. It increments calls and estimated exposure before invoking the provider, preserves assistant tool requests, invokes the real Chapter 2 dispatcher, and appends identified observations.
+
+```python tags=["integration", "learner-path"]
+def run_loop(
+    model, tool_dispatcher, initial_messages, admission, *, max_calls=4, call_cost=2, budget=8
+):
+    transcript = copy.deepcopy(initial_messages)
+    model_calls = 0
+    tool_calls = 0
+    spent = 0
+    seen = set()
+    while True:
+        decision = admission(
+            {
+                "used_calls": model_calls,
+                "max_calls": max_calls,
+                "spent": spent,
+                "next_cost": call_cost,
+                "budget": budget,
+            }
+        )
+        if decision != "CALL":
+            return {
+                "status": decision,
+                "messages": transcript,
+                "model_calls": model_calls,
+                "tool_calls": tool_calls,
+                "estimated_pence": spent,
+            }
+        model_calls += 1
+        spent += call_cost
+        try:
+            turn = model.complete(copy.deepcopy(transcript), tool_dispatcher.schemas())
+        except ModelError:
+            return {
+                "status": "MODEL_FAILED",
+                "messages": transcript,
+                "model_calls": model_calls,
+                "tool_calls": tool_calls,
+                "estimated_pence": spent,
+            }
+        identifiers = [call.id for call in turn.calls]
+        if len(identifiers) != len(set(identifiers)) or seen.intersection(identifiers):
+            return {
+                "status": "REPEATED_CALL_ID",
+                "messages": transcript,
+                "model_calls": model_calls,
+                "tool_calls": tool_calls,
+                "estimated_pence": spent,
+            }
+        seen.update(identifiers)
+        transcript.append(turn.message())
+        if not turn.calls:
+            return {
+                "status": "COMPLETED" if turn.content.strip() else "EMPTY_REPLY",
+                "messages": transcript,
+                "model_calls": model_calls,
+                "tool_calls": tool_calls,
+                "estimated_pence": spent,
+                "answer": turn.content,
+            }
+        for call in turn.calls:
+            tool_calls += 1
+            result = tool_dispatcher.invoke(call)
+            transcript.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": json.dumps(result, sort_keys=True),
+                }
+            )
+
+
+INITIAL_MESSAGES = [
+    {"role": "system", "content": "Use stock tools to prepare drafts. Never purchase."},
+    {"role": "user", "content": "What needs ordering?"},
+]
+connected = None
+if VISIBLE_PASSED:
+    connected = run_loop(
+        ReplayModel(OPENING_TURNS),
+        dispatcher,
+        INITIAL_MESSAGES,
+        decide_admission,
+    )
+    print(connected["status"], connected["model_calls"], connected["tool_calls"])
+    print([message["role"] for message in connected["messages"]])
+    assert connected["status"] == "COMPLETED"
+    assert (connected["model_calls"], connected["tool_calls"]) == (3, 3)
+else:
+    print("CONNECTION_NOT_READY — repair decide_admission, then run again.")
+```
+
+Trace one `tool_call_id` from assistant request to tool observation. Final prose alone does not prove the two draft tools returned valid results.
+
+## 5. Save the bounded transcript
+
+```python tags=["handoff"]
+ARTIFACT_PATH = Path("ch03-unit-a-handoff-v1.json")
+artifact_status = "NOT_WRITTEN"
+if connected is not None:
+    encoded = json.dumps(connected, indent=2, sort_keys=True) + "\n"
+    ARTIFACT_PATH.write_text(encoded, encoding="utf-8")
+    artifact_status = "WRITTEN"
+    print(ARTIFACT_PATH)
+else:
+    print("HANDOFF_NOT_WRITTEN")
+```
+
+## Exit ticket
+
+Explain why failed provider attempts count, why call-limit precedence matters when two limits are exhausted, and which transcript observation proves each draft tool actually ran.
+
+```python tags=["exercise-report"]
+exercise_report = {
+    "unit": "ch03-a",
+    "attempted": 1,
+    "completed": int(VISIBLE_PASSED),
+    "failed": int(not VISIBLE_PASSED),
+    "skipped": 0,
+    "connection": "PASSED" if connected else "NOT_READY",
+    "handoff": artifact_status,
+}
+print("EXERCISE_REPORT=" + json.dumps(exercise_report, sort_keys=True))
+```

--- a/book/always_on/exercises/ch03/unit-b-failure-accounting-v1.ipynb
+++ b/book/always_on/exercises/ch03/unit-b-failure-accounting-v1.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "605e00d80e3f5a6b",
+   "metadata": {},
+   "source": [
+    "# Chapter 3, Unit B — Repair failed-call accounting\n",
+    "\n",
+    "**Student edition v1 · 2026-09-09 · 60–75 minutes**\n",
+    "\n",
+    "The bounded loop works when the provider cooperates. Now a provider fails on its first admitted call. You will break a temporary copy of the actual Chapter 3 learner implementation, repair the accounting line, and test a second failure shape.\n",
+    "\n",
+    "This unit runs reviewed local course code in bounded subprocesses. It is not a security sandbox.\n",
+    "\n",
+    "## 1. Verify the Unit A handoff and load the real experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9ef780619d696e4",
+   "metadata": {
+    "tags": [
+     "setup",
+     "handoff-consumer"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import runpy\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "assert sys.version_info >= (3, 14)\n",
+    "start = Path(os.environ.get(\"SOVEREIGN_AGENT_REPO\", Path.cwd())).resolve()\n",
+    "ROOT = next(\n",
+    "    (\n",
+    "        path\n",
+    "        for path in (start, *start.parents)\n",
+    "        if (path / \"book/always_on/learner/ch03.py\").is_file()\n",
+    "    ),\n",
+    "    None,\n",
+    ")\n",
+    "if ROOT is None:\n",
+    "    raise RuntimeError(\"Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.\")\n",
+    "\n",
+    "\n",
+    "def run_book(relative):\n",
+    "    previous = Path.cwd()\n",
+    "    try:\n",
+    "        os.chdir(ROOT)\n",
+    "        return runpy.run_path(str(ROOT / relative))\n",
+    "    finally:\n",
+    "        os.chdir(previous)\n",
+    "\n",
+    "\n",
+    "HANDOFF_PATH = Path(\"ch03-unit-a-handoff-v1.json\")\n",
+    "handoff_status = \"MISSING\"\n",
+    "if HANDOFF_PATH.is_file():\n",
+    "    handoff = json.loads(HANDOFF_PATH.read_text(encoding=\"utf-8\"))\n",
+    "    handoff_status = \"VERIFIED\" if handoff.get(\"status\") == \"COMPLETED\" else \"INVALID\"\n",
+    "print(\"UNIT_A_HANDOFF\", handoff_status)\n",
+    "\n",
+    "support = runpy.run_path(str(ROOT / \"book/always_on/educator/runtime_labs_v1.py\"))\n",
+    "RuntimeLab = support[\"RuntimeLab\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b33795a360e65397",
+   "metadata": {},
+   "source": [
+    "Predict the baseline observation. If the provider fails after admission, should the local result record zero or one model attempt? Should the configured five-pence exposure disappear?\n",
+    "\n",
+    "## 2. Break the real source copy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b480b72b258385f",
+   "metadata": {
+    "tags": [
+     "failure-experiment"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "lab = RuntimeLab(ROOT, 3)\n",
+    "baseline = lab.run(\"BASELINE\", expected=lab.spec[\"expected_baseline\"])\n",
+    "lab.break_source()\n",
+    "broken = lab.run(\"BROKEN\", expected=lab.spec[\"expected_broken\"])\n",
+    "print(json.dumps({\"baseline\": baseline[\"observation\"], \"broken\": broken[\"observation\"]}, indent=2))\n",
+    "assert baseline[\"status\"] == \"PASS\"\n",
+    "assert broken[\"status\"] == \"PASS\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54c9799ebbe8c02d",
+   "metadata": {},
+   "source": [
+    "The broken source changes `exposure += limits.estimated_call_pence` to `exposure += 0`. The model-call counter still advances. This separates attempted calls from configured cost exposure and makes repeated failures look free.\n",
+    "\n",
+    "## 3. Construct the repair\n",
+    "\n",
+    "Return the complete replacement for the one marked broken fragment. The starter repeats the broken code and therefore fails the baseline contract."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe699b33a8d71ee4",
+   "metadata": {
+    "tags": [
+     "exercise",
+     "learner-owned",
+     "ch03-repair"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def repair_fragment():\n",
+    "    return \"exposure += 0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfd058559ea8946a",
+   "metadata": {},
+   "source": [
+    "<details><summary>Hint 1 — the decision</summary>\n",
+    "\n",
+    "Repair the accounting statement; do not change the provider fixture, expected result, or call counter.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 2 — the evidence</summary>\n",
+    "\n",
+    "Compare `baseline[\"observation\"]` with `broken[\"observation\"]`. Only `estimated_pence` should change.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 3 — the structure</summary>\n",
+    "\n",
+    "The replacement adds `limits.estimated_call_pence` to `exposure` before `model.complete` begins.\n",
+    "\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4e8a81d78943fa1",
+   "metadata": {
+    "tags": [
+     "integration",
+     "learner-path"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "lab.repair(repair_fragment())\n",
+    "student_repair = lab.run(\"STUDENT_REPAIR\", expected=lab.spec[\"expected_baseline\"])\n",
+    "REPAIR_PASSED = student_repair[\"status\"] == \"PASS\"\n",
+    "print(json.dumps(student_repair[\"observation\"], indent=2))\n",
+    "print(\"REAL_SOURCE_REPAIR\", \"PASSED\" if REPAIR_PASSED else \"NEEDS_WORK\")\n",
+    "lab.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc5e928ccc684c0c",
+   "metadata": {},
+   "source": [
+    "The original checkout is never edited. `RuntimeLab` fingerprints it, copies the real source and probe, executes the copy, and checks the original again after every run.\n",
+    "\n",
+    "## 4. Challenge two termination paths\n",
+    "\n",
+    "Use the real Chapter 3 loop. First, repeat a tool-call identifier. Then fail on the first provider call. Predict the result status and counters before running."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f028e4a4335ac2bd",
+   "metadata": {
+    "tags": [
+     "challenge"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "chapter3 = run_book(\"book/always_on/learner/ch03.py\")\n",
+    "ToolCall = chapter3[\"ToolCall\"]\n",
+    "ModelTurn = chapter3[\"ModelTurn\"]\n",
+    "ReplayModel = chapter3[\"ReplayModel\"]\n",
+    "Limits = chapter3[\"Limits\"]\n",
+    "run_loop = chapter3[\"run_loop\"]\n",
+    "dispatcher = chapter3[\"shop_tools\"][\"build_tools\"](chapter3[\"shop_tools\"][\"SHOP\"])\n",
+    "\n",
+    "repeated = run_loop(\n",
+    "    ReplayModel(\n",
+    "        [\n",
+    "            ModelTurn(calls=(ToolCall(id=\"same\", name=\"list_stock\", arguments={}),)),\n",
+    "            ModelTurn(calls=(ToolCall(id=\"same\", name=\"list_stock\", arguments={}),)),\n",
+    "        ]\n",
+    "    ),\n",
+    "    dispatcher,\n",
+    "    chapter3[\"messages\"],\n",
+    ")\n",
+    "\n",
+    "\n",
+    "class FailedModel:\n",
+    "    def complete(self, *args, **kwargs):\n",
+    "        raise chapter3[\"ModelError\"](\"fixture failure\")\n",
+    "\n",
+    "\n",
+    "failed = run_loop(\n",
+    "    FailedModel(),\n",
+    "    dispatcher,\n",
+    "    chapter3[\"messages\"],\n",
+    "    limits=Limits(estimated_call_pence=5, model_budget_pence=10),\n",
+    ")\n",
+    "print(\"repeated\", repeated.status, repeated.model_calls, repeated.tool_calls)\n",
+    "print(\"failed\", failed.status, failed.model_calls, failed.estimated_cost_pence)\n",
+    "assert repeated.status == \"REPEATED_CALL_ID\"\n",
+    "assert (failed.status, failed.model_calls, failed.estimated_cost_pence) == (\"MODEL_FAILED\", 1, 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8669834dfd0286d",
+   "metadata": {},
+   "source": [
+    "## 5. Transfer the repair\n",
+    "\n",
+    "Change the copied probe so the failed model is invoked twice through two separate `run_loop` calls and retain both observations. Explain why each run begins a new local budget and why a durable organization later needs budget reservations outside this in-memory loop.\n",
+    "\n",
+    "The instructor holdout also applies your fragment to a fresh copy and uses an unseen configured estimate. A repair that prints five, changes expected data, or special-cases the visible observation will fail.\n",
+    "\n",
+    "## Exit ticket\n",
+    "\n",
+    "Submit the baseline, broken and repaired observations; your fragment; the repeated-ID and provider-failure results; and a causal explanation naming what would falsify it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce591ecabdf6ab7d",
+   "metadata": {
+    "tags": [
+     "exercise-report"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "exercise_report = {\n",
+    "    \"unit\": \"ch03-b\",\n",
+    "    \"attempted\": 1,\n",
+    "    \"completed\": int(REPAIR_PASSED),\n",
+    "    \"failed\": int(not REPAIR_PASSED),\n",
+    "    \"skipped\": 0,\n",
+    "    \"connection\": \"PASSED\" if REPAIR_PASSED else \"NOT_READY\",\n",
+    "    \"handoff\": handoff_status,\n",
+    "}\n",
+    "print(\"EXERCISE_REPORT=\" + json.dumps(exercise_report, sort_keys=True))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/book/always_on/exercises/ch03/unit-b-failure-accounting-v1.md
+++ b/book/always_on/exercises/ch03/unit-b-failure-accounting-v1.md
@@ -1,0 +1,182 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+# Chapter 3, Unit B — Repair failed-call accounting
+
+**Student edition v1 · 2026-09-09 · 60–75 minutes**
+
+The bounded loop works when the provider cooperates. Now a provider fails on its first admitted call. You will break a temporary copy of the actual Chapter 3 learner implementation, repair the accounting line, and test a second failure shape.
+
+This unit runs reviewed local course code in bounded subprocesses. It is not a security sandbox.
+
+## 1. Verify the Unit A handoff and load the real experiment
+
+```python tags=["setup", "handoff-consumer"]
+import json
+import os
+import runpy
+import sys
+from pathlib import Path
+
+assert sys.version_info >= (3, 14)
+start = Path(os.environ.get("SOVEREIGN_AGENT_REPO", Path.cwd())).resolve()
+ROOT = next(
+    (
+        path
+        for path in (start, *start.parents)
+        if (path / "book/always_on/learner/ch03.py").is_file()
+    ),
+    None,
+)
+if ROOT is None:
+    raise RuntimeError("Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.")
+
+
+def run_book(relative):
+    previous = Path.cwd()
+    try:
+        os.chdir(ROOT)
+        return runpy.run_path(str(ROOT / relative))
+    finally:
+        os.chdir(previous)
+
+
+HANDOFF_PATH = Path("ch03-unit-a-handoff-v1.json")
+handoff_status = "MISSING"
+if HANDOFF_PATH.is_file():
+    handoff = json.loads(HANDOFF_PATH.read_text(encoding="utf-8"))
+    handoff_status = "VERIFIED" if handoff.get("status") == "COMPLETED" else "INVALID"
+print("UNIT_A_HANDOFF", handoff_status)
+
+support = runpy.run_path(str(ROOT / "book/always_on/educator/runtime_labs_v1.py"))
+RuntimeLab = support["RuntimeLab"]
+```
+
+Predict the baseline observation. If the provider fails after admission, should the local result record zero or one model attempt? Should the configured five-pence exposure disappear?
+
+## 2. Break the real source copy
+
+```python tags=["failure-experiment"]
+lab = RuntimeLab(ROOT, 3)
+baseline = lab.run("BASELINE", expected=lab.spec["expected_baseline"])
+lab.break_source()
+broken = lab.run("BROKEN", expected=lab.spec["expected_broken"])
+print(json.dumps({"baseline": baseline["observation"], "broken": broken["observation"]}, indent=2))
+assert baseline["status"] == "PASS"
+assert broken["status"] == "PASS"
+```
+
+The broken source changes `exposure += limits.estimated_call_pence` to `exposure += 0`. The model-call counter still advances. This separates attempted calls from configured cost exposure and makes repeated failures look free.
+
+## 3. Construct the repair
+
+Return the complete replacement for the one marked broken fragment. The starter repeats the broken code and therefore fails the baseline contract.
+
+```python tags=["exercise", "learner-owned", "ch03-repair"]
+def repair_fragment():
+    return "exposure += 0"
+```
+
+<details><summary>Hint 1 — the decision</summary>
+
+Repair the accounting statement; do not change the provider fixture, expected result, or call counter.
+
+</details>
+
+<details><summary>Hint 2 — the evidence</summary>
+
+Compare `baseline["observation"]` with `broken["observation"]`. Only `estimated_pence` should change.
+
+</details>
+
+<details><summary>Hint 3 — the structure</summary>
+
+The replacement adds `limits.estimated_call_pence` to `exposure` before `model.complete` begins.
+
+</details>
+
+```python tags=["integration", "learner-path"]
+lab.repair(repair_fragment())
+student_repair = lab.run("STUDENT_REPAIR", expected=lab.spec["expected_baseline"])
+REPAIR_PASSED = student_repair["status"] == "PASS"
+print(json.dumps(student_repair["observation"], indent=2))
+print("REAL_SOURCE_REPAIR", "PASSED" if REPAIR_PASSED else "NEEDS_WORK")
+lab.close()
+```
+
+The original checkout is never edited. `RuntimeLab` fingerprints it, copies the real source and probe, executes the copy, and checks the original again after every run.
+
+## 4. Challenge two termination paths
+
+Use the real Chapter 3 loop. First, repeat a tool-call identifier. Then fail on the first provider call. Predict the result status and counters before running.
+
+```python tags=["challenge"]
+chapter3 = run_book("book/always_on/learner/ch03.py")
+ToolCall = chapter3["ToolCall"]
+ModelTurn = chapter3["ModelTurn"]
+ReplayModel = chapter3["ReplayModel"]
+Limits = chapter3["Limits"]
+run_loop = chapter3["run_loop"]
+dispatcher = chapter3["shop_tools"]["build_tools"](chapter3["shop_tools"]["SHOP"])
+
+repeated = run_loop(
+    ReplayModel(
+        [
+            ModelTurn(calls=(ToolCall(id="same", name="list_stock", arguments={}),)),
+            ModelTurn(calls=(ToolCall(id="same", name="list_stock", arguments={}),)),
+        ]
+    ),
+    dispatcher,
+    chapter3["messages"],
+)
+
+
+class FailedModel:
+    def complete(self, *args, **kwargs):
+        raise chapter3["ModelError"]("fixture failure")
+
+
+failed = run_loop(
+    FailedModel(),
+    dispatcher,
+    chapter3["messages"],
+    limits=Limits(estimated_call_pence=5, model_budget_pence=10),
+)
+print("repeated", repeated.status, repeated.model_calls, repeated.tool_calls)
+print("failed", failed.status, failed.model_calls, failed.estimated_cost_pence)
+assert repeated.status == "REPEATED_CALL_ID"
+assert (failed.status, failed.model_calls, failed.estimated_cost_pence) == ("MODEL_FAILED", 1, 5)
+```
+
+## 5. Transfer the repair
+
+Change the copied probe so the failed model is invoked twice through two separate `run_loop` calls and retain both observations. Explain why each run begins a new local budget and why a durable organization later needs budget reservations outside this in-memory loop.
+
+The instructor holdout also applies your fragment to a fresh copy and uses an unseen configured estimate. A repair that prints five, changes expected data, or special-cases the visible observation will fail.
+
+## Exit ticket
+
+Submit the baseline, broken and repaired observations; your fragment; the repeated-ID and provider-failure results; and a causal explanation naming what would falsify it.
+
+```python tags=["exercise-report"]
+exercise_report = {
+    "unit": "ch03-b",
+    "attempted": 1,
+    "completed": int(REPAIR_PASSED),
+    "failed": int(not REPAIR_PASSED),
+    "skipped": 0,
+    "connection": "PASSED" if REPAIR_PASSED else "NOT_READY",
+    "handoff": handoff_status,
+}
+print("EXERCISE_REPORT=" + json.dumps(exercise_report, sort_keys=True))
+```

--- a/book/always_on/exercises/release-v2.json
+++ b/book/always_on/exercises/release-v2.json
@@ -1,0 +1,198 @@
+{
+  "environmentLock": "uv.lock",
+  "environmentLockSha256": "955cea601c9ae719e8808277fb1ba9cc59461373a72974434ffb329f79a46475",
+  "executionLimitations": [
+    "trusted local course code",
+    "per-cell timeout is not a whole-run deadline",
+    "captured output limit is checked after execution",
+    "process, network, and descendant isolation unavailable"
+  ],
+  "schemaVersion": 2,
+  "sourceCommit": "a947ceca3896c3cc8c3430d6cdb605c49218e89d",
+  "status": "DRAFT",
+  "studentFiles": [
+    {
+      "path": "book/always_on/exercises/README.md",
+      "sha256": "91cf2ee74da4ed70007a911920a2243a306bc34a677d36675391bd2b8ad3f629"
+    },
+    {
+      "path": "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.md",
+      "sha256": "a8a07c7bb7da73ab5b8ffea210e163ced0e1cc3b557fd397674e26e33ed086f1"
+    },
+    {
+      "path": "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.ipynb",
+      "sha256": "73e85dafad80f9ca7f95b6dc4a7a86a616b049db9a7281798c0aed42a3ea6fcb"
+    },
+    {
+      "path": "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.md",
+      "sha256": "14da22ea89a30a0935afda775e2b2f4e97c3b25f9a3dd63a1e53f10f7394ec6a"
+    },
+    {
+      "path": "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.ipynb",
+      "sha256": "085bd5fb6dbcdddff41b91911a3aa4b3bbda91ecbcb9a4da008df9f4ed858961"
+    },
+    {
+      "path": "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.md",
+      "sha256": "cf193e6f010324ed806a7230740d7b56e3f118857650c4a564c9df82e6549207"
+    },
+    {
+      "path": "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.ipynb",
+      "sha256": "df387d0ffed79b6d91618a2b86f8257da201d18eba24cbf0ce9e5ff6341d3e46"
+    },
+    {
+      "path": "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.md",
+      "sha256": "fe2fd54386e53cd457949a064cd73319bb61e1e6e00def176341148c0c1b2de4"
+    },
+    {
+      "path": "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.ipynb",
+      "sha256": "d8d295868191451509eaf7ef3d8a35b09e0de1d01bd4916fdb2fd0de4d6d20ba"
+    }
+  ],
+  "units": [
+    {
+      "canonicalSha256": "a8a07c7bb7da73ab5b8ffea210e163ced0e1cc3b557fd397674e26e33ed086f1",
+      "canonicalSource": "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.md",
+      "execution": {
+        "attempted": 8,
+        "capturedOutputBytes": 2711,
+        "completed": 8,
+        "exerciseReport": {
+          "attempted": 1,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "NOT_WRITTEN",
+          "skipped": 0,
+          "unit": "ch01-a"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch01-a",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch01/holdouts/unit-a-holdout-v2.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch01-a"
+        },
+        "holdoutSha256": "1631a31969854133504210520de052f956f7fdb231afd6c3c52e8f5946216691",
+        "solution": "book/always_on/exercises/ch01/solutions/unit-a-solution-v1.py",
+        "solutionSha256": "497fa9ebfdc5febbc7a58f08be76aae8bf233916490122ecd2de6eb8783c5fb3"
+      },
+      "notebook": "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.ipynb",
+      "notebookSha256": "73e85dafad80f9ca7f95b6dc4a7a86a616b049db9a7281798c0aed42a3ea6fcb",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "9d3cd0e6bb3f0694c3c607741e3e15ad78c87417a810e69075ee14825902f52f"
+    },
+    {
+      "canonicalSha256": "14da22ea89a30a0935afda775e2b2f4e97c3b25f9a3dd63a1e53f10f7394ec6a",
+      "canonicalSource": "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.md",
+      "execution": {
+        "attempted": 9,
+        "capturedOutputBytes": 5535,
+        "completed": 9,
+        "exerciseReport": {
+          "attempted": 2,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "VERIFIED",
+          "skipped": 1,
+          "transfer": "NOT_SUBMITTED",
+          "unit": "ch01-b"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch01-b",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch01/holdouts/unit-b-holdout-v1.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch01-b"
+        },
+        "holdoutSha256": "463f311ab3a42fc08e7b6c75a9b7ac39feba1af664818376fb22eaf1b3933c21",
+        "solution": "book/always_on/exercises/ch01/solutions/unit-b-solution-v1.py",
+        "solutionSha256": "373652503fda659c23ea727a1a39476b61f9f2a3c3637105fb328dc62c922f52"
+      },
+      "notebook": "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.ipynb",
+      "notebookSha256": "085bd5fb6dbcdddff41b91911a3aa4b3bbda91ecbcb9a4da008df9f4ed858961",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "b5c8ccbc405b20338404da6853d4beafb2d9007b4bbdf659b2b0a19040d6c9cc"
+    },
+    {
+      "canonicalSha256": "cf193e6f010324ed806a7230740d7b56e3f118857650c4a564c9df82e6549207",
+      "canonicalSource": "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.md",
+      "execution": {
+        "attempted": 7,
+        "capturedOutputBytes": 1093,
+        "completed": 7,
+        "exerciseReport": {
+          "attempted": 1,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "NOT_WRITTEN",
+          "skipped": 0,
+          "unit": "ch03-a"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch03-a",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch03/holdouts/unit-a-holdout-v1.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch03-a"
+        },
+        "holdoutSha256": "81241b26416a22d86f5ddb497bf3c3bb2e5b35c3d24a9e76b6e0a551c4ec6834",
+        "solution": "book/always_on/exercises/ch03/solutions/unit-a-solution-v1.py",
+        "solutionSha256": "3712a91e78cb2dce82facf2912b46e4d585b688954087051b9f348d07ba7b15f"
+      },
+      "notebook": "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.ipynb",
+      "notebookSha256": "df387d0ffed79b6d91618a2b86f8257da201d18eba24cbf0ce9e5ff6341d3e46",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "311cfe10959a15ed1c132ea7896dca82872adf5918ec99c8f04349288a5d545c"
+    },
+    {
+      "canonicalSha256": "fe2fd54386e53cd457949a064cd73319bb61e1e6e00def176341148c0c1b2de4",
+      "canonicalSource": "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.md",
+      "execution": {
+        "attempted": 6,
+        "capturedOutputBytes": 1309,
+        "completed": 6,
+        "exerciseReport": {
+          "attempted": 1,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "VERIFIED",
+          "skipped": 0,
+          "unit": "ch03-b"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch03-b",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch03/holdouts/unit-b-holdout-v1.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch03-b"
+        },
+        "holdoutSha256": "a9248645d86607b74a116e3c749549b4f9b3d8b643a67c7107b8825d940edb75",
+        "solution": "book/always_on/exercises/ch03/solutions/unit-b-solution-v1.py",
+        "solutionSha256": "01886a084394b935a61cff1571d1bd79b65115282ad6829d47464a8ffe74dc7d"
+      },
+      "notebook": "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.ipynb",
+      "notebookSha256": "d8d295868191451509eaf7ef3d8a35b09e0de1d01bd4916fdb2fd0de4d6d20ba",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "bbb35f63f5aef18909689b89189544e84026c14bc47969edfc2bb7931045cc5f"
+    }
+  ]
+}

--- a/scripts/build_exercise_release_v2.py
+++ b/scripts/build_exercise_release_v2.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Build and execute the Chapter 1 and Chapter 3 exercise release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import nbformat
+from nbclient import NotebookClient
+
+ROOT = Path(__file__).resolve().parent.parent
+EXERCISES = ROOT / "book" / "always_on" / "exercises"
+
+
+@dataclass(frozen=True)
+class Unit:
+    identity: str
+    source: Path
+    notebook: Path
+    solution: Path
+    holdout: Path
+
+
+UNITS = (
+    Unit(
+        "ch01-a",
+        EXERCISES / "ch01" / "unit-a-first-grounded-brief-v1.md",
+        EXERCISES / "ch01" / "unit-a-first-grounded-brief-v1.ipynb",
+        EXERCISES / "ch01" / "solutions" / "unit-a-solution-v1.py",
+        EXERCISES / "ch01" / "holdouts" / "unit-a-holdout-v2.py",
+    ),
+    Unit(
+        "ch01-b",
+        EXERCISES / "ch01" / "unit-b-prompt-and-harness-v1.md",
+        EXERCISES / "ch01" / "unit-b-prompt-and-harness-v1.ipynb",
+        EXERCISES / "ch01" / "solutions" / "unit-b-solution-v1.py",
+        EXERCISES / "ch01" / "holdouts" / "unit-b-holdout-v1.py",
+    ),
+    Unit(
+        "ch03-a",
+        EXERCISES / "ch03" / "unit-a-bounded-loop-v1.md",
+        EXERCISES / "ch03" / "unit-a-bounded-loop-v1.ipynb",
+        EXERCISES / "ch03" / "solutions" / "unit-a-solution-v1.py",
+        EXERCISES / "ch03" / "holdouts" / "unit-a-holdout-v1.py",
+    ),
+    Unit(
+        "ch03-b",
+        EXERCISES / "ch03" / "unit-b-failure-accounting-v1.md",
+        EXERCISES / "ch03" / "unit-b-failure-accounting-v1.ipynb",
+        EXERCISES / "ch03" / "solutions" / "unit-b-solution-v1.py",
+        EXERCISES / "ch03" / "holdouts" / "unit-b-holdout-v1.py",
+    ),
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def relative(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def semantic_digest(notebook: dict) -> str:
+    stable = [
+        {
+            "cell_type": cell["cell_type"],
+            "source": cell.get("source", ""),
+            "tags": cell.get("metadata", {}).get("tags", []),
+        }
+        for cell in notebook["cells"]
+    ]
+    encoded = json.dumps(stable, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def outputs_bytes(notebook: dict) -> int:
+    total = 0
+    for cell in notebook["cells"]:
+        for output in cell.get("outputs", []):
+            total += len(json.dumps(output, sort_keys=True, default=str).encode())
+    return total
+
+
+def marker(notebook: dict, prefix: str) -> dict:
+    found = []
+    for cell in notebook["cells"]:
+        for output in cell.get("outputs", []):
+            text = output.get("text", "")
+            if isinstance(text, list):
+                text = "".join(text)
+            for line in str(text).splitlines():
+                if line.startswith(prefix):
+                    found.append(json.loads(line.removeprefix(prefix)))
+    if len(found) != 1:
+        raise RuntimeError(f"expected one {prefix!r} marker, found {len(found)}")
+    return found[0]
+
+
+def execute(notebook: dict, cwd: Path) -> dict:
+    previous_root = os.environ.get("SOVEREIGN_AGENT_REPO")
+    os.environ["SOVEREIGN_AGENT_REPO"] = str(ROOT)
+    try:
+        executed = NotebookClient(
+            nbformat.from_dict(notebook),
+            timeout=30,
+            kernel_name="python3",
+            allow_errors=False,
+            record_timing=False,
+        ).execute(cwd=str(cwd))
+    finally:
+        if previous_root is None:
+            os.environ.pop("SOVEREIGN_AGENT_REPO", None)
+        else:
+            os.environ["SOVEREIGN_AGENT_REPO"] = previous_root
+    size = outputs_bytes(executed)
+    if size > 1_000_000:
+        raise RuntimeError(f"captured notebook output exceeds post-run limit: {size} bytes")
+    return executed
+
+
+def convert(unit: Unit, jupytext: str) -> dict:
+    subprocess.run(
+        [jupytext, "--to", "ipynb", "--output", str(unit.notebook), str(unit.source)],
+        cwd=ROOT,
+        check=True,
+    )
+    notebook = nbformat.read(unit.notebook, as_version=4)
+    for index, cell in enumerate(notebook.cells):
+        identity = f"{unit.identity}:{index}:{cell.cell_type}:{cell.source}".encode()
+        cell.id = hashlib.sha256(identity).hexdigest()[:16]
+        if cell.cell_type == "code":
+            cell.execution_count = None
+            cell.outputs = []
+    nbformat.write(notebook, unit.notebook)
+    return notebook
+
+
+def verify_solution(unit: Unit, notebook: dict, cwd: Path) -> dict:
+    assessment = nbformat.from_dict(notebook)
+    assessment.cells.append(nbformat.v4.new_code_cell(unit.solution.read_text(encoding="utf-8")))
+    assessment.cells.append(nbformat.v4.new_code_cell(unit.holdout.read_text(encoding="utf-8")))
+    executed = execute(assessment, cwd)
+    return marker(executed, "HOLDOUT_RESULT=")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=EXERCISES / "release-v2.json")
+    args = parser.parse_args()
+    jupytext = shutil.which("jupytext")
+    if not jupytext:
+        raise RuntimeError("jupytext CLI unavailable; run with the locked authoring group")
+    source_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    lock_hash = sha256(ROOT / "uv.lock")
+    rows = []
+    with tempfile.TemporaryDirectory(prefix="sovereign-agent-exercises-") as temporary:
+        run_root = Path(temporary)
+        for unit in UNITS:
+            notebook = convert(unit, jupytext)
+            unit_root = run_root / unit.identity.split("-")[0]
+            unit_root.mkdir(exist_ok=True)
+            executed = execute(notebook, unit_root)
+            report = marker(executed, "EXERCISE_REPORT=")
+            solution = verify_solution(unit, notebook, unit_root)
+            rows.append(
+                {
+                    "id": unit.identity,
+                    "canonicalSource": relative(unit.source),
+                    "canonicalSha256": sha256(unit.source),
+                    "notebook": relative(unit.notebook),
+                    "notebookSha256": sha256(unit.notebook),
+                    "semanticDigestVersion": 1,
+                    "semanticSha256": semantic_digest(notebook),
+                    "freshKernel": True,
+                    "execution": {
+                        "attempted": sum(c["cell_type"] == "code" for c in executed["cells"]),
+                        "completed": sum(c["cell_type"] == "code" for c in executed["cells"]),
+                        "failed": 0,
+                        "skipped": 0,
+                        "capturedOutputBytes": outputs_bytes(executed),
+                        "exerciseReport": report,
+                    },
+                    "instructorEvidence": {
+                        "solution": relative(unit.solution),
+                        "solutionSha256": sha256(unit.solution),
+                        "holdout": relative(unit.holdout),
+                        "holdoutSha256": sha256(unit.holdout),
+                        "holdoutResult": solution,
+                    },
+                }
+            )
+    release = {
+        "schemaVersion": 2,
+        "status": "DRAFT",
+        "sourceCommit": source_commit,
+        "environmentLock": "uv.lock",
+        "environmentLockSha256": lock_hash,
+        "studentFiles": [
+            {"path": path, "sha256": sha256(ROOT / path)}
+            for path in (
+                "book/always_on/exercises/README.md",
+                "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.md",
+                "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.ipynb",
+                "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.md",
+                "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.ipynb",
+                "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.md",
+                "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.ipynb",
+                "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.md",
+                "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.ipynb",
+            )
+        ],
+        "units": rows,
+        "executionLimitations": [
+            "trusted local course code",
+            "per-cell timeout is not a whole-run deadline",
+            "captured output limit is checked after execution",
+            "process, network, and descendant isolation unavailable",
+        ],
+    }
+    args.output.write_text(json.dumps(release, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"built {len(rows)} units -> {args.output.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_exercise_release_v2.py
+++ b/scripts/build_exercise_release_v2.py
@@ -229,7 +229,10 @@ def main() -> int:
         ],
     }
     args.output.write_text(json.dumps(release, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(f"built {len(rows)} units -> {args.output.relative_to(ROOT)}")
+    displayed_output = (
+        args.output.relative_to(ROOT) if args.output.is_relative_to(ROOT) else args.output
+    )
+    print(f"built {len(rows)} units -> {displayed_output}")
     return 0
 
 

--- a/scripts/verify_exercise_release_v2.py
+++ b/scripts/verify_exercise_release_v2.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Verify the Chapter 1 and Chapter 3 release without executing student solutions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RELEASE = ROOT / "book" / "always_on" / "exercises" / "release-v2.json"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def committed_bytes(commit: str, path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f"{commit}:{path}"], cwd=ROOT, capture_output=True, check=False
+    )
+    require(result.returncode == 0, f"source commit does not contain {path}")
+    return result.stdout
+
+
+def verify(release_path: Path = RELEASE) -> None:
+    release = json.loads(release_path.read_text(encoding="utf-8"))
+    require(release["schemaVersion"] == 2, "unknown release schema")
+    require(re.fullmatch(r"[0-9a-f]{40}", release["sourceCommit"]) is not None, "bad commit")
+    lock = ROOT / release["environmentLock"]
+    require(lock.is_file() and sha256(lock) == release["environmentLockSha256"], "lock drift")
+    student_files = release["studentFiles"]
+    paths = [item["path"] for item in student_files]
+    require(len(paths) == len(set(paths)), "duplicate student file")
+    require(not any("solution" in path or "holdout" in path for path in paths), "answer leak")
+    for item in student_files:
+        path = item["path"]
+        target = ROOT / path
+        require(target.is_file() and target.resolve().is_relative_to(ROOT), f"missing file: {path}")
+        require(sha256(target) == item["sha256"], f"student file drift: {path}")
+        committed = hashlib.sha256(committed_bytes(release["sourceCommit"], path)).hexdigest()
+        require(committed == item["sha256"], f"source commit drift: {path}")
+    require(
+        {row["id"] for row in release["units"]} == {"ch01-a", "ch01-b", "ch03-a", "ch03-b"},
+        "unit set drift",
+    )
+    for row in release["units"]:
+        source = ROOT / row["canonicalSource"]
+        notebook_path = ROOT / row["notebook"]
+        require(sha256(source) == row["canonicalSha256"], f"source drift: {row['id']}")
+        require(sha256(notebook_path) == row["notebookSha256"], f"notebook drift: {row['id']}")
+        notebook = json.loads(notebook_path.read_text(encoding="utf-8"))
+        stable = [
+            {
+                "cell_type": cell["cell_type"],
+                "source": (
+                    "".join(cell.get("source", []))
+                    if isinstance(cell.get("source", ""), list)
+                    else cell.get("source", "")
+                ),
+                "tags": cell.get("metadata", {}).get("tags", []),
+            }
+            for cell in notebook["cells"]
+        ]
+        semantic = hashlib.sha256(
+            json.dumps(stable, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        require(row["semanticDigestVersion"] == 1, "unknown semantic digest")
+        require(semantic == row["semanticSha256"], f"semantic drift: {row['id']}")
+        execution = row["execution"]
+        require(execution["failed"] == 0 and execution["skipped"] == 0, "execution incomplete")
+        require(execution["attempted"] == execution["completed"], "cell accounting mismatch")
+        require(row["freshKernel"] is True, "fresh-kernel evidence missing")
+        evidence = row["instructorEvidence"]
+        for kind in ("solution", "holdout"):
+            evidence_path = ROOT / evidence[kind]
+            require(sha256(evidence_path) == evidence[f"{kind}Sha256"], f"{kind} drift")
+        require(evidence["holdoutResult"]["status"] == "PASSED", "holdout failed")
+
+
+if __name__ == "__main__":
+    verify()
+    print("EXERCISE RELEASE: exact bytes, semantic cells, execution and holdouts verified.")
+    print("Student starters running is not evidence of learner mastery.")

--- a/tests/test_ch03_exercise_holdouts_v1.py
+++ b/tests/test_ch03_exercise_holdouts_v1.py
@@ -1,4 +1,4 @@
-"""The Chapter 1 holdouts reject plausible visible-case shortcuts."""
+"""The Chapter 3 holdouts reject unbounded calls and free failed attempts."""
 
 from __future__ import annotations
 
@@ -9,15 +9,17 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
-CHAPTER = ROOT / "book" / "always_on" / "exercises" / "ch01"
+CHAPTER = ROOT / "book" / "always_on" / "exercises" / "ch03"
 
 
 def notebook_scope(name: str, tmp_path: Path) -> dict[str, object]:
     notebook = json.loads((CHAPTER / name).read_text(encoding="utf-8"))
     scope: dict[str, object] = {"__name__": "__exercise__", "__exercise_cwd__": str(tmp_path)}
-    old = Path.cwd()
+    old_cwd = Path.cwd()
+    old_root = os.environ.get("SOVEREIGN_AGENT_REPO")
     try:
         os.chdir(tmp_path)
+        os.environ["SOVEREIGN_AGENT_REPO"] = str(ROOT)
         for index, cell in enumerate(notebook["cells"]):
             if cell["cell_type"] != "code":
                 continue
@@ -26,7 +28,11 @@ def notebook_scope(name: str, tmp_path: Path) -> dict[str, object]:
                 source = "".join(source)
             exec(compile(source, f"{name}:cell-{index}", "exec", dont_inherit=True), scope)
     finally:
-        os.chdir(old)
+        os.chdir(old_cwd)
+        if old_root is None:
+            os.environ.pop("SOVEREIGN_AGENT_REPO", None)
+        else:
+            os.environ["SOVEREIGN_AGENT_REPO"] = old_root
     return scope
 
 
@@ -40,38 +46,24 @@ def execute(path: Path, scope: dict[str, object]) -> None:
 
 
 def test_unit_a_official_solution_passes_holdout(tmp_path: Path) -> None:
-    scope = notebook_scope("unit-a-first-grounded-brief-v1.ipynb", tmp_path)
+    scope = notebook_scope("unit-a-bounded-loop-v1.ipynb", tmp_path)
     execute(CHAPTER / "solutions" / "unit-a-solution-v1.py", scope)
     execute(CHAPTER / "holdouts" / "unit-a-holdout-v1.py", scope)
 
 
-def test_unit_a_visible_fixture_lookup_fails_holdout(tmp_path: Path) -> None:
-    scope = notebook_scope("unit-a-first-grounded-brief-v1.ipynb", tmp_path)
-    exec(
-        "def read_brief(document):\n"
-        "    if document == GOOD_RESPONSE:\n"
-        "        return document['choices'][0]['message']['content']\n"
-        "    raise ValueError('not the visible fixture')\n",
-        scope,
-    )
-    with pytest.raises(ValueError, match="visible fixture"):
+def test_unit_a_always_call_shortcut_fails_holdout(tmp_path: Path) -> None:
+    scope = notebook_scope("unit-a-bounded-loop-v1.ipynb", tmp_path)
+    with pytest.raises(AssertionError):
         execute(CHAPTER / "holdouts" / "unit-a-holdout-v1.py", scope)
 
 
 def test_unit_b_official_solution_passes_holdout(tmp_path: Path) -> None:
-    scope = notebook_scope("unit-b-prompt-and-harness-v1.ipynb", tmp_path)
+    scope = notebook_scope("unit-b-failure-accounting-v1.ipynb", tmp_path)
     execute(CHAPTER / "solutions" / "unit-b-solution-v1.py", scope)
     execute(CHAPTER / "holdouts" / "unit-b-holdout-v1.py", scope)
 
 
-def test_unit_b_visible_product_lookup_fails_holdout(tmp_path: Path) -> None:
-    scope = notebook_scope("unit-b-prompt-and-harness-v1.ipynb", tmp_path)
-    exec(
-        "def validate_draft(proposal, shop, prices, estimate_limit=3000):\n"
-        "    if proposal != GOOD_PROPOSAL:\n"
-        "        raise ValueError('not the visible products')\n"
-        "    return {'drafts': proposal['drafts'], 'estimated_pence': 2600}\n",
-        scope,
-    )
-    with pytest.raises(ValueError, match="visible products"):
+def test_unit_b_free_failure_shortcut_fails_holdout(tmp_path: Path) -> None:
+    scope = notebook_scope("unit-b-failure-accounting-v1.ipynb", tmp_path)
+    with pytest.raises(AssertionError):
         execute(CHAPTER / "holdouts" / "unit-b-holdout-v1.py", scope)


### PR DESCRIPTION
Chapter 3 needs executable practice that proves the learner can bound a model and tool loop, then repair failure accounting in the cumulative runtime. This adds two canonical Jupytext units with generated notebooks, progressive hints, a saved Unit A handoff, separate solutions, fresh-kernel holdouts, and plausible-wrong-solution tests.

Unit A connects the learner's call/cost admission decision to an in-notebook model-tool-observation loop using the Chapter 2 dispatcher. Unit B mutates the real Chapter 3 checkpoint in a temporary `RuntimeLab`, repairs provider-failure exposure accounting, and applies the repair to a hidden changed-cost case. The v2 release builder and verifier publish Chapters 1 and 3 together with deterministic cell IDs, exact artifact hashes, versioned semantic digests, execution observations, and hidden-holdout acceptance.

This PR is stacked on PR 91 so its diff contains Chapter 3 only. After PR 91 merges, retarget this PR to `main`.

Validation:

- `make verify`: 858 passed, 18 deselected
- clean-clone onboarding: 853 passed, 5 expected Git-only skips, 18 deselected
- two consecutive builds produced byte-identical notebooks and release receipt
- official solutions pass; always-call/always-zero shortcuts fail
