### PR TITLE
Build the Chapter 9 exercise successor bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 	@printf "  make lint      Run Ruff and mypy\n"
 	@printf "  make doctor    Check the offline learner environment\n"
 	@printf "  make labs      Execute every companion lab from fresh roots\n"
-	@printf "  make exercises Build Chapter 1 notebooks in fresh kernels\n"
+	@printf "  make exercises Build successor notebooks in fresh kernels\n"
 
 .PHONY: install
 install:
@@ -37,8 +37,8 @@ labs:
 
 .PHONY: exercises
 exercises:
-	$(UV) run --python 3.14 --group authoring python scripts/build_exercise_release_v2.py
-	$(UV) run --python 3.14 python scripts/verify_exercise_release_v2.py
+	$(UV) run --python 3.14 --group authoring python scripts/build_exercise_release_v3.py
+	$(UV) run --python 3.14 python scripts/verify_exercise_release_v3.py
 
 .PHONY: verify
 verify: lint test
@@ -50,7 +50,7 @@ verify: lint test
 	$(UV) run --python 3.14 python scripts/verify_book_structure_v1.py
 	$(UV) run --python 3.14 python scripts/verify_always_on_v1.py
 	$(UV) run --python 3.14 python scripts/verify_publication_v2.py
-	$(UV) run --python 3.14 python scripts/verify_exercise_release_v2.py
+	$(UV) run --python 3.14 python scripts/verify_exercise_release_v3.py
 	$(UV) run --python 3.14 python scripts/verify_book_labs.py
 	$(UV) run --python 3.14 sovereign-agent --help >/dev/null
 	$(UV) run --python 3.14 sovereign-agent doctor

--- a/book/always_on/ch09_ambiguous_order/README.md
+++ b/book/always_on/ch09_ambiguous_order/README.md
@@ -1,5 +1,7 @@
 # Chapter 9 — Survive the ambiguous supplier order
 
+For practical work, use the [Chapter 9 successor exercises](../exercises/ch09/unit-a-durable-intent-v1.md): build the durable transition, reproduce a real duplicate-purchase defect, repair the cumulative order path, and transfer reconciliation to a second supplier shape.
+
 The supplier accepts Lucy's vanilla order and records it in its database. Before the receipt reaches her agent, the connection drops. The agent sees a failed request. The supplier sees six tubs to deliver.
 
 If the agent creates another order, Lucy may receive twelve tubs and pay twice. If it declares failure and releases the reserved money, a later order may spend funds already committed to the first purchase. If it declares success without a receipt, the shop's records may claim an order that never existed. The honest immediate result is that the outcome is unknown.

--- a/book/always_on/exercises/README.md
+++ b/book/always_on/exercises/README.md
@@ -21,6 +21,12 @@ Chapter 3 is the second successor bundle:
 - [Unit B: Repair failed-call accounting](ch03/unit-b-failure-accounting-v1.md)
 - [Instructor guide](ch03/instructor-guide-v1.md)
 
+Chapter 9 completes the first-wave stress test with durable effects:
+
+- [Unit A: Build durable intent and evidence](ch09/unit-a-durable-intent-v1.md)
+- [Unit B: Survive the ambiguous order](ch09/unit-b-reconcile-unknown-v1.md)
+- [Instructor guide](ch09/instructor-guide-v1.md)
+
 Only the two Chapter 1 units are designed for Colab. Later chapters depend on local processes, files, containers, or service behavior. The full book is not a Colab course.
 
 Solutions and holdouts are separate from the student release. A notebook that executes supplied scaffolding has shown only that the artifact runs. Learning evidence comes from the learner's implementation, its connection to the cumulative behavior, and a transfer case that defeats a plausible shortcut.

--- a/book/always_on/exercises/ch09/holdouts/unit-a-holdout-v1.py
+++ b/book/always_on/exercises/ch09/holdouts/unit-a-holdout-v1.py
@@ -1,0 +1,61 @@
+"""Instructor-held checks appended after a submitted Chapter 9 Unit A notebook."""
+
+# ruff: noqa: F821 - executed inside the submitted notebook namespace
+
+import json
+
+with tempfile.TemporaryDirectory(prefix="ch09-transition-hidden-") as directory:
+    db, work, identifier = approved_order(Path(directory), sku="SKU-STRAWBERRY", quantity=4)
+    try:
+        admitted = record_transition(db, work.id, identifier, "ADMIT")
+        unknown = record_transition(db, work.id, identifier, "UNKNOWN")
+        rejected = {
+            "operation": identifier,
+            "proposal": unknown["proposal"],
+            "status": "REJECTED",
+        }
+        final = record_transition(db, work.id, identifier, "RECEIPT", rejected)
+        replay = record_transition(db, work.id, identifier, "RECEIPT", rejected)
+        assert admitted["status"] == "SENDING"
+        assert (unknown["reserved_pence"], unknown["spent_pence"]) == (1100, 0)
+        assert final["status"] == replay["status"] == "REJECTED"
+        assert (replay["reserved_pence"], replay["spent_pence"]) == (0, 0)
+        try:
+            record_transition(db, work.id, identifier, "UNKNOWN")
+        except PermissionError:
+            pass
+        else:
+            raise AssertionError("terminal evidence was overwritten by uncertainty")
+    finally:
+        db.close()
+
+with tempfile.TemporaryDirectory(prefix="ch09-handoff-hidden-") as directory:
+    root = Path(directory)
+    with independent_supplier(root) as (supplier, supplier_path):
+        db, work, identifier = approved_order(root, target=supplier.identity)
+        try:
+            sent = record_transition(db, work.id, identifier, "ADMIT")
+            try:
+                supplier.order(identifier, sent["proposal"])
+            except OSError:
+                after_loss = record_transition(db, work.id, identifier, "UNKNOWN")
+            receipt = supplier.lookup(identifier)
+            final = record_transition(db, work.id, identifier, "RECEIPT", receipt)
+            with sqlite3.connect(supplier_path) as remote:
+                count = remote.execute("SELECT count(*) FROM orders").fetchone()[0]
+            handoff = {
+                "operation": identifier,
+                "proposal": final["proposal"],
+                "after_loss": after_loss,
+                "final": final,
+                "supplier_orders": count,
+            }
+            Path("ch09-unit-a-handoff-v1.json").write_text(
+                json.dumps(handoff, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+        finally:
+            db.close()
+assert handoff["after_loss"]["status"] == "UNKNOWN"
+assert handoff["final"]["status"] == "CONFIRMED"
+assert handoff["supplier_orders"] == 1
+print("HOLDOUT_RESULT=" + json.dumps({"unit": "ch09-a", "status": "PASSED"}, sort_keys=True))

--- a/book/always_on/exercises/ch09/holdouts/unit-b-holdout-v1.py
+++ b/book/always_on/exercises/ch09/holdouts/unit-b-holdout-v1.py
@@ -1,0 +1,45 @@
+"""Instructor-held checks appended after a submitted Chapter 9 Unit B notebook."""
+
+# ruff: noqa: F821 - executed inside the submitted notebook namespace
+
+import json
+
+hidden_lab = RuntimeLab(ROOT, 9)
+try:
+    hidden_lab.break_source()
+    hidden_lab.repair(repair_fragment())
+    hidden_repair = hidden_lab.run(
+        "HIDDEN_RECONCILIATION",
+        expected={
+            "supplier_order_count": 1,
+            "local_statuses": ["UNKNOWN", "ACCEPTED"],
+            "same_id_retransmission_count": 1,
+        },
+    )
+finally:
+    hidden_lab.close()
+assert hidden_repair["status"] == "PASS"
+
+declined = run_partner_fixture(normalize_discovery, "declined")
+assert declined == {
+    "statuses": ["UNKNOWN", "REJECTED"],
+    "local_status": "REJECTED",
+    "events": ["order", "lookup"],
+    "supplier_orders": 1,
+    "money": (0, 0),
+}
+
+try:
+    normalize_discovery(
+        {
+            "order_ref": "hidden",
+            "payload": partner_proposal,
+            "decision": "maybe",
+        }
+    )
+except ValueError:
+    pass
+else:
+    raise AssertionError("unknown partner decision was guessed")
+
+print("HOLDOUT_RESULT=" + json.dumps({"unit": "ch09-b", "status": "PASSED"}, sort_keys=True))

--- a/book/always_on/exercises/ch09/instructor-guide-v1.md
+++ b/book/always_on/exercises/ch09/instructor-guide-v1.md
@@ -1,0 +1,53 @@
+# Chapter 9 instructor guide — Survive the ambiguous order
+
+**Created:** 2026-09-09 · **Status:** DRAFT successor companion v1
+
+## Purpose
+
+Students build the durable local transition around an external effect, then make and repair a real duplicate-purchase defect. Lucy's observable consequence is concrete: a fresh retry identity creates two supplier orders while the agent still reports uncertainty.
+
+Unit A owns the `SENDING → UNKNOWN → CONFIRMED/REJECTED` transition against the real SQLite schema. Unit B mutates `src/sovereign_agent/assistant_orders.py` in a fingerprinted temporary copy and adapts a second supplier's discovery shape into the exact internal receipt contract.
+
+## Preparation
+
+Use the locked Python 3.14 authoring environment. The exercises make no model or channel calls and cannot contact a real supplier. They start reviewed loopback or in-memory fixtures. A local subprocess is not a security sandbox.
+
+Run Unit A before Unit B in the same working directory. The official release builder uses a chapter-scoped temporary directory so the signed handoff is consumed across fresh kernels.
+
+## Teaching sequence
+
+| Minutes | Activity | Evidence |
+|---:|---|---|
+| 0–10 | Predict local and supplier state after the lost reply | First prediction and falsifier |
+| 10–35 | Implement `record_transition` | Visible state and money transitions |
+| 35–55 | Connect to the loopback supplier | `UNKNOWN`, one remote row, then exact receipt |
+| 55–65 | Inspect Unit A handoff and predict the retry fault | Durable evidence path |
+| 65–80 | Break and repair the actual send boundary | Baseline/broken/repaired records |
+| 80–100 | Normalize another supplier and transfer to rejection | Chronology and money evidence |
+| 100–110 | Explain guarantee and limits | Exit ticket |
+
+Record actual classroom time. This plan is not evidence that a learner completed it.
+
+## Assessment
+
+Require all of the following:
+
+- `SENDING` is committed before the external call;
+- `UNKNOWN` keeps the reservation;
+- an exact conclusive receipt settles the reservation only once;
+- mismatched or nonconclusive receipts fail closed;
+- the real copied runtime returns one supplier order after repair;
+- the partner transfer produces `order` then `lookup`, with no second send;
+- the learner explains that provider idempotency and discovery are contractual dependencies.
+
+The hidden Unit A case uses strawberry, a rejection, and 1,100 pence. It defeats hard-coded vanilla/1,500/accepted logic. The hidden Unit B case uses the actual response-loss probe and a `declined` partner result. A fresh-ID repair or an adapter that returns the partner payload unchanged fails.
+
+The source repository contains the instructor holdouts; they are separated from student artifacts, not cryptographically secret. Do not present a starter notebook's clean execution or an official solution run as student mastery.
+
+## Worked mechanisms
+
+The solution records one row whose exact `id` and `work_id` match, validates canonical proposal JSON, and changes reserved/spent amounts only on the first terminal transition. The runtime repair restores the stable `identifier` at `supplier.order`. The adapter maps only `accepted` and `declined`; any other decision is rejected.
+
+## Scope
+
+This fixture proves one retained intent can reconcile against a supplier with persistent discovery and stable-key idempotency. It does not prove universal exactly-once delivery, safe recovery from a backup that predates the intent, authentication of arbitrary receipts, process containment, or correctness for a supplier whose idempotency keys expire before recovery.

--- a/book/always_on/exercises/ch09/solutions/unit-a-solution-v1.py
+++ b/book/always_on/exercises/ch09/solutions/unit-a-solution-v1.py
@@ -1,0 +1,57 @@
+# ruff: noqa: F821 - executed inside the submitted notebook namespace
+
+
+def record_transition(db, work_id, identifier, event, receipt=None):
+    with db.immediate() as connection:
+        row = connection.execute(
+            "SELECT * FROM assistant_orders WHERE id=? AND work_id=?", (identifier, work_id)
+        ).fetchone()
+        if row is None:
+            raise PermissionError("operation does not belong to this work")
+        if event == "ADMIT":
+            if row["status"] != "APPROVED":
+                raise PermissionError("only an approved operation may be sent")
+            connection.execute(
+                "UPDATE assistant_orders SET status='SENDING' WHERE id=?", (identifier,)
+            )
+            append_event(db, "assistant.order.intent", {"order": identifier})
+        elif event == "UNKNOWN":
+            if row["status"] != "SENDING":
+                raise PermissionError("only an admitted send may become unknown")
+            connection.execute(
+                "UPDATE assistant_orders SET status='UNKNOWN' WHERE id=?", (identifier,)
+            )
+        elif event == "RECEIPT":
+            if not isinstance(receipt, dict):
+                raise ValueError("receipt required")
+            encoded = json.dumps(
+                receipt.get("proposal"), sort_keys=True, separators=(",", ":"), allow_nan=False
+            )
+            if receipt.get("operation") != identifier or encoded != row["proposal"]:
+                raise ValueError("receipt does not match exact intent")
+            if receipt.get("status") not in {"ACCEPTED", "REJECTED"}:
+                raise ValueError("receipt is not conclusive")
+            if row["status"] in {"CONFIRMED", "REJECTED"}:
+                if json.loads(row["receipt"]) != receipt:
+                    raise ValueError("receipt contradicts recorded outcome")
+                return order_observation(db, identifier)
+            if row["status"] not in {"SENDING", "UNKNOWN"}:
+                raise PermissionError("operation was not admitted")
+            accepted = receipt["status"] == "ACCEPTED"
+            connection.execute(
+                "UPDATE assistant_orders SET status=?,receipt=? WHERE id=?",
+                ("CONFIRMED" if accepted else "REJECTED", json.dumps(receipt), identifier),
+            )
+            connection.execute(
+                "UPDATE assistant_spending SET reserved_pence=reserved_pence-?,"
+                "spent_pence=spent_pence+? WHERE id=1",
+                (row["amount"], row["amount"] if accepted else 0),
+            )
+            append_event(
+                db,
+                "assistant.order.reconciled",
+                {"order": identifier, "status": receipt["status"]},
+            )
+        else:
+            raise ValueError("unknown transition")
+    return order_observation(db, identifier)

--- a/book/always_on/exercises/ch09/solutions/unit-a-solution-v1.py
+++ b/book/always_on/exercises/ch09/solutions/unit-a-solution-v1.py
@@ -1,5 +1,9 @@
 # ruff: noqa: F821 - executed inside the submitted notebook namespace
 
+import json
+
+from sovereign_agent.events import append_event
+
 
 def record_transition(db, work_id, identifier, event, receipt=None):
     with db.immediate() as connection:

--- a/book/always_on/exercises/ch09/solutions/unit-b-solution-v1.py
+++ b/book/always_on/exercises/ch09/solutions/unit-b-solution-v1.py
@@ -1,0 +1,15 @@
+def repair_fragment():
+    return 'receipt = supplier.order(identifier, json.loads(row["proposal"]))'
+
+
+def normalize_discovery(raw):
+    if raw is None:
+        return None
+    statuses = {"accepted": "ACCEPTED", "declined": "REJECTED"}
+    try:
+        status = statuses[raw["decision"]]
+        operation = raw["order_ref"]
+        proposal = raw["payload"]
+    except KeyError, TypeError:
+        raise ValueError("invalid partner discovery result") from None
+    return {"operation": operation, "proposal": proposal, "status": status}

--- a/book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb
+++ b/book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b6a3c9fddc59832",
+   "id": "16f3e3d76f7c763c",
    "metadata": {
     "tags": [
      "setup"
@@ -36,6 +36,11 @@
     "import time\n",
     "from pathlib import Path\n",
     "\n",
+    "from reference_organizations.store.agent import seed_lucy\n",
+    "from sovereign_agent.assistant_orders import SpendingPolicy, approve, propose\n",
+    "from sovereign_agent.assistant_work import claim, enqueue\n",
+    "from sovereign_agent.database import Database\n",
+    "\n",
     "assert sys.version_info >= (3, 14)\n",
     "start = Path(os.environ.get(\"SOVEREIGN_AGENT_REPO\", Path.cwd())).resolve()\n",
     "ROOT = next(\n",
@@ -48,12 +53,6 @@
     ")\n",
     "if ROOT is None:\n",
     "    raise RuntimeError(\"Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.\")\n",
-    "\n",
-    "from reference_organizations.store.agent import seed_lucy\n",
-    "from sovereign_agent.assistant_orders import SpendingPolicy, approve, propose\n",
-    "from sovereign_agent.assistant_work import claim, enqueue\n",
-    "from sovereign_agent.database import Database\n",
-    "from sovereign_agent.events import append_event\n",
     "\n",
     "independent_supplier = runpy.run_path(str(ROOT / \"book/always_on/checkpoints/ch09.py\"))[\n",
     "    \"independent_supplier\"\n",

--- a/book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb
+++ b/book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c67a1833fd043fdf",
+   "metadata": {},
+   "source": [
+    "# Chapter 9, Unit A — Build durable intent and evidence\n",
+    "\n",
+    "**Student edition v1 · 2026-09-09 · 75–90 minutes**\n",
+    "\n",
+    "Lucy's supplier can accept an order and lose the reply. You will implement the local transitions around that uncertain interval, connect them to the real SQLite order schema and the simulated supplier, and save evidence for Unit B.\n",
+    "\n",
+    "This unit starts only the repository's loopback supplier fixture. It cannot make a real purchase and uses no model, channel, or supplier credential.\n",
+    "\n",
+    "## 1. Locate the cumulative code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b6a3c9fddc59832",
+   "metadata": {
+    "tags": [
+     "setup"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import runpy\n",
+    "import sqlite3\n",
+    "import sys\n",
+    "import tempfile\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "assert sys.version_info >= (3, 14)\n",
+    "start = Path(os.environ.get(\"SOVEREIGN_AGENT_REPO\", Path.cwd())).resolve()\n",
+    "ROOT = next(\n",
+    "    (\n",
+    "        path\n",
+    "        for path in (start, *start.parents)\n",
+    "        if (path / \"book/always_on/checkpoints/ch09.py\").is_file()\n",
+    "    ),\n",
+    "    None,\n",
+    ")\n",
+    "if ROOT is None:\n",
+    "    raise RuntimeError(\"Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.\")\n",
+    "\n",
+    "from reference_organizations.store.agent import seed_lucy\n",
+    "from sovereign_agent.assistant_orders import SpendingPolicy, approve, propose\n",
+    "from sovereign_agent.assistant_work import claim, enqueue\n",
+    "from sovereign_agent.database import Database\n",
+    "from sovereign_agent.events import append_event\n",
+    "\n",
+    "independent_supplier = runpy.run_path(str(ROOT / \"book/always_on/checkpoints/ch09.py\"))[\n",
+    "    \"independent_supplier\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d80e062fca3ba82",
+   "metadata": {},
+   "source": [
+    "Predict the two ledgers immediately after the supplier commits and drops the response. Which local amount remains reserved? How many remote orders exist?\n",
+    "\n",
+    "## 2. Prepare one exact approved proposal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ef7b391c93ec8ec",
+   "metadata": {
+    "tags": [
+     "setup"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "POLICY = SpendingPolicy(frozenset({\"lucy\"}), total_pence=2_000)\n",
+    "\n",
+    "\n",
+    "def approved_order(root, *, target=\"fixture\", sku=\"SKU-VANILLA\", quantity=6):\n",
+    "    db = Database(root / \"agent.sqlite\")\n",
+    "    seed_lucy(db)\n",
+    "    enqueue(db, \"chapter9:exercise\", \"lucy\", \"Replenish\", subject=sku)\n",
+    "    work = claim(db, \"chapter9-student\")\n",
+    "    identifier = propose(db, work, sku, quantity, target=target)\n",
+    "    digest = db.connection.execute(\n",
+    "        \"SELECT digest FROM assistant_orders WHERE id=?\", (identifier,)\n",
+    "    ).fetchone()[0]\n",
+    "    approve(\n",
+    "        db,\n",
+    "        identifier,\n",
+    "        digest,\n",
+    "        actor=\"lucy\",\n",
+    "        policy=POLICY,\n",
+    "        expires=time.time() + 60,\n",
+    "    )\n",
+    "    return db, work, identifier\n",
+    "\n",
+    "\n",
+    "def order_observation(db, identifier):\n",
+    "    row = db.connection.execute(\n",
+    "        \"SELECT status,proposal,receipt FROM assistant_orders WHERE id=?\", (identifier,)\n",
+    "    ).fetchone()\n",
+    "    money = db.connection.execute(\n",
+    "        \"SELECT reserved_pence,spent_pence FROM assistant_spending WHERE id=1\"\n",
+    "    ).fetchone()\n",
+    "    return {\n",
+    "        \"status\": row[\"status\"],\n",
+    "        \"proposal\": json.loads(row[\"proposal\"]),\n",
+    "        \"receipt\": json.loads(row[\"receipt\"]) if row[\"receipt\"] else None,\n",
+    "        \"reserved_pence\": money[\"reserved_pence\"],\n",
+    "        \"spent_pence\": money[\"spent_pence\"],\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "379923208d2055a2",
+   "metadata": {},
+   "source": [
+    "## 3. Construct the durable transition\n",
+    "\n",
+    "Implement three events:\n",
+    "\n",
+    "- `ADMIT` changes one exact approved row to `SENDING` before the network call;\n",
+    "- `UNKNOWN` changes only `SENDING` to `UNKNOWN` while keeping the reservation;\n",
+    "- `RECEIPT` validates the operation, exact proposal, and conclusive status, then settles the reservation once.\n",
+    "\n",
+    "Terminal receipt replay must be idempotent. Any unsupported transition, wrong prior state, mismatched receipt, or nonconclusive receipt must raise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "275d4ebb1ab5187a",
+   "metadata": {
+    "tags": [
+     "exercise",
+     "learner-owned",
+     "ch09-transition"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def record_transition(db, work_id, identifier, event, receipt=None):\n",
+    "    \"\"\"Record ADMIT, UNKNOWN, or RECEIPT and return the resulting observation.\"\"\"\n",
+    "    return None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2aa6344b312f4ce0",
+   "metadata": {},
+   "source": [
+    "<details><summary>Hint 1 — the decision</summary>\n",
+    "\n",
+    "Commit `SENDING` before any external call. A timeout changes knowledge to `UNKNOWN`; it does not release money. Only exact conclusive evidence can settle it.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 2 — the evidence</summary>\n",
+    "\n",
+    "Read `status`, `proposal`, `amount`, and `receipt` for the row whose `id` and `work_id` both match. Compare canonical JSON for the stored and returned proposals.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 3 — the structure</summary>\n",
+    "\n",
+    "Use `with db.immediate() as connection`. Branch on the event, reject invalid prior states, update the order, and for a first conclusive receipt subtract `amount` from reserved and add it to spent only when accepted.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "## 4. Challenge the visible contract"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4685e1d7afdac73a",
+   "metadata": {
+    "tags": [
+     "assessment",
+     "visible"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def grade_transition(candidate):\n",
+    "    with tempfile.TemporaryDirectory(prefix=\"ch09-transition-visible-\") as directory:\n",
+    "        db, work, identifier = approved_order(Path(directory))\n",
+    "        try:\n",
+    "            rows = []\n",
+    "            rows.append(candidate(db, work.id, identifier, \"ADMIT\"))\n",
+    "            rows.append(candidate(db, work.id, identifier, \"UNKNOWN\"))\n",
+    "            proposal = order_observation(db, identifier)[\"proposal\"]\n",
+    "            receipt = {\"operation\": identifier, \"proposal\": proposal, \"status\": \"ACCEPTED\"}\n",
+    "            rows.append(candidate(db, work.id, identifier, \"RECEIPT\", receipt))\n",
+    "            rows.append(candidate(db, work.id, identifier, \"RECEIPT\", receipt))\n",
+    "            observed = [row[\"status\"] for row in rows]\n",
+    "            money = rows[-1][\"reserved_pence\"], rows[-1][\"spent_pence\"]\n",
+    "            assert observed == [\"SENDING\", \"UNKNOWN\", \"CONFIRMED\", \"CONFIRMED\"]\n",
+    "            assert money == (0, 1500)\n",
+    "            mismatch = dict(receipt)\n",
+    "            mismatch[\"proposal\"] = {**proposal, \"quantity\": 99}\n",
+    "            try:\n",
+    "                candidate(db, work.id, identifier, \"RECEIPT\", mismatch)\n",
+    "            except ValueError:\n",
+    "                pass\n",
+    "            else:\n",
+    "                raise AssertionError(\"mismatched receipt accepted\")\n",
+    "            return {\"status\": \"PASSED\", \"states\": observed, \"money\": money}\n",
+    "        except Exception as error:\n",
+    "            return {\"status\": \"NEEDS_WORK\", \"error\": type(error).__name__}\n",
+    "        finally:\n",
+    "            db.close()\n",
+    "\n",
+    "\n",
+    "visible = grade_transition(record_transition)\n",
+    "VISIBLE_PASSED = visible[\"status\"] == \"PASSED\"\n",
+    "print(json.dumps(visible, indent=2))\n",
+    "print(\"VISIBLE_CONTRACT\", \"PASSED\" if VISIBLE_PASSED else \"NEEDS_WORK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00929d4dcd1c56c5",
+   "metadata": {},
+   "source": [
+    "## 5. Connect the transition to the supplier\n",
+    "\n",
+    "The local `SENDING` commit happens first. The supplier then commits one remote receipt and closes the connection. Your `UNKNOWN` transition retains 1,500 pence. Reconciliation reads the supplier's existing receipt and records it without another order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8e2a5ade9e8c3d4",
+   "metadata": {
+    "tags": [
+     "integration",
+     "learner-path",
+     "handoff"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "connected = None\n",
+    "if VISIBLE_PASSED:\n",
+    "    with tempfile.TemporaryDirectory(prefix=\"ch09-connected-\") as directory:\n",
+    "        root = Path(directory)\n",
+    "        with independent_supplier(root) as (supplier, supplier_path):\n",
+    "            db, work, identifier = approved_order(root, target=supplier.identity)\n",
+    "            try:\n",
+    "                before_send = record_transition(db, work.id, identifier, \"ADMIT\")\n",
+    "                assert before_send[\"status\"] == \"SENDING\"\n",
+    "                try:\n",
+    "                    supplier.order(identifier, before_send[\"proposal\"])\n",
+    "                except OSError:\n",
+    "                    after_loss = record_transition(db, work.id, identifier, \"UNKNOWN\")\n",
+    "                else:\n",
+    "                    raise AssertionError(\"fixture did not drop the first response\")\n",
+    "                with sqlite3.connect(supplier_path) as remote:\n",
+    "                    remote_count = remote.execute(\"SELECT count(*) FROM orders\").fetchone()[0]\n",
+    "                found = supplier.lookup(identifier)\n",
+    "                final = record_transition(db, work.id, identifier, \"RECEIPT\", found)\n",
+    "                connected = {\n",
+    "                    \"operation\": identifier,\n",
+    "                    \"proposal\": final[\"proposal\"],\n",
+    "                    \"after_loss\": after_loss,\n",
+    "                    \"final\": final,\n",
+    "                    \"supplier_orders\": remote_count,\n",
+    "                }\n",
+    "                assert after_loss[\"status\"] == \"UNKNOWN\"\n",
+    "                assert (after_loss[\"reserved_pence\"], after_loss[\"spent_pence\"]) == (1500, 0)\n",
+    "                assert final[\"status\"] == \"CONFIRMED\"\n",
+    "                assert (final[\"reserved_pence\"], final[\"spent_pence\"]) == (0, 1500)\n",
+    "                assert remote_count == 1\n",
+    "            finally:\n",
+    "                db.close()\n",
+    "    Path(\"ch09-unit-a-handoff-v1.json\").write_text(\n",
+    "        json.dumps(connected, indent=2, sort_keys=True) + \"\\n\", encoding=\"utf-8\"\n",
+    "    )\n",
+    "    print(\"CONNECTED\", connected[\"after_loss\"][\"status\"], connected[\"final\"][\"status\"])\n",
+    "else:\n",
+    "    print(\"CONNECTION_NOT_READY — repair record_transition, then run again.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f21e47df820f37c",
+   "metadata": {},
+   "source": [
+    "## Exit ticket\n",
+    "\n",
+    "Explain why the local transaction cannot include the supplier commit, why `UNKNOWN` retains the reservation, and which exact evidence justifies `CONFIRMED`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c9d435fa1de6c96",
+   "metadata": {
+    "tags": [
+     "exercise-report"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "exercise_report = {\n",
+    "    \"unit\": \"ch09-a\",\n",
+    "    \"attempted\": 1,\n",
+    "    \"completed\": int(VISIBLE_PASSED),\n",
+    "    \"failed\": int(not VISIBLE_PASSED),\n",
+    "    \"skipped\": 0,\n",
+    "    \"connection\": \"PASSED\" if connected else \"NOT_READY\",\n",
+    "    \"handoff\": \"WRITTEN\" if connected else \"NOT_WRITTEN\",\n",
+    "}\n",
+    "print(\"EXERCISE_REPORT=\" + json.dumps(exercise_report, sort_keys=True))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/book/always_on/exercises/ch09/unit-a-durable-intent-v1.md
+++ b/book/always_on/exercises/ch09/unit-a-durable-intent-v1.md
@@ -1,0 +1,236 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+# Chapter 9, Unit A — Build durable intent and evidence
+
+**Student edition v1 · 2026-09-09 · 75–90 minutes**
+
+Lucy's supplier can accept an order and lose the reply. You will implement the local transitions around that uncertain interval, connect them to the real SQLite order schema and the simulated supplier, and save evidence for Unit B.
+
+This unit starts only the repository's loopback supplier fixture. It cannot make a real purchase and uses no model, channel, or supplier credential.
+
+## 1. Locate the cumulative code
+
+```python tags=["setup"]
+import json
+import os
+import runpy
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+assert sys.version_info >= (3, 14)
+start = Path(os.environ.get("SOVEREIGN_AGENT_REPO", Path.cwd())).resolve()
+ROOT = next(
+    (
+        path
+        for path in (start, *start.parents)
+        if (path / "book/always_on/checkpoints/ch09.py").is_file()
+    ),
+    None,
+)
+if ROOT is None:
+    raise RuntimeError("Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.")
+
+from reference_organizations.store.agent import seed_lucy
+from sovereign_agent.assistant_orders import SpendingPolicy, approve, propose
+from sovereign_agent.assistant_work import claim, enqueue
+from sovereign_agent.database import Database
+from sovereign_agent.events import append_event
+
+independent_supplier = runpy.run_path(str(ROOT / "book/always_on/checkpoints/ch09.py"))[
+    "independent_supplier"
+]
+```
+
+Predict the two ledgers immediately after the supplier commits and drops the response. Which local amount remains reserved? How many remote orders exist?
+
+## 2. Prepare one exact approved proposal
+
+```python tags=["setup"]
+POLICY = SpendingPolicy(frozenset({"lucy"}), total_pence=2_000)
+
+
+def approved_order(root, *, target="fixture", sku="SKU-VANILLA", quantity=6):
+    db = Database(root / "agent.sqlite")
+    seed_lucy(db)
+    enqueue(db, "chapter9:exercise", "lucy", "Replenish", subject=sku)
+    work = claim(db, "chapter9-student")
+    identifier = propose(db, work, sku, quantity, target=target)
+    digest = db.connection.execute(
+        "SELECT digest FROM assistant_orders WHERE id=?", (identifier,)
+    ).fetchone()[0]
+    approve(
+        db,
+        identifier,
+        digest,
+        actor="lucy",
+        policy=POLICY,
+        expires=time.time() + 60,
+    )
+    return db, work, identifier
+
+
+def order_observation(db, identifier):
+    row = db.connection.execute(
+        "SELECT status,proposal,receipt FROM assistant_orders WHERE id=?", (identifier,)
+    ).fetchone()
+    money = db.connection.execute(
+        "SELECT reserved_pence,spent_pence FROM assistant_spending WHERE id=1"
+    ).fetchone()
+    return {
+        "status": row["status"],
+        "proposal": json.loads(row["proposal"]),
+        "receipt": json.loads(row["receipt"]) if row["receipt"] else None,
+        "reserved_pence": money["reserved_pence"],
+        "spent_pence": money["spent_pence"],
+    }
+```
+
+## 3. Construct the durable transition
+
+Implement three events:
+
+- `ADMIT` changes one exact approved row to `SENDING` before the network call;
+- `UNKNOWN` changes only `SENDING` to `UNKNOWN` while keeping the reservation;
+- `RECEIPT` validates the operation, exact proposal, and conclusive status, then settles the reservation once.
+
+Terminal receipt replay must be idempotent. Any unsupported transition, wrong prior state, mismatched receipt, or nonconclusive receipt must raise.
+
+```python tags=["exercise", "learner-owned", "ch09-transition"]
+def record_transition(db, work_id, identifier, event, receipt=None):
+    """Record ADMIT, UNKNOWN, or RECEIPT and return the resulting observation."""
+    return None
+```
+
+<details><summary>Hint 1 — the decision</summary>
+
+Commit `SENDING` before any external call. A timeout changes knowledge to `UNKNOWN`; it does not release money. Only exact conclusive evidence can settle it.
+
+</details>
+
+<details><summary>Hint 2 — the evidence</summary>
+
+Read `status`, `proposal`, `amount`, and `receipt` for the row whose `id` and `work_id` both match. Compare canonical JSON for the stored and returned proposals.
+
+</details>
+
+<details><summary>Hint 3 — the structure</summary>
+
+Use `with db.immediate() as connection`. Branch on the event, reject invalid prior states, update the order, and for a first conclusive receipt subtract `amount` from reserved and add it to spent only when accepted.
+
+</details>
+
+## 4. Challenge the visible contract
+
+```python tags=["assessment", "visible"]
+def grade_transition(candidate):
+    with tempfile.TemporaryDirectory(prefix="ch09-transition-visible-") as directory:
+        db, work, identifier = approved_order(Path(directory))
+        try:
+            rows = []
+            rows.append(candidate(db, work.id, identifier, "ADMIT"))
+            rows.append(candidate(db, work.id, identifier, "UNKNOWN"))
+            proposal = order_observation(db, identifier)["proposal"]
+            receipt = {"operation": identifier, "proposal": proposal, "status": "ACCEPTED"}
+            rows.append(candidate(db, work.id, identifier, "RECEIPT", receipt))
+            rows.append(candidate(db, work.id, identifier, "RECEIPT", receipt))
+            observed = [row["status"] for row in rows]
+            money = rows[-1]["reserved_pence"], rows[-1]["spent_pence"]
+            assert observed == ["SENDING", "UNKNOWN", "CONFIRMED", "CONFIRMED"]
+            assert money == (0, 1500)
+            mismatch = dict(receipt)
+            mismatch["proposal"] = {**proposal, "quantity": 99}
+            try:
+                candidate(db, work.id, identifier, "RECEIPT", mismatch)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("mismatched receipt accepted")
+            return {"status": "PASSED", "states": observed, "money": money}
+        except Exception as error:
+            return {"status": "NEEDS_WORK", "error": type(error).__name__}
+        finally:
+            db.close()
+
+
+visible = grade_transition(record_transition)
+VISIBLE_PASSED = visible["status"] == "PASSED"
+print(json.dumps(visible, indent=2))
+print("VISIBLE_CONTRACT", "PASSED" if VISIBLE_PASSED else "NEEDS_WORK")
+```
+
+## 5. Connect the transition to the supplier
+
+The local `SENDING` commit happens first. The supplier then commits one remote receipt and closes the connection. Your `UNKNOWN` transition retains 1,500 pence. Reconciliation reads the supplier's existing receipt and records it without another order.
+
+```python tags=["integration", "learner-path", "handoff"]
+connected = None
+if VISIBLE_PASSED:
+    with tempfile.TemporaryDirectory(prefix="ch09-connected-") as directory:
+        root = Path(directory)
+        with independent_supplier(root) as (supplier, supplier_path):
+            db, work, identifier = approved_order(root, target=supplier.identity)
+            try:
+                before_send = record_transition(db, work.id, identifier, "ADMIT")
+                assert before_send["status"] == "SENDING"
+                try:
+                    supplier.order(identifier, before_send["proposal"])
+                except OSError:
+                    after_loss = record_transition(db, work.id, identifier, "UNKNOWN")
+                else:
+                    raise AssertionError("fixture did not drop the first response")
+                with sqlite3.connect(supplier_path) as remote:
+                    remote_count = remote.execute("SELECT count(*) FROM orders").fetchone()[0]
+                found = supplier.lookup(identifier)
+                final = record_transition(db, work.id, identifier, "RECEIPT", found)
+                connected = {
+                    "operation": identifier,
+                    "proposal": final["proposal"],
+                    "after_loss": after_loss,
+                    "final": final,
+                    "supplier_orders": remote_count,
+                }
+                assert after_loss["status"] == "UNKNOWN"
+                assert (after_loss["reserved_pence"], after_loss["spent_pence"]) == (1500, 0)
+                assert final["status"] == "CONFIRMED"
+                assert (final["reserved_pence"], final["spent_pence"]) == (0, 1500)
+                assert remote_count == 1
+            finally:
+                db.close()
+    Path("ch09-unit-a-handoff-v1.json").write_text(
+        json.dumps(connected, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print("CONNECTED", connected["after_loss"]["status"], connected["final"]["status"])
+else:
+    print("CONNECTION_NOT_READY — repair record_transition, then run again.")
+```
+
+## Exit ticket
+
+Explain why the local transaction cannot include the supplier commit, why `UNKNOWN` retains the reservation, and which exact evidence justifies `CONFIRMED`.
+
+```python tags=["exercise-report"]
+exercise_report = {
+    "unit": "ch09-a",
+    "attempted": 1,
+    "completed": int(VISIBLE_PASSED),
+    "failed": int(not VISIBLE_PASSED),
+    "skipped": 0,
+    "connection": "PASSED" if connected else "NOT_READY",
+    "handoff": "WRITTEN" if connected else "NOT_WRITTEN",
+}
+print("EXERCISE_REPORT=" + json.dumps(exercise_report, sort_keys=True))
+```

--- a/book/always_on/exercises/ch09/unit-a-durable-intent-v1.md
+++ b/book/always_on/exercises/ch09/unit-a-durable-intent-v1.md
@@ -31,6 +31,11 @@ import tempfile
 import time
 from pathlib import Path
 
+from reference_organizations.store.agent import seed_lucy
+from sovereign_agent.assistant_orders import SpendingPolicy, approve, propose
+from sovereign_agent.assistant_work import claim, enqueue
+from sovereign_agent.database import Database
+
 assert sys.version_info >= (3, 14)
 start = Path(os.environ.get("SOVEREIGN_AGENT_REPO", Path.cwd())).resolve()
 ROOT = next(
@@ -43,12 +48,6 @@ ROOT = next(
 )
 if ROOT is None:
     raise RuntimeError("Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.")
-
-from reference_organizations.store.agent import seed_lucy
-from sovereign_agent.assistant_orders import SpendingPolicy, approve, propose
-from sovereign_agent.assistant_work import claim, enqueue
-from sovereign_agent.database import Database
-from sovereign_agent.events import append_event
 
 independent_supplier = runpy.run_path(str(ROOT / "book/always_on/checkpoints/ch09.py"))[
     "independent_supplier"

--- a/book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.ipynb
+++ b/book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.ipynb
@@ -1,0 +1,420 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4c728cc63655a7a8",
+   "metadata": {},
+   "source": [
+    "# Chapter 9, Unit B — Survive the ambiguous order\n",
+    "\n",
+    "**Student edition v1 · 2026-09-09 · 75–90 minutes**\n",
+    "\n",
+    "Unit A preserved one exact intent and later settled it from supplier evidence. Now you will make a plausible retry bug create two remote purchases, repair the real order boundary, and adapt a second supplier's discovery shape without changing the meaning of its receipt.\n",
+    "\n",
+    "This unit runs reviewed repository code in bounded local subprocesses and starts only in-memory or loopback supplier fixtures. A subprocess is not a security sandbox.\n",
+    "\n",
+    "## 1. Verify the handoff and load the real experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c563ea31e370ddde",
+   "metadata": {
+    "tags": [
+     "setup",
+     "handoff-consumer"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import runpy\n",
+    "import sys\n",
+    "import tempfile\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "assert sys.version_info >= (3, 14)\n",
+    "start = Path(os.environ.get(\"SOVEREIGN_AGENT_REPO\", Path.cwd())).resolve()\n",
+    "ROOT = next(\n",
+    "    (\n",
+    "        path\n",
+    "        for path in (start, *start.parents)\n",
+    "        if (path / \"book/always_on/checkpoints/ch09.py\").is_file()\n",
+    "    ),\n",
+    "    None,\n",
+    ")\n",
+    "if ROOT is None:\n",
+    "    raise RuntimeError(\"Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.\")\n",
+    "\n",
+    "HANDOFF_PATH = Path(\"ch09-unit-a-handoff-v1.json\")\n",
+    "handoff_status = \"MISSING\"\n",
+    "if HANDOFF_PATH.is_file():\n",
+    "    handoff = json.loads(HANDOFF_PATH.read_text(encoding=\"utf-8\"))\n",
+    "    valid_handoff = (\n",
+    "        handoff.get(\"after_loss\", {}).get(\"status\") == \"UNKNOWN\"\n",
+    "        and handoff.get(\"final\", {}).get(\"status\") == \"CONFIRMED\"\n",
+    "        and handoff.get(\"supplier_orders\") == 1\n",
+    "    )\n",
+    "    handoff_status = \"VERIFIED\" if valid_handoff else \"INVALID\"\n",
+    "print(\"UNIT_A_HANDOFF\", handoff_status)\n",
+    "\n",
+    "support = runpy.run_path(str(ROOT / \"book/always_on/educator/runtime_labs_v1.py\"))\n",
+    "RuntimeLab = support[\"RuntimeLab\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad4cb87a68b11ab2",
+   "metadata": {},
+   "source": [
+    "Predict the broken observation before running it. If a retry invents a new operation ID, what can lookup of the original ID discover? How many supplier rows remain?\n",
+    "\n",
+    "## 2. Break the real source copy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfa27189440ac967",
+   "metadata": {
+    "tags": [
+     "failure-experiment"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "lab = RuntimeLab(ROOT, 9)\n",
+    "baseline = lab.run(\"BASELINE\", expected=lab.spec[\"expected_baseline\"])\n",
+    "lab.break_source()\n",
+    "broken = lab.run(\"BROKEN\", expected=lab.spec[\"expected_broken\"])\n",
+    "print(json.dumps({\"baseline\": baseline[\"observation\"], \"broken\": broken[\"observation\"]}, indent=2))\n",
+    "assert baseline[\"status\"] == \"PASS\"\n",
+    "assert broken[\"status\"] == \"PASS\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fb021ecc838ea20",
+   "metadata": {},
+   "source": [
+    "The fault replaces the stable operation ID at the actual `supplier.order` call. The supplier accepts two distinct effects while both local attempts remain `UNKNOWN`.\n",
+    "\n",
+    "## 3. Construct the repair\n",
+    "\n",
+    "Return the complete replacement for the one broken fragment. The starter preserves the unsafe fresh-ID send."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "014bbd167380bace",
+   "metadata": {
+    "tags": [
+     "exercise",
+     "learner-owned",
+     "ch09-repair"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def repair_fragment():\n",
+    "    return 'receipt = supplier.order(uuid.uuid4().hex, json.loads(row[\"proposal\"]))'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3495514c0ce0e5aa",
+   "metadata": {},
+   "source": [
+    "<details><summary>Hint 1 — the decision</summary>\n",
+    "\n",
+    "Retries for one intended purchase keep one operation identity. A new business purchase needs a new work item.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 2 — the evidence</summary>\n",
+    "\n",
+    "Compare `supplier_order_count` and `local_statuses` in the baseline and broken records. Read the marked line in `lab.source_excerpt()`.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 3 — the structure</summary>\n",
+    "\n",
+    "Call `supplier.order` with the existing `identifier` and the stored proposal. Do not generate another UUID or change the expected data.\n",
+    "\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f8fc5b0a3a0792e",
+   "metadata": {
+    "tags": [
+     "integration",
+     "learner-path"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "lab.repair(repair_fragment())\n",
+    "student_repair = lab.run(\"STUDENT_REPAIR\", expected=lab.spec[\"expected_baseline\"])\n",
+    "REPAIR_PASSED = student_repair[\"status\"] == \"PASS\"\n",
+    "print(json.dumps(student_repair[\"observation\"], indent=2))\n",
+    "print(\"REAL_SOURCE_REPAIR\", \"PASSED\" if REPAIR_PASSED else \"NEEDS_WORK\")\n",
+    "lab.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13ea9fa715176c64",
+   "metadata": {},
+   "source": [
+    "State a diagnosis that this result could falsify. Printing the expected dictionary, changing expected data, or returning a canned tool result does not alter the independently observed supplier database.\n",
+    "\n",
+    "## 4. Adapt another supplier's discovery evidence\n",
+    "\n",
+    "The partner returns `order_ref`, `payload`, and `decision`. Implement the adapter boundary that converts `None`, `accepted`, or `declined` into the exact internal receipt shape. Reject unknown decisions rather than guessing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1ab0761d9fa35bc",
+   "metadata": {
+    "tags": [
+     "exercise",
+     "learner-owned",
+     "ch09-adapter"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def normalize_discovery(raw):\n",
+    "    return raw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7188bbc86576029",
+   "metadata": {},
+   "source": [
+    "<details><summary>Hint 1 — the decision</summary>\n",
+    "\n",
+    "Normalize vocabulary at the integration boundary. Keep the stable operation and exact proposal unchanged.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 2 — the evidence</summary>\n",
+    "\n",
+    "Internal receipts use `operation`, `proposal`, and an uppercase conclusive `status`. An absent lookup stays `None`.\n",
+    "\n",
+    "</details>\n",
+    "\n",
+    "<details><summary>Hint 3 — the structure</summary>\n",
+    "\n",
+    "Return `None` unchanged. Map `accepted` to `ACCEPTED` and `declined` to `REJECTED`; raise `ValueError` for any other decision.\n",
+    "\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a9011f625f2b693",
+   "metadata": {
+    "tags": [
+     "assessment",
+     "visible"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "partner_proposal = {\n",
+    "    \"sku\": \"SKU-VANILLA\",\n",
+    "    \"quantity\": 6,\n",
+    "    \"unit_cost_pence\": 250,\n",
+    "    \"supplier\": \"lucy-local\",\n",
+    "    \"currency\": \"GBP\",\n",
+    "}\n",
+    "expected_partner = {\n",
+    "    \"operation\": \"partner-order-1\",\n",
+    "    \"proposal\": partner_proposal,\n",
+    "    \"status\": \"ACCEPTED\",\n",
+    "}\n",
+    "try:\n",
+    "    VISIBLE_ADAPTER_PASSED = (\n",
+    "        normalize_discovery(None) is None\n",
+    "        and normalize_discovery(\n",
+    "            {\n",
+    "                \"order_ref\": \"partner-order-1\",\n",
+    "                \"payload\": partner_proposal,\n",
+    "                \"decision\": \"accepted\",\n",
+    "            }\n",
+    "        )\n",
+    "        == expected_partner\n",
+    "    )\n",
+    "except Exception:\n",
+    "    VISIBLE_ADAPTER_PASSED = False\n",
+    "print(\"VISIBLE_ADAPTER\", \"PASSED\" if VISIBLE_ADAPTER_PASSED else \"NEEDS_WORK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1061d7441c5fa248",
+   "metadata": {},
+   "source": [
+    "## 5. Connect the adapter to the real order workflow\n",
+    "\n",
+    "The partner makes its result discoverable only after `order` has been attempted. The second call to the real `execute` path must look up that evidence before considering another send."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53b863b72ae75bed",
+   "metadata": {
+    "tags": [
+     "setup",
+     "integration",
+     "learner-path"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from reference_organizations.store.agent import seed_lucy\n",
+    "from sovereign_agent.assistant_orders import SpendingPolicy, approve, execute, propose\n",
+    "from sovereign_agent.assistant_work import claim, enqueue\n",
+    "from sovereign_agent.database import Database\n",
+    "\n",
+    "\n",
+    "class PartnerSupplier:\n",
+    "    idempotent = True\n",
+    "    identity = \"partner-v2\"\n",
+    "    timeout = 1.0\n",
+    "\n",
+    "    def __init__(self, normalizer, decision):\n",
+    "        self.normalizer = normalizer\n",
+    "        self.decision = decision\n",
+    "        self.receipts = {}\n",
+    "        self.events = []\n",
+    "\n",
+    "    def order(self, operation, proposal):\n",
+    "        self.events.append((\"order\", operation))\n",
+    "        self.receipts.setdefault(\n",
+    "            operation,\n",
+    "            {\"order_ref\": operation, \"payload\": proposal, \"decision\": self.decision},\n",
+    "        )\n",
+    "        raise OSError(\"partner committed but reply was lost\")\n",
+    "\n",
+    "    def lookup(self, operation):\n",
+    "        self.events.append((\"lookup\", operation))\n",
+    "        return self.normalizer(self.receipts.get(operation))\n",
+    "\n",
+    "\n",
+    "def run_partner_fixture(normalizer, decision):\n",
+    "    with tempfile.TemporaryDirectory(prefix=\"ch09-partner-\") as directory:\n",
+    "        db = Database(Path(directory) / \"agent.sqlite\")\n",
+    "        supplier = PartnerSupplier(normalizer, decision)\n",
+    "        policy = SpendingPolicy(frozenset({\"lucy\"}), total_pence=2_000)\n",
+    "        try:\n",
+    "            seed_lucy(db)\n",
+    "            enqueue(db, \"chapter9:partner\", \"lucy\", \"Replenish\", subject=\"SKU-VANILLA\")\n",
+    "            work = claim(db, \"chapter9-partner-worker\")\n",
+    "            identifier = propose(db, work, \"SKU-VANILLA\", 6, target=supplier.identity)\n",
+    "            digest = db.connection.execute(\n",
+    "                \"SELECT digest FROM assistant_orders WHERE id=?\", (identifier,)\n",
+    "            ).fetchone()[0]\n",
+    "            approve(\n",
+    "                db,\n",
+    "                identifier,\n",
+    "                digest,\n",
+    "                actor=\"lucy\",\n",
+    "                policy=policy,\n",
+    "                expires=time.time() + 60,\n",
+    "            )\n",
+    "            first = execute(db, work, identifier, supplier, policy=policy)\n",
+    "            second = execute(db, work, identifier, supplier, policy=policy)\n",
+    "            status = db.connection.execute(\n",
+    "                \"SELECT status FROM assistant_orders WHERE id=?\", (identifier,)\n",
+    "            ).fetchone()[0]\n",
+    "            money = tuple(\n",
+    "                db.connection.execute(\n",
+    "                    \"SELECT reserved_pence,spent_pence FROM assistant_spending WHERE id=1\"\n",
+    "                ).fetchone()\n",
+    "            )\n",
+    "            return {\n",
+    "                \"statuses\": [first[\"status\"], second[\"status\"]],\n",
+    "                \"local_status\": status,\n",
+    "                \"events\": [event for event, _ in supplier.events],\n",
+    "                \"supplier_orders\": len(supplier.receipts),\n",
+    "                \"money\": money,\n",
+    "            }\n",
+    "        finally:\n",
+    "            db.close()\n",
+    "\n",
+    "\n",
+    "partner_result = None\n",
+    "if REPAIR_PASSED and VISIBLE_ADAPTER_PASSED:\n",
+    "    partner_result = run_partner_fixture(normalize_discovery, \"accepted\")\n",
+    "    print(json.dumps(partner_result, indent=2))\n",
+    "    assert partner_result == {\n",
+    "        \"statuses\": [\"UNKNOWN\", \"ACCEPTED\"],\n",
+    "        \"local_status\": \"CONFIRMED\",\n",
+    "        \"events\": [\"order\", \"lookup\"],\n",
+    "        \"supplier_orders\": 1,\n",
+    "        \"money\": (0, 1500),\n",
+    "    }\n",
+    "else:\n",
+    "    print(\"TRANSFER_NOT_READY — repair both learner-owned mechanisms.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7930e68dedd17826",
+   "metadata": {},
+   "source": [
+    "The event order is evidence: no receipt existed until after `order`; reconciliation then used `lookup`; no second `order` began.\n",
+    "\n",
+    "## Exit ticket\n",
+    "\n",
+    "Explain why a local transaction cannot guarantee exactly-once external effects. Name the supplier properties this result depends on, and state what the system must do if discovery is unavailable and retransmission is not idempotent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34cf78e3a459a937",
+   "metadata": {
+    "tags": [
+     "exercise-report"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "exercise_report = {\n",
+    "    \"unit\": \"ch09-b\",\n",
+    "    \"attempted\": 2,\n",
+    "    \"completed\": int(REPAIR_PASSED) + int(VISIBLE_ADAPTER_PASSED),\n",
+    "    \"failed\": int(not REPAIR_PASSED) + int(not VISIBLE_ADAPTER_PASSED),\n",
+    "    \"skipped\": 0,\n",
+    "    \"connection\": \"PASSED\" if partner_result else \"NOT_READY\",\n",
+    "    \"handoff\": handoff_status,\n",
+    "}\n",
+    "print(\"EXERCISE_REPORT=\" + json.dumps(exercise_report, sort_keys=True))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.md
+++ b/book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.md
@@ -1,0 +1,282 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+# Chapter 9, Unit B — Survive the ambiguous order
+
+**Student edition v1 · 2026-09-09 · 75–90 minutes**
+
+Unit A preserved one exact intent and later settled it from supplier evidence. Now you will make a plausible retry bug create two remote purchases, repair the real order boundary, and adapt a second supplier's discovery shape without changing the meaning of its receipt.
+
+This unit runs reviewed repository code in bounded local subprocesses and starts only in-memory or loopback supplier fixtures. A subprocess is not a security sandbox.
+
+## 1. Verify the handoff and load the real experiment
+
+```python tags=["setup", "handoff-consumer"]
+import json
+import os
+import runpy
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+assert sys.version_info >= (3, 14)
+start = Path(os.environ.get("SOVEREIGN_AGENT_REPO", Path.cwd())).resolve()
+ROOT = next(
+    (
+        path
+        for path in (start, *start.parents)
+        if (path / "book/always_on/checkpoints/ch09.py").is_file()
+    ),
+    None,
+)
+if ROOT is None:
+    raise RuntimeError("Set SOVEREIGN_AGENT_REPO to the Sovereign Agent checkout.")
+
+HANDOFF_PATH = Path("ch09-unit-a-handoff-v1.json")
+handoff_status = "MISSING"
+if HANDOFF_PATH.is_file():
+    handoff = json.loads(HANDOFF_PATH.read_text(encoding="utf-8"))
+    valid_handoff = (
+        handoff.get("after_loss", {}).get("status") == "UNKNOWN"
+        and handoff.get("final", {}).get("status") == "CONFIRMED"
+        and handoff.get("supplier_orders") == 1
+    )
+    handoff_status = "VERIFIED" if valid_handoff else "INVALID"
+print("UNIT_A_HANDOFF", handoff_status)
+
+support = runpy.run_path(str(ROOT / "book/always_on/educator/runtime_labs_v1.py"))
+RuntimeLab = support["RuntimeLab"]
+```
+
+Predict the broken observation before running it. If a retry invents a new operation ID, what can lookup of the original ID discover? How many supplier rows remain?
+
+## 2. Break the real source copy
+
+```python tags=["failure-experiment"]
+lab = RuntimeLab(ROOT, 9)
+baseline = lab.run("BASELINE", expected=lab.spec["expected_baseline"])
+lab.break_source()
+broken = lab.run("BROKEN", expected=lab.spec["expected_broken"])
+print(json.dumps({"baseline": baseline["observation"], "broken": broken["observation"]}, indent=2))
+assert baseline["status"] == "PASS"
+assert broken["status"] == "PASS"
+```
+
+The fault replaces the stable operation ID at the actual `supplier.order` call. The supplier accepts two distinct effects while both local attempts remain `UNKNOWN`.
+
+## 3. Construct the repair
+
+Return the complete replacement for the one broken fragment. The starter preserves the unsafe fresh-ID send.
+
+```python tags=["exercise", "learner-owned", "ch09-repair"]
+def repair_fragment():
+    return 'receipt = supplier.order(uuid.uuid4().hex, json.loads(row["proposal"]))'
+```
+
+<details><summary>Hint 1 — the decision</summary>
+
+Retries for one intended purchase keep one operation identity. A new business purchase needs a new work item.
+
+</details>
+
+<details><summary>Hint 2 — the evidence</summary>
+
+Compare `supplier_order_count` and `local_statuses` in the baseline and broken records. Read the marked line in `lab.source_excerpt()`.
+
+</details>
+
+<details><summary>Hint 3 — the structure</summary>
+
+Call `supplier.order` with the existing `identifier` and the stored proposal. Do not generate another UUID or change the expected data.
+
+</details>
+
+```python tags=["integration", "learner-path"]
+lab.repair(repair_fragment())
+student_repair = lab.run("STUDENT_REPAIR", expected=lab.spec["expected_baseline"])
+REPAIR_PASSED = student_repair["status"] == "PASS"
+print(json.dumps(student_repair["observation"], indent=2))
+print("REAL_SOURCE_REPAIR", "PASSED" if REPAIR_PASSED else "NEEDS_WORK")
+lab.close()
+```
+
+State a diagnosis that this result could falsify. Printing the expected dictionary, changing expected data, or returning a canned tool result does not alter the independently observed supplier database.
+
+## 4. Adapt another supplier's discovery evidence
+
+The partner returns `order_ref`, `payload`, and `decision`. Implement the adapter boundary that converts `None`, `accepted`, or `declined` into the exact internal receipt shape. Reject unknown decisions rather than guessing.
+
+```python tags=["exercise", "learner-owned", "ch09-adapter"]
+def normalize_discovery(raw):
+    return raw
+```
+
+<details><summary>Hint 1 — the decision</summary>
+
+Normalize vocabulary at the integration boundary. Keep the stable operation and exact proposal unchanged.
+
+</details>
+
+<details><summary>Hint 2 — the evidence</summary>
+
+Internal receipts use `operation`, `proposal`, and an uppercase conclusive `status`. An absent lookup stays `None`.
+
+</details>
+
+<details><summary>Hint 3 — the structure</summary>
+
+Return `None` unchanged. Map `accepted` to `ACCEPTED` and `declined` to `REJECTED`; raise `ValueError` for any other decision.
+
+</details>
+
+```python tags=["assessment", "visible"]
+partner_proposal = {
+    "sku": "SKU-VANILLA",
+    "quantity": 6,
+    "unit_cost_pence": 250,
+    "supplier": "lucy-local",
+    "currency": "GBP",
+}
+expected_partner = {
+    "operation": "partner-order-1",
+    "proposal": partner_proposal,
+    "status": "ACCEPTED",
+}
+try:
+    VISIBLE_ADAPTER_PASSED = (
+        normalize_discovery(None) is None
+        and normalize_discovery(
+            {
+                "order_ref": "partner-order-1",
+                "payload": partner_proposal,
+                "decision": "accepted",
+            }
+        )
+        == expected_partner
+    )
+except Exception:
+    VISIBLE_ADAPTER_PASSED = False
+print("VISIBLE_ADAPTER", "PASSED" if VISIBLE_ADAPTER_PASSED else "NEEDS_WORK")
+```
+
+## 5. Connect the adapter to the real order workflow
+
+The partner makes its result discoverable only after `order` has been attempted. The second call to the real `execute` path must look up that evidence before considering another send.
+
+```python tags=["setup", "integration", "learner-path"]
+from reference_organizations.store.agent import seed_lucy
+from sovereign_agent.assistant_orders import SpendingPolicy, approve, execute, propose
+from sovereign_agent.assistant_work import claim, enqueue
+from sovereign_agent.database import Database
+
+
+class PartnerSupplier:
+    idempotent = True
+    identity = "partner-v2"
+    timeout = 1.0
+
+    def __init__(self, normalizer, decision):
+        self.normalizer = normalizer
+        self.decision = decision
+        self.receipts = {}
+        self.events = []
+
+    def order(self, operation, proposal):
+        self.events.append(("order", operation))
+        self.receipts.setdefault(
+            operation,
+            {"order_ref": operation, "payload": proposal, "decision": self.decision},
+        )
+        raise OSError("partner committed but reply was lost")
+
+    def lookup(self, operation):
+        self.events.append(("lookup", operation))
+        return self.normalizer(self.receipts.get(operation))
+
+
+def run_partner_fixture(normalizer, decision):
+    with tempfile.TemporaryDirectory(prefix="ch09-partner-") as directory:
+        db = Database(Path(directory) / "agent.sqlite")
+        supplier = PartnerSupplier(normalizer, decision)
+        policy = SpendingPolicy(frozenset({"lucy"}), total_pence=2_000)
+        try:
+            seed_lucy(db)
+            enqueue(db, "chapter9:partner", "lucy", "Replenish", subject="SKU-VANILLA")
+            work = claim(db, "chapter9-partner-worker")
+            identifier = propose(db, work, "SKU-VANILLA", 6, target=supplier.identity)
+            digest = db.connection.execute(
+                "SELECT digest FROM assistant_orders WHERE id=?", (identifier,)
+            ).fetchone()[0]
+            approve(
+                db,
+                identifier,
+                digest,
+                actor="lucy",
+                policy=policy,
+                expires=time.time() + 60,
+            )
+            first = execute(db, work, identifier, supplier, policy=policy)
+            second = execute(db, work, identifier, supplier, policy=policy)
+            status = db.connection.execute(
+                "SELECT status FROM assistant_orders WHERE id=?", (identifier,)
+            ).fetchone()[0]
+            money = tuple(
+                db.connection.execute(
+                    "SELECT reserved_pence,spent_pence FROM assistant_spending WHERE id=1"
+                ).fetchone()
+            )
+            return {
+                "statuses": [first["status"], second["status"]],
+                "local_status": status,
+                "events": [event for event, _ in supplier.events],
+                "supplier_orders": len(supplier.receipts),
+                "money": money,
+            }
+        finally:
+            db.close()
+
+
+partner_result = None
+if REPAIR_PASSED and VISIBLE_ADAPTER_PASSED:
+    partner_result = run_partner_fixture(normalize_discovery, "accepted")
+    print(json.dumps(partner_result, indent=2))
+    assert partner_result == {
+        "statuses": ["UNKNOWN", "ACCEPTED"],
+        "local_status": "CONFIRMED",
+        "events": ["order", "lookup"],
+        "supplier_orders": 1,
+        "money": (0, 1500),
+    }
+else:
+    print("TRANSFER_NOT_READY — repair both learner-owned mechanisms.")
+```
+
+The event order is evidence: no receipt existed until after `order`; reconciliation then used `lookup`; no second `order` began.
+
+## Exit ticket
+
+Explain why a local transaction cannot guarantee exactly-once external effects. Name the supplier properties this result depends on, and state what the system must do if discovery is unavailable and retransmission is not idempotent.
+
+```python tags=["exercise-report"]
+exercise_report = {
+    "unit": "ch09-b",
+    "attempted": 2,
+    "completed": int(REPAIR_PASSED) + int(VISIBLE_ADAPTER_PASSED),
+    "failed": int(not REPAIR_PASSED) + int(not VISIBLE_ADAPTER_PASSED),
+    "skipped": 0,
+    "connection": "PASSED" if partner_result else "NOT_READY",
+    "handoff": handoff_status,
+}
+print("EXERCISE_REPORT=" + json.dumps(exercise_report, sort_keys=True))
+```

--- a/book/always_on/exercises/release-v3.json
+++ b/book/always_on/exercises/release-v3.json
@@ -1,0 +1,286 @@
+{
+  "environmentLock": "uv.lock",
+  "environmentLockSha256": "955cea601c9ae719e8808277fb1ba9cc59461373a72974434ffb329f79a46475",
+  "executionLimitations": [
+    "trusted local course code",
+    "per-cell timeout is not a whole-run deadline",
+    "captured output limit is checked after execution",
+    "process, network, and descendant isolation unavailable"
+  ],
+  "schemaVersion": 2,
+  "sourceCommit": "a4146a4271961c36a7da2d9a7a5ea6dbaf5fd8c9",
+  "status": "DRAFT",
+  "studentFiles": [
+    {
+      "path": "book/always_on/exercises/README.md",
+      "sha256": "82260caeba20475136884a8cc68c7bee5126ffa5c267f2958c7bb9cb475b98fe"
+    },
+    {
+      "path": "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.md",
+      "sha256": "a8a07c7bb7da73ab5b8ffea210e163ced0e1cc3b557fd397674e26e33ed086f1"
+    },
+    {
+      "path": "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.ipynb",
+      "sha256": "73e85dafad80f9ca7f95b6dc4a7a86a616b049db9a7281798c0aed42a3ea6fcb"
+    },
+    {
+      "path": "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.md",
+      "sha256": "14da22ea89a30a0935afda775e2b2f4e97c3b25f9a3dd63a1e53f10f7394ec6a"
+    },
+    {
+      "path": "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.ipynb",
+      "sha256": "085bd5fb6dbcdddff41b91911a3aa4b3bbda91ecbcb9a4da008df9f4ed858961"
+    },
+    {
+      "path": "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.md",
+      "sha256": "cf193e6f010324ed806a7230740d7b56e3f118857650c4a564c9df82e6549207"
+    },
+    {
+      "path": "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.ipynb",
+      "sha256": "df387d0ffed79b6d91618a2b86f8257da201d18eba24cbf0ce9e5ff6341d3e46"
+    },
+    {
+      "path": "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.md",
+      "sha256": "fe2fd54386e53cd457949a064cd73319bb61e1e6e00def176341148c0c1b2de4"
+    },
+    {
+      "path": "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.ipynb",
+      "sha256": "d8d295868191451509eaf7ef3d8a35b09e0de1d01bd4916fdb2fd0de4d6d20ba"
+    },
+    {
+      "path": "book/always_on/exercises/ch09/unit-a-durable-intent-v1.md",
+      "sha256": "e09bb77de530ed057d576b2ffa2d83ef075aad6f76fb8112390c59bc6587d8e1"
+    },
+    {
+      "path": "book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb",
+      "sha256": "28571361f804c0ea9b0b1c1599b5bc88e7e2b3f1ee9327987ffe7e9b3a6579ff"
+    },
+    {
+      "path": "book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.md",
+      "sha256": "c8cc219cf323fcaf67f82f9a69f90ee5b881289f2a8d85d7d5f7d3f4cae0c0d3"
+    },
+    {
+      "path": "book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.ipynb",
+      "sha256": "d6c0a6a314365079f90eabc5a2edf14f363293e0f266a5bf92f85e495179524e"
+    }
+  ],
+  "units": [
+    {
+      "canonicalSha256": "a8a07c7bb7da73ab5b8ffea210e163ced0e1cc3b557fd397674e26e33ed086f1",
+      "canonicalSource": "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.md",
+      "execution": {
+        "attempted": 8,
+        "capturedOutputBytes": 2711,
+        "completed": 8,
+        "exerciseReport": {
+          "attempted": 1,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "NOT_WRITTEN",
+          "skipped": 0,
+          "unit": "ch01-a"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch01-a",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch01/holdouts/unit-a-holdout-v2.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch01-a"
+        },
+        "holdoutSha256": "1631a31969854133504210520de052f956f7fdb231afd6c3c52e8f5946216691",
+        "solution": "book/always_on/exercises/ch01/solutions/unit-a-solution-v1.py",
+        "solutionSha256": "497fa9ebfdc5febbc7a58f08be76aae8bf233916490122ecd2de6eb8783c5fb3"
+      },
+      "notebook": "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.ipynb",
+      "notebookSha256": "73e85dafad80f9ca7f95b6dc4a7a86a616b049db9a7281798c0aed42a3ea6fcb",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "9d3cd0e6bb3f0694c3c607741e3e15ad78c87417a810e69075ee14825902f52f"
+    },
+    {
+      "canonicalSha256": "14da22ea89a30a0935afda775e2b2f4e97c3b25f9a3dd63a1e53f10f7394ec6a",
+      "canonicalSource": "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.md",
+      "execution": {
+        "attempted": 9,
+        "capturedOutputBytes": 5535,
+        "completed": 9,
+        "exerciseReport": {
+          "attempted": 2,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "VERIFIED",
+          "skipped": 1,
+          "transfer": "NOT_SUBMITTED",
+          "unit": "ch01-b"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch01-b",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch01/holdouts/unit-b-holdout-v1.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch01-b"
+        },
+        "holdoutSha256": "463f311ab3a42fc08e7b6c75a9b7ac39feba1af664818376fb22eaf1b3933c21",
+        "solution": "book/always_on/exercises/ch01/solutions/unit-b-solution-v1.py",
+        "solutionSha256": "373652503fda659c23ea727a1a39476b61f9f2a3c3637105fb328dc62c922f52"
+      },
+      "notebook": "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.ipynb",
+      "notebookSha256": "085bd5fb6dbcdddff41b91911a3aa4b3bbda91ecbcb9a4da008df9f4ed858961",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "b5c8ccbc405b20338404da6853d4beafb2d9007b4bbdf659b2b0a19040d6c9cc"
+    },
+    {
+      "canonicalSha256": "cf193e6f010324ed806a7230740d7b56e3f118857650c4a564c9df82e6549207",
+      "canonicalSource": "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.md",
+      "execution": {
+        "attempted": 7,
+        "capturedOutputBytes": 1093,
+        "completed": 7,
+        "exerciseReport": {
+          "attempted": 1,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "NOT_WRITTEN",
+          "skipped": 0,
+          "unit": "ch03-a"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch03-a",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch03/holdouts/unit-a-holdout-v1.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch03-a"
+        },
+        "holdoutSha256": "81241b26416a22d86f5ddb497bf3c3bb2e5b35c3d24a9e76b6e0a551c4ec6834",
+        "solution": "book/always_on/exercises/ch03/solutions/unit-a-solution-v1.py",
+        "solutionSha256": "3712a91e78cb2dce82facf2912b46e4d585b688954087051b9f348d07ba7b15f"
+      },
+      "notebook": "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.ipynb",
+      "notebookSha256": "df387d0ffed79b6d91618a2b86f8257da201d18eba24cbf0ce9e5ff6341d3e46",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "311cfe10959a15ed1c132ea7896dca82872adf5918ec99c8f04349288a5d545c"
+    },
+    {
+      "canonicalSha256": "fe2fd54386e53cd457949a064cd73319bb61e1e6e00def176341148c0c1b2de4",
+      "canonicalSource": "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.md",
+      "execution": {
+        "attempted": 6,
+        "capturedOutputBytes": 1309,
+        "completed": 6,
+        "exerciseReport": {
+          "attempted": 1,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "VERIFIED",
+          "skipped": 0,
+          "unit": "ch03-b"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch03-b",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch03/holdouts/unit-b-holdout-v1.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch03-b"
+        },
+        "holdoutSha256": "a9248645d86607b74a116e3c749549b4f9b3d8b643a67c7107b8825d940edb75",
+        "solution": "book/always_on/exercises/ch03/solutions/unit-b-solution-v1.py",
+        "solutionSha256": "01886a084394b935a61cff1571d1bd79b65115282ad6829d47464a8ffe74dc7d"
+      },
+      "notebook": "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.ipynb",
+      "notebookSha256": "d8d295868191451509eaf7ef3d8a35b09e0de1d01bd4916fdb2fd0de4d6d20ba",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "bbb35f63f5aef18909689b89189544e84026c14bc47969edfc2bb7931045cc5f"
+    },
+    {
+      "canonicalSha256": "e09bb77de530ed057d576b2ffa2d83ef075aad6f76fb8112390c59bc6587d8e1",
+      "canonicalSource": "book/always_on/exercises/ch09/unit-a-durable-intent-v1.md",
+      "execution": {
+        "attempted": 6,
+        "capturedOutputBytes": 498,
+        "completed": 6,
+        "exerciseReport": {
+          "attempted": 1,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 1,
+          "handoff": "NOT_WRITTEN",
+          "skipped": 0,
+          "unit": "ch09-a"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch09-a",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch09/holdouts/unit-a-holdout-v1.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch09-a"
+        },
+        "holdoutSha256": "a1bfcac46ea526bf710733bbece4cc76b51ef27b1ba374eee4b557daa134a471",
+        "solution": "book/always_on/exercises/ch09/solutions/unit-a-solution-v1.py",
+        "solutionSha256": "8b0a4f5b01c72c372644741b7c90464af793ad2acf8f79eeb08b6826222fe282"
+      },
+      "notebook": "book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb",
+      "notebookSha256": "28571361f804c0ea9b0b1c1599b5bc88e7e2b3f1ee9327987ffe7e9b3a6579ff",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "30b7986572949648d8ac4055b6c82f2b21e4adcec5a37cfc89c45ea086b01cfd"
+    },
+    {
+      "canonicalSha256": "c8cc219cf323fcaf67f82f9a69f90ee5b881289f2a8d85d7d5f7d3f4cae0c0d3",
+      "canonicalSource": "book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.md",
+      "execution": {
+        "attempted": 8,
+        "capturedOutputBytes": 1555,
+        "completed": 8,
+        "exerciseReport": {
+          "attempted": 2,
+          "completed": 0,
+          "connection": "NOT_READY",
+          "failed": 2,
+          "handoff": "VERIFIED",
+          "skipped": 0,
+          "unit": "ch09-b"
+        },
+        "failed": 0,
+        "skipped": 0
+      },
+      "freshKernel": true,
+      "id": "ch09-b",
+      "instructorEvidence": {
+        "holdout": "book/always_on/exercises/ch09/holdouts/unit-b-holdout-v1.py",
+        "holdoutResult": {
+          "status": "PASSED",
+          "unit": "ch09-b"
+        },
+        "holdoutSha256": "56aa4d16367c1367d7f24ac9dd54e5b9166f0613cc195898534c66cec6591065",
+        "solution": "book/always_on/exercises/ch09/solutions/unit-b-solution-v1.py",
+        "solutionSha256": "a0b64fb655a30b0c44f54804276db46c3eb2e5f52291c2d7660f4c5de27d8497"
+      },
+      "notebook": "book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.ipynb",
+      "notebookSha256": "d6c0a6a314365079f90eabc5a2edf14f363293e0f266a5bf92f85e495179524e",
+      "semanticDigestVersion": 1,
+      "semanticSha256": "cc89eb55defa89fec46cf50240b6cfb1cde8be517e24eca987d1c908b0e07afc"
+    }
+  ]
+}

--- a/book/always_on/exercises/release-v3.json
+++ b/book/always_on/exercises/release-v3.json
@@ -8,7 +8,7 @@
     "process, network, and descendant isolation unavailable"
   ],
   "schemaVersion": 2,
-  "sourceCommit": "5b5ddb2558911d1482a97a1317ee22fb36a68049",
+  "sourceCommit": "159cb51207a1d7ccc41b66fefa88342f57a146cd",
   "status": "DRAFT",
   "studentFiles": [
     {

--- a/book/always_on/exercises/release-v3.json
+++ b/book/always_on/exercises/release-v3.json
@@ -8,7 +8,7 @@
     "process, network, and descendant isolation unavailable"
   ],
   "schemaVersion": 2,
-  "sourceCommit": "a4146a4271961c36a7da2d9a7a5ea6dbaf5fd8c9",
+  "sourceCommit": "5b5ddb2558911d1482a97a1317ee22fb36a68049",
   "status": "DRAFT",
   "studentFiles": [
     {
@@ -49,11 +49,11 @@
     },
     {
       "path": "book/always_on/exercises/ch09/unit-a-durable-intent-v1.md",
-      "sha256": "e09bb77de530ed057d576b2ffa2d83ef075aad6f76fb8112390c59bc6587d8e1"
+      "sha256": "ba69a15b05a9e317331f01862a2f223fa3efe0527a86db1fcc684053d8808921"
     },
     {
       "path": "book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb",
-      "sha256": "28571361f804c0ea9b0b1c1599b5bc88e7e2b3f1ee9327987ffe7e9b3a6579ff"
+      "sha256": "a1e46c8d84b59715c063b9526d46c64b57c954180b678318164157b33306c3bc"
     },
     {
       "path": "book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.md",
@@ -211,7 +211,7 @@
       "semanticSha256": "bbb35f63f5aef18909689b89189544e84026c14bc47969edfc2bb7931045cc5f"
     },
     {
-      "canonicalSha256": "e09bb77de530ed057d576b2ffa2d83ef075aad6f76fb8112390c59bc6587d8e1",
+      "canonicalSha256": "ba69a15b05a9e317331f01862a2f223fa3efe0527a86db1fcc684053d8808921",
       "canonicalSource": "book/always_on/exercises/ch09/unit-a-durable-intent-v1.md",
       "execution": {
         "attempted": 6,
@@ -239,12 +239,12 @@
         },
         "holdoutSha256": "a1bfcac46ea526bf710733bbece4cc76b51ef27b1ba374eee4b557daa134a471",
         "solution": "book/always_on/exercises/ch09/solutions/unit-a-solution-v1.py",
-        "solutionSha256": "8b0a4f5b01c72c372644741b7c90464af793ad2acf8f79eeb08b6826222fe282"
+        "solutionSha256": "253e2518096cdb75a653a0f08eaa4670f03a14715d92d34737b488d99c304215"
       },
       "notebook": "book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb",
-      "notebookSha256": "28571361f804c0ea9b0b1c1599b5bc88e7e2b3f1ee9327987ffe7e9b3a6579ff",
+      "notebookSha256": "a1e46c8d84b59715c063b9526d46c64b57c954180b678318164157b33306c3bc",
       "semanticDigestVersion": 1,
-      "semanticSha256": "30b7986572949648d8ac4055b6c82f2b21e4adcec5a37cfc89c45ea086b01cfd"
+      "semanticSha256": "1953d187493305483cbaaadff6c668fe8b0f7f734d0304443c2b7affe3fc15d5"
     },
     {
       "canonicalSha256": "c8cc219cf323fcaf67f82f9a69f90ee5b881289f2a8d85d7d5f7d3f4cae0c0d3",

--- a/scripts/build_exercise_release_v3.py
+++ b/scripts/build_exercise_release_v3.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Build and execute the Chapter 1, Chapter 3, and Chapter 9 exercise release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import nbformat
+from nbclient import NotebookClient
+
+ROOT = Path(__file__).resolve().parent.parent
+EXERCISES = ROOT / "book" / "always_on" / "exercises"
+
+
+@dataclass(frozen=True)
+class Unit:
+    identity: str
+    source: Path
+    notebook: Path
+    solution: Path
+    holdout: Path
+
+
+UNITS = (
+    Unit(
+        "ch01-a",
+        EXERCISES / "ch01" / "unit-a-first-grounded-brief-v1.md",
+        EXERCISES / "ch01" / "unit-a-first-grounded-brief-v1.ipynb",
+        EXERCISES / "ch01" / "solutions" / "unit-a-solution-v1.py",
+        EXERCISES / "ch01" / "holdouts" / "unit-a-holdout-v2.py",
+    ),
+    Unit(
+        "ch01-b",
+        EXERCISES / "ch01" / "unit-b-prompt-and-harness-v1.md",
+        EXERCISES / "ch01" / "unit-b-prompt-and-harness-v1.ipynb",
+        EXERCISES / "ch01" / "solutions" / "unit-b-solution-v1.py",
+        EXERCISES / "ch01" / "holdouts" / "unit-b-holdout-v1.py",
+    ),
+    Unit(
+        "ch03-a",
+        EXERCISES / "ch03" / "unit-a-bounded-loop-v1.md",
+        EXERCISES / "ch03" / "unit-a-bounded-loop-v1.ipynb",
+        EXERCISES / "ch03" / "solutions" / "unit-a-solution-v1.py",
+        EXERCISES / "ch03" / "holdouts" / "unit-a-holdout-v1.py",
+    ),
+    Unit(
+        "ch03-b",
+        EXERCISES / "ch03" / "unit-b-failure-accounting-v1.md",
+        EXERCISES / "ch03" / "unit-b-failure-accounting-v1.ipynb",
+        EXERCISES / "ch03" / "solutions" / "unit-b-solution-v1.py",
+        EXERCISES / "ch03" / "holdouts" / "unit-b-holdout-v1.py",
+    ),
+    Unit(
+        "ch09-a",
+        EXERCISES / "ch09" / "unit-a-durable-intent-v1.md",
+        EXERCISES / "ch09" / "unit-a-durable-intent-v1.ipynb",
+        EXERCISES / "ch09" / "solutions" / "unit-a-solution-v1.py",
+        EXERCISES / "ch09" / "holdouts" / "unit-a-holdout-v1.py",
+    ),
+    Unit(
+        "ch09-b",
+        EXERCISES / "ch09" / "unit-b-reconcile-unknown-v1.md",
+        EXERCISES / "ch09" / "unit-b-reconcile-unknown-v1.ipynb",
+        EXERCISES / "ch09" / "solutions" / "unit-b-solution-v1.py",
+        EXERCISES / "ch09" / "holdouts" / "unit-b-holdout-v1.py",
+    ),
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def relative(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def semantic_digest(notebook: dict) -> str:
+    stable = [
+        {
+            "cell_type": cell["cell_type"],
+            "source": cell.get("source", ""),
+            "tags": cell.get("metadata", {}).get("tags", []),
+        }
+        for cell in notebook["cells"]
+    ]
+    encoded = json.dumps(stable, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def outputs_bytes(notebook: dict) -> int:
+    total = 0
+    for cell in notebook["cells"]:
+        for output in cell.get("outputs", []):
+            total += len(json.dumps(output, sort_keys=True, default=str).encode())
+    return total
+
+
+def marker(notebook: dict, prefix: str) -> dict:
+    found = []
+    for cell in notebook["cells"]:
+        for output in cell.get("outputs", []):
+            text = output.get("text", "")
+            if isinstance(text, list):
+                text = "".join(text)
+            for line in str(text).splitlines():
+                if line.startswith(prefix):
+                    found.append(json.loads(line.removeprefix(prefix)))
+    if len(found) != 1:
+        raise RuntimeError(f"expected one {prefix!r} marker, found {len(found)}")
+    return found[0]
+
+
+def execute(notebook: dict, cwd: Path) -> dict:
+    previous_root = os.environ.get("SOVEREIGN_AGENT_REPO")
+    os.environ["SOVEREIGN_AGENT_REPO"] = str(ROOT)
+    try:
+        executed = NotebookClient(
+            nbformat.from_dict(notebook),
+            timeout=30,
+            kernel_name="python3",
+            allow_errors=False,
+            record_timing=False,
+        ).execute(cwd=str(cwd))
+    finally:
+        if previous_root is None:
+            os.environ.pop("SOVEREIGN_AGENT_REPO", None)
+        else:
+            os.environ["SOVEREIGN_AGENT_REPO"] = previous_root
+    size = outputs_bytes(executed)
+    if size > 1_000_000:
+        raise RuntimeError(f"captured notebook output exceeds post-run limit: {size} bytes")
+    return executed
+
+
+def convert(unit: Unit, jupytext: str) -> dict:
+    subprocess.run(
+        [jupytext, "--to", "ipynb", "--output", str(unit.notebook), str(unit.source)],
+        cwd=ROOT,
+        check=True,
+    )
+    notebook = nbformat.read(unit.notebook, as_version=4)
+    for index, cell in enumerate(notebook.cells):
+        identity = f"{unit.identity}:{index}:{cell.cell_type}:{cell.source}".encode()
+        cell.id = hashlib.sha256(identity).hexdigest()[:16]
+        if cell.cell_type == "code":
+            cell.execution_count = None
+            cell.outputs = []
+    nbformat.write(notebook, unit.notebook)
+    return notebook
+
+
+def verify_solution(unit: Unit, notebook: dict, cwd: Path) -> dict:
+    assessment = nbformat.from_dict(notebook)
+    assessment.cells.append(nbformat.v4.new_code_cell(unit.solution.read_text(encoding="utf-8")))
+    assessment.cells.append(nbformat.v4.new_code_cell(unit.holdout.read_text(encoding="utf-8")))
+    executed = execute(assessment, cwd)
+    return marker(executed, "HOLDOUT_RESULT=")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=EXERCISES / "release-v3.json")
+    args = parser.parse_args()
+    jupytext = shutil.which("jupytext")
+    if not jupytext:
+        raise RuntimeError("jupytext CLI unavailable; run with the locked authoring group")
+    source_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    lock_hash = sha256(ROOT / "uv.lock")
+    rows = []
+    with tempfile.TemporaryDirectory(prefix="sovereign-agent-exercises-") as temporary:
+        run_root = Path(temporary)
+        for unit in UNITS:
+            notebook = convert(unit, jupytext)
+            unit_root = run_root / unit.identity.split("-")[0]
+            unit_root.mkdir(exist_ok=True)
+            executed = execute(notebook, unit_root)
+            report = marker(executed, "EXERCISE_REPORT=")
+            solution = verify_solution(unit, notebook, unit_root)
+            rows.append(
+                {
+                    "id": unit.identity,
+                    "canonicalSource": relative(unit.source),
+                    "canonicalSha256": sha256(unit.source),
+                    "notebook": relative(unit.notebook),
+                    "notebookSha256": sha256(unit.notebook),
+                    "semanticDigestVersion": 1,
+                    "semanticSha256": semantic_digest(notebook),
+                    "freshKernel": True,
+                    "execution": {
+                        "attempted": sum(c["cell_type"] == "code" for c in executed["cells"]),
+                        "completed": sum(c["cell_type"] == "code" for c in executed["cells"]),
+                        "failed": 0,
+                        "skipped": 0,
+                        "capturedOutputBytes": outputs_bytes(executed),
+                        "exerciseReport": report,
+                    },
+                    "instructorEvidence": {
+                        "solution": relative(unit.solution),
+                        "solutionSha256": sha256(unit.solution),
+                        "holdout": relative(unit.holdout),
+                        "holdoutSha256": sha256(unit.holdout),
+                        "holdoutResult": solution,
+                    },
+                }
+            )
+    release = {
+        "schemaVersion": 2,
+        "status": "DRAFT",
+        "sourceCommit": source_commit,
+        "environmentLock": "uv.lock",
+        "environmentLockSha256": lock_hash,
+        "studentFiles": [
+            {"path": path, "sha256": sha256(ROOT / path)}
+            for path in (
+                "book/always_on/exercises/README.md",
+                "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.md",
+                "book/always_on/exercises/ch01/unit-a-first-grounded-brief-v1.ipynb",
+                "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.md",
+                "book/always_on/exercises/ch01/unit-b-prompt-and-harness-v1.ipynb",
+                "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.md",
+                "book/always_on/exercises/ch03/unit-a-bounded-loop-v1.ipynb",
+                "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.md",
+                "book/always_on/exercises/ch03/unit-b-failure-accounting-v1.ipynb",
+                "book/always_on/exercises/ch09/unit-a-durable-intent-v1.md",
+                "book/always_on/exercises/ch09/unit-a-durable-intent-v1.ipynb",
+                "book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.md",
+                "book/always_on/exercises/ch09/unit-b-reconcile-unknown-v1.ipynb",
+            )
+        ],
+        "units": rows,
+        "executionLimitations": [
+            "trusted local course code",
+            "per-cell timeout is not a whole-run deadline",
+            "captured output limit is checked after execution",
+            "process, network, and descendant isolation unavailable",
+        ],
+    }
+    args.output.write_text(json.dumps(release, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    displayed_output = (
+        args.output.relative_to(ROOT) if args.output.is_relative_to(ROOT) else args.output
+    )
+    print(f"built {len(rows)} units -> {displayed_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_exercise_release_v3.py
+++ b/scripts/verify_exercise_release_v3.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Verify the Chapter 1, Chapter 3, and Chapter 9 student release."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RELEASE = ROOT / "book" / "always_on" / "exercises" / "release-v3.json"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def committed_bytes(commit: str, path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f"{commit}:{path}"], cwd=ROOT, capture_output=True, check=False
+    )
+    require(result.returncode == 0, f"source commit does not contain {path}")
+    return result.stdout
+
+
+def verify(release_path: Path = RELEASE) -> None:
+    release = json.loads(release_path.read_text(encoding="utf-8"))
+    require(release["schemaVersion"] == 2, "unknown release schema")
+    require(re.fullmatch(r"[0-9a-f]{40}", release["sourceCommit"]) is not None, "bad commit")
+    lock = ROOT / release["environmentLock"]
+    require(lock.is_file() and sha256(lock) == release["environmentLockSha256"], "lock drift")
+    student_files = release["studentFiles"]
+    paths = [item["path"] for item in student_files]
+    require(len(paths) == len(set(paths)), "duplicate student file")
+    require(not any("solution" in path or "holdout" in path for path in paths), "answer leak")
+    for item in student_files:
+        path = item["path"]
+        target = ROOT / path
+        require(target.is_file() and target.resolve().is_relative_to(ROOT), f"missing file: {path}")
+        require(sha256(target) == item["sha256"], f"student file drift: {path}")
+        committed = hashlib.sha256(committed_bytes(release["sourceCommit"], path)).hexdigest()
+        require(committed == item["sha256"], f"source commit drift: {path}")
+    require(
+        {row["id"] for row in release["units"]}
+        == {"ch01-a", "ch01-b", "ch03-a", "ch03-b", "ch09-a", "ch09-b"},
+        "unit set drift",
+    )
+    for row in release["units"]:
+        source = ROOT / row["canonicalSource"]
+        notebook_path = ROOT / row["notebook"]
+        require(sha256(source) == row["canonicalSha256"], f"source drift: {row['id']}")
+        require(sha256(notebook_path) == row["notebookSha256"], f"notebook drift: {row['id']}")
+        notebook = json.loads(notebook_path.read_text(encoding="utf-8"))
+        stable = [
+            {
+                "cell_type": cell["cell_type"],
+                "source": (
+                    "".join(cell.get("source", []))
+                    if isinstance(cell.get("source", ""), list)
+                    else cell.get("source", "")
+                ),
+                "tags": cell.get("metadata", {}).get("tags", []),
+            }
+            for cell in notebook["cells"]
+        ]
+        semantic = hashlib.sha256(
+            json.dumps(stable, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        require(row["semanticDigestVersion"] == 1, "unknown semantic digest")
+        require(semantic == row["semanticSha256"], f"semantic drift: {row['id']}")
+        execution = row["execution"]
+        require(execution["failed"] == 0 and execution["skipped"] == 0, "execution incomplete")
+        require(execution["attempted"] == execution["completed"], "cell accounting mismatch")
+        require(row["freshKernel"] is True, "fresh-kernel evidence missing")
+        evidence = row["instructorEvidence"]
+        for kind in ("solution", "holdout"):
+            evidence_path = ROOT / evidence[kind]
+            require(sha256(evidence_path) == evidence[f"{kind}Sha256"], f"{kind} drift")
+        require(evidence["holdoutResult"]["status"] == "PASSED", "holdout failed")
+
+
+if __name__ == "__main__":
+    verify()
+    print("EXERCISE RELEASE: exact bytes, semantic cells, execution and holdouts verified.")
+    print("Student starters running is not evidence of learner mastery.")

--- a/tests/test_ch09_exercise_holdouts_v1.py
+++ b/tests/test_ch09_exercise_holdouts_v1.py
@@ -1,0 +1,86 @@
+"""The Chapter 9 holdouts reject fake transitions and blind retry repairs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+CHAPTER = ROOT / "book" / "always_on" / "exercises" / "ch09"
+
+
+def notebook_scope(name: str, tmp_path: Path) -> dict[str, object]:
+    notebook = json.loads((CHAPTER / name).read_text(encoding="utf-8"))
+    scope: dict[str, object] = {"__name__": "__exercise__", "__exercise_cwd__": str(tmp_path)}
+    old_cwd = Path.cwd()
+    old_root = os.environ.get("SOVEREIGN_AGENT_REPO")
+    try:
+        os.chdir(tmp_path)
+        os.environ["SOVEREIGN_AGENT_REPO"] = str(ROOT)
+        for index, cell in enumerate(notebook["cells"]):
+            if cell["cell_type"] != "code":
+                continue
+            source = cell.get("source", "")
+            if isinstance(source, list):
+                source = "".join(source)
+            exec(compile(source, f"{name}:cell-{index}", "exec", dont_inherit=True), scope)
+    finally:
+        os.chdir(old_cwd)
+        if old_root is None:
+            os.environ.pop("SOVEREIGN_AGENT_REPO", None)
+        else:
+            os.environ["SOVEREIGN_AGENT_REPO"] = old_root
+    return scope
+
+
+def execute(path: Path, scope: dict[str, object]) -> None:
+    previous = Path.cwd()
+    try:
+        os.chdir(str(scope["__exercise_cwd__"]))
+        exec(compile(path.read_text(encoding="utf-8"), str(path), "exec", dont_inherit=True), scope)
+    finally:
+        os.chdir(previous)
+
+
+def test_unit_a_official_solution_passes_holdout(tmp_path: Path) -> None:
+    scope = notebook_scope("unit-a-durable-intent-v1.ipynb", tmp_path)
+    execute(CHAPTER / "solutions" / "unit-a-solution-v1.py", scope)
+    execute(CHAPTER / "holdouts" / "unit-a-holdout-v1.py", scope)
+
+
+def test_unit_a_noop_transition_fails_holdout(tmp_path: Path) -> None:
+    scope = notebook_scope("unit-a-durable-intent-v1.ipynb", tmp_path)
+    with pytest.raises((AssertionError, TypeError)):
+        execute(CHAPTER / "holdouts" / "unit-a-holdout-v1.py", scope)
+
+
+def test_unit_b_official_solution_passes_holdout(tmp_path: Path) -> None:
+    scope = notebook_scope("unit-b-reconcile-unknown-v1.ipynb", tmp_path)
+    execute(CHAPTER / "solutions" / "unit-b-solution-v1.py", scope)
+    execute(CHAPTER / "holdouts" / "unit-b-holdout-v1.py", scope)
+
+
+def test_unit_b_fresh_identity_retry_fails_holdout(tmp_path: Path) -> None:
+    scope = notebook_scope("unit-b-reconcile-unknown-v1.ipynb", tmp_path)
+
+    def correct_normalizer(raw):
+        if raw is None:
+            return None
+        status = {"accepted": "ACCEPTED", "declined": "REJECTED"}[raw["decision"]]
+        return {"operation": raw["order_ref"], "proposal": raw["payload"], "status": status}
+
+    scope["normalize_discovery"] = correct_normalizer
+    with pytest.raises(AssertionError):
+        execute(CHAPTER / "holdouts" / "unit-b-holdout-v1.py", scope)
+
+
+def test_unit_b_passthrough_adapter_fails_holdout(tmp_path: Path) -> None:
+    scope = notebook_scope("unit-b-reconcile-unknown-v1.ipynb", tmp_path)
+    scope["repair_fragment"] = lambda: (
+        'receipt = supplier.order(identifier, json.loads(row["proposal"]))'
+    )
+    with pytest.raises(AssertionError):
+        execute(CHAPTER / "holdouts" / "unit-b-holdout-v1.py", scope)


### PR DESCRIPTION
Chapter 9 needs executable practice that makes the learner own durable intent, observe a real ambiguous external effect, and repair blind retry behavior. This adds two canonical Jupytext units with generated notebooks, progressive hints, a durable Unit A handoff, separate solutions, fresh-kernel holdouts, and plausible-wrong-solution tests.

Unit A implements `SENDING`, `UNKNOWN`, and exact-receipt settlement against the real SQLite order schema, then connects the transition to the loopback supplier that commits before dropping its response. Unit B changes the real `assistant_orders.execute` call to create duplicate remote effects, repairs the stable operation identity, and adapts a second supplier's discovery shape through an explicit boundary. The hidden supplier exposes its receipt only after the send; the accepted chronology is `order`, then `lookup`, with one remote effect.

The v3 release builder and verifier publish Chapters 1, 3, and 9 together with deterministic cell IDs, exact artifact hashes, versioned semantic digests, execution observations, and hidden-holdout acceptance.

This PR is stacked on PR 92 so its diff contains Chapter 9 only. After PR 92 merges, retarget this PR to `main`.

Validation:

- `make verify`: 863 passed, 18 deselected
- clean-clone onboarding: 858 passed, 5 expected Git-only skips, 18 deselected
- full suite also passes with `PytestUnraisableExceptionWarning` promoted to an error
- two consecutive builds produced byte-identical six-unit notebooks and receipt
- official solutions pass; no-op transition, fresh-ID retry, and passthrough adapter shortcuts fail

Retained observation: two clean-clone runs emitted an intermittent Python 3.14 `HTTPResponse` finalizer warning after all assertions. It did not reproduce in the Chapter 9, durability, or full suite with unraisable warnings promoted to errors. No cleanup guarantee is inferred from its absence in those reruns.
